### PR TITLE
Remove jquery calls in widget manager and base widget class

### DIFF
--- a/ipython_widgets/static/notebook/js/widgetarea.js
+++ b/ipython_widgets/static/notebook/js/widgetarea.js
@@ -31,7 +31,7 @@ define(['jquery', 'base/js/events'], function($, events) {
         var that = this;
         return view_promise.then(function(view) {
             that.widget_area.show();
-            dummy.replaceWith(view.$el);
+            dummy.replaceWith(view.el);
             that.widget_views.push(view);
 
             // Check the live state of the view's model.

--- a/ipython_widgets/static/widgets/js/manager.js
+++ b/ipython_widgets/static/widgets/js/manager.js
@@ -4,11 +4,10 @@
 define([
     "underscore",
     "backbone",
-    "jquery",
     "base/js/utils",
     "base/js/namespace",
     "services/kernels/comm"
-], function (_, Backbone, $, utils, IPython, comm) {
+], function (_, Backbone, utils, IPython, comm) {
     "use strict";
     //--------------------------------------------------------------------
     // WidgetManager class
@@ -27,7 +26,7 @@ define([
         this._models = {}; /* Dictionary of model ids and model instance promises */
 
         // Register with the comm manager.
-        this.comm_manager.register_target(this.comm_target_name, $.proxy(this._handle_comm_open, this));
+        this.comm_manager.register_target(this.comm_target_name, _.bind(this._handle_comm_open, this));
 
         // Load the initial state of the widget manager if a load callback was
         // registered.
@@ -163,7 +162,7 @@ define([
          * Note, this is only done on the outer most widgets.
          */
         if (this.keyboard_manager) {
-            this.keyboard_manager.register_events(view.$el);
+            this.keyboard_manager.register_events(view.el);
         
             if (view.additional_elements) {
                 for (var i = 0; i < view.additional_elements.length; i++) {
@@ -247,8 +246,8 @@ define([
             var handle_output = null;
             var handle_clear_output = null;
             if (cell.output_area) {
-                handle_output = $.proxy(cell.output_area.handle_output, cell.output_area);
-                handle_clear_output = $.proxy(cell.output_area.handle_clear_output, cell.output_area);
+                handle_output = _.bind(cell.output_area.handle_output, cell.output_area);
+                handle_clear_output = _.bind(cell.output_area.handle_clear_output, cell.output_area);
             }
 
             // Create callback dictionary using what is known
@@ -298,10 +297,10 @@ define([
          * --------
          * JS:
          * IPython.notebook.kernel.widget_manager.create_model({
-         *      model_name: 'WidgetModel', 
+         *      model_name: 'WidgetModel',
          *      widget_class: 'ipython_widgets.IntSlider'})
          *      .then(function(model) { console.log('Create success!', model); },
-         *      $.proxy(console.error, console));
+         *      _.bind(console.error, console));
          *
          * Parameters
          * ----------

--- a/ipython_widgets/static/widgets/js/widget.js
+++ b/ipython_widgets/static/widgets/js/widget.js
@@ -441,7 +441,7 @@ define(["nbextensions/widgets/widgets/js/manager",
     widgetmanager.WidgetManager.register_widget_model('WidgetModel', WidgetModel);
 
 
-    var WidgetInterface = {
+    var WidgetViewMixin = {
         initialize: function(parameters) {
             /**
              * Public constructor.
@@ -525,12 +525,12 @@ define(["nbextensions/widgets/widgets/js/manager",
     };
 
 
-    var DOMWidgetInterface = {
+    var DOMWidgetViewMixin = {
         initialize: function (parameters) {
             /**
              * Public constructor
              */
-            DOMWidgetView.__super__.initialize.apply(this, [parameters]);
+            WidgetViewMixin.initialize.apply(this, [parameters]);
             this.model.on('change:visible', this.update_visible, this);
             this.model.on('change:_css', this.update_css, this);
 
@@ -802,15 +802,20 @@ define(["nbextensions/widgets/widgets/js/manager",
         },
     });
 
-    var WidgetView = Backbone.View.extend(WidgetInterface);
-    var DOMWidgetView = WidgetView.extend(DOMWidgetInterface);
+    // For backwards compatibility.
+    var WidgetView = Backbone.View.extend(WidgetViewMixin);
+    var DOMWidgetView = WidgetView.extend(DOMWidgetViewMixin);
 
     var widget = {
         'unpack_models': unpack_models,
         'WidgetModel': WidgetModel,
+        'WidgetViewMixin': WidgetViewMixin,
+        'DOMWidgetViewMixin': DOMWidgetViewMixin,
+        'ViewList': ViewList,
+
+        // For backwards compatibility.
         'WidgetView': WidgetView,
         'DOMWidgetView': DOMWidgetView,
-        'ViewList': ViewList,
     };
 
     // For backwards compatability.

--- a/ipython_widgets/static/widgets/js/widget.js
+++ b/ipython_widgets/static/widgets/js/widget.js
@@ -807,8 +807,5 @@ define(["nbextensions/widgets/widgets/js/manager",
         'DOMWidgetView': DOMWidgetView,
     };
 
-    // For backwards compatability.
-    _.extend(IPython, widget);
-
     return widget;
 });

--- a/ipython_widgets/static/widgets/js/widget.js
+++ b/ipython_widgets/static/widgets/js/widget.js
@@ -4,10 +4,9 @@
 define(["nbextensions/widgets/widgets/js/manager",
         "underscore",
         "backbone",
-        "jquery",
         "base/js/utils",
         "base/js/namespace",
-], function(widgetmanager, _, Backbone, $, utils, IPython){
+], function(widgetmanager, _, Backbone, utils, IPython){
     "use strict";
 
     var unpack_models = function unpack_models(value, model) {
@@ -15,7 +14,7 @@ define(["nbextensions/widgets/widgets/js/manager",
          * Replace model ids with models recursively.
          */
         var unpacked;
-        if ($.isArray(value)) {
+        if (_.isArray(value)) {
             unpacked = [];
             _.each(value, function(sub_value, key) {
                 unpacked.push(unpack_models(sub_value, model));
@@ -73,8 +72,8 @@ define(["nbextensions/widgets/widgets/js/manager",
                 comm.model = this;
 
                 // Hook comm messages up to model.
-                comm.on_close($.proxy(this._handle_comm_closed, this));
-                comm.on_msg($.proxy(this._handle_comm_msg, this));
+                comm.on_close(_.bind(this._handle_comm_closed, this));
+                comm.on_msg(_.bind(this._handle_comm_msg, this));
 
                 // Assume the comm is alive.
                 this.set_comm_live(true);
@@ -280,9 +279,9 @@ define(["nbextensions/widgets/widgets/js/manager",
             var return_value = WidgetModel.__super__.set.apply(this, arguments);
 
             // Backbone only remembers the diff of the most recent set()
-            // operation.  Calling set multiple times in a row results in a 
+            // operation.  Calling set multiple times in a row results in a
             // loss of diff information.  Here we keep our own running diff.
-            this._buffered_state_diff = $.extend(this._buffered_state_diff, this.changedAttributes() || {});
+            this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
             return return_value;
         },
 
@@ -338,13 +337,12 @@ define(["nbextensions/widgets/widgets/js/manager",
                 // Check throttle.
                 if (this.pending_msgs >= (this.get('msg_throttle') || 3)) {
                     // The throttle has been exceeded, buffer the current msg so
-                    // it can be sent once the kernel has finished processing 
+                    // it can be sent once the kernel has finished processing
                     // some of the existing messages.
-                    
                     // Combine updates if it is a 'patch' sync, otherwise replace updates
                     switch (method) {
                         case 'patch':
-                            this.msg_buffer = $.extend(this.msg_buffer || {}, attrs);
+                            this.msg_buffer = _.extend(this.msg_buffer || {}, attrs);
                             break;
                         case 'update':
                         case 'create':
@@ -357,7 +355,7 @@ define(["nbextensions/widgets/widgets/js/manager",
                     this.msg_buffer_callbacks = callbacks;
 
                 } else {
-                    // We haven't exceeded the throttle, send the message like 
+                    // We haven't exceeded the throttle, send the message like
                     // normal.
                     this.send_sync_message(attrs, callbacks);
                     this.pending_msgs++;
@@ -443,7 +441,7 @@ define(["nbextensions/widgets/widgets/js/manager",
     widgetmanager.WidgetManager.register_widget_model('WidgetModel', WidgetModel);
 
 
-    var WidgetView = Backbone.View.extend({
+    var WidgetInterface = {
         initialize: function(parameters) {
             /**
              * Public constructor.
@@ -477,7 +475,7 @@ define(["nbextensions/widgets/widgets/js/manager",
              * Create and promise that resolves to a child view of a given model
              */
             var that = this;
-            options = $.extend({ parent: this }, options || {});
+            options = _.extend({ parent: this }, options || {});
             return this.model.widget_manager.create_view(child_model, options).catch(utils.reject("Couldn't create child view", true));
         },
 
@@ -524,10 +522,10 @@ define(["nbextensions/widgets/widgets/js/manager",
             WidgetView.__super__.remove.apply(this, arguments);
             this.trigger('remove');
         }
-    });
+    };
 
 
-    var DOMWidgetView = WidgetView.extend({
+    var DOMWidgetInterface = {
         initialize: function (parameters) {
             /**
              * Public constructor
@@ -620,7 +618,7 @@ define(["nbextensions/widgets/widgets/js/manager",
             /**
              * Set a css attr of the widget view.
              */
-            this.$el.css(name, value);
+            this.el.style[name] = value;
         },
 
         update_visible: function(model, value) {
@@ -629,13 +627,15 @@ define(["nbextensions/widgets/widgets/js/manager",
              */
             switch(value) {
                 case null: // python None
-                    this.$el.show().css('visibility', 'hidden'); break;
+                    this.el.style.display = '';
+                    this.el.style.visibility = 'hidden'; break;
                 case false:
-                    this.$el.hide(); break;
+                    this.el.style.display = 'none'; break;
                 case true:
-                    this.$el.show().css('visibility', ''); break;
+                    this.el.style.display = '';
+                    this.el.style.visibility = ''; break;
             }
-         },
+        },
 
         update_css: function (model, css) {
             /**
@@ -649,23 +649,25 @@ define(["nbextensions/widgets/widgets/js/manager",
                 if (elements.length > 0) {
                     var trait_key = css[i][1];
                     var trait_value = css[i][2];
-                    elements.css(trait_key ,trait_value);
+                    _.each(elements, function(e) {
+                        e.style[trait_key] = trait_value;
+                    });
                 }
             }
         },
 
-        update_classes: function (old_classes, new_classes, $el) {
+        update_classes: function (old_classes, new_classes, el) {
             /**
-             * Update the DOM classes applied to an element, default to this.$el.
+             * Update the DOM classes applied to an element, default to this.el.
              */
-            if ($el===undefined) {
-                $el = this.$el;
+            if (el===undefined) {
+                el = this.el;
             }
-            _.difference(old_classes, new_classes).map(function(c) {$el.removeClass(c);})
-            _.difference(new_classes, old_classes).map(function(c) {$el.addClass(c);})
+            _.difference(old_classes, new_classes).map(function(c) { el.classList.remove(c); });
+            _.difference(new_classes, old_classes).map(function(c) { el.classList.add(c); });
         },
 
-        update_mapped_classes: function(class_map, trait_name, previous_trait_value, $el) {
+        update_mapped_classes: function(class_map, trait_name, previous_trait_value, el) {
             /**
              * Update the DOM classes applied to the widget based on a single
              * trait's value.
@@ -689,7 +691,7 @@ define(["nbextensions/widgets/widgets/js/manager",
              *  Name of the trait to check the value of.
              * previous_trait_value: optional string, default ''
              *  Last trait value
-             * $el: optional jQuery element handle, defaults to this.$el
+             * el: optional DOM element handle, defaults to this.$el
              *  Element that the classes are applied to.
              */
             var key = previous_trait_value;
@@ -700,7 +702,7 @@ define(["nbextensions/widgets/widgets/js/manager",
             key = this.model.get(trait_name);
             var new_classes = class_map[key] ? class_map[key] : [];
 
-            this.update_classes(old_classes, new_classes, $el || this.$el);
+            this.update_classes(old_classes, new_classes, el || this.el);
         },
         
         _get_selector_element: function (selector) {
@@ -709,9 +711,9 @@ define(["nbextensions/widgets/widgets/js/manager",
              */
             var elements;
             if (!selector) {
-                elements = this.$el;
+                elements = [this.el];
             } else {
-                elements = this.$el.find(selector).addBack(selector);
+                elements = this.el.querySelectorAll(selector);
             }
             return elements;
         },
@@ -719,7 +721,7 @@ define(["nbextensions/widgets/widgets/js/manager",
         typeset: function(element, text){
             utils.typeset.apply(null, arguments);
         },
-    });
+    };
 
 
     var ViewList = function(create_view, remove_view, context) {
@@ -729,7 +731,7 @@ define(["nbextensions/widgets/widgets/js/manager",
          * - remove_view takes a view and destroys it (including calling `view.remove()`)
          * - each time the update() function is called with a new list, the create and remove
          *   callbacks will be called in an order so that if you append the views created in the
-         *   create callback and remove the views in the remove callback, you will duplicate 
+         *   create callback and remove the views in the remove callback, you will duplicate
          *   the order of the list.
          * - the remove callback defaults to just removing the view (e.g., pass in null for the second parameter)
          * - the context defaults to the created ViewList.  If you pass another context, the create and remove
@@ -766,7 +768,6 @@ define(["nbextensions/widgets/widgets/js/manager",
                     break;
                 }
             }
-            
             var first_removed = i;
             // Remove the non-matching items from the old list.
             var removed = this.views.splice(first_removed, this.views.length-first_removed);
@@ -801,6 +802,9 @@ define(["nbextensions/widgets/widgets/js/manager",
         },
     });
 
+    var WidgetView = Backbone.View.extend(WidgetInterface);
+    var DOMWidgetView = WidgetView.extend(DOMWidgetInterface);
+
     var widget = {
         'unpack_models': unpack_models,
         'WidgetModel': WidgetModel,
@@ -810,7 +814,7 @@ define(["nbextensions/widgets/widgets/js/manager",
     };
 
     // For backwards compatability.
-    $.extend(IPython, widget);
+    _.extend(IPython, widget);
 
     return widget;
 });

--- a/ipython_widgets/static/widgets/js/widget.js
+++ b/ipython_widgets/static/widgets/js/widget.js
@@ -645,7 +645,7 @@ define(["nbextensions/widgets/widgets/js/manager",
             for (var i = 0; i < css.length; i++) {
                 // Apply the css traits to all elements that match the selector.
                 var selector = css[i][0];
-                var elements = this._get_selector_element(selector);
+                var elements = this.el.querySelectorAll(selector) || [this.el];
                 if (elements.length > 0) {
                     var trait_key = css[i][1];
                     var trait_value = css[i][2];
@@ -704,19 +704,8 @@ define(["nbextensions/widgets/widgets/js/manager",
 
             this.update_classes(old_classes, new_classes, el || this.el);
         },
-        
-        _get_selector_element: function (selector) {
-            /**
-             * Get the elements via the css selector.
-             */
-            var elements;
-            if (!selector) {
-                elements = [this.el];
-            } else {
-                elements = this.el.querySelectorAll(selector);
-            }
-            return elements;
-        },
+
+
 
         typeset: function(element, text){
             utils.typeset.apply(null, arguments);

--- a/ipython_widgets/static/widgets/js/widget_box.js
+++ b/ipython_widgets/static/widgets/js/widget_box.js
@@ -77,7 +77,7 @@ define([
                 warning: ['alert', 'alert-warning'],
                 danger: ['alert', 'alert-danger']
             };
-            this.update_mapped_classes(class_map, 'box_style', previous_trait_value, this.$box);
+            this.update_mapped_classes(class_map, 'box_style', previous_trait_value, this.$box[0]);
         },
         
         add_child_model: function(model) {

--- a/ipython_widgets/static/widgets/js/widget_int.js
+++ b/ipython_widgets/static/widgets/js/widget_int.js
@@ -461,7 +461,7 @@ define([
                 warning: ['progress-bar-warning'],
                 danger: ['progress-bar-danger']
             };
-            this.update_mapped_classes(class_map, 'bar_style', previous_trait_value, this.$bar);
+            this.update_mapped_classes(class_map, 'bar_style', previous_trait_value, this.$bar[0]);
         },
 
         update_attr: function(name, value) {

--- a/ipython_widgets/static/widgets/js/widget_selection.js
+++ b/ipython_widgets/static/widgets/js/widget_selection.js
@@ -113,8 +113,8 @@ define([
                 warning: ['btn-warning'],
                 danger: ['btn-danger']
             };
-            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$droplabel);
-            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$dropbutton);
+            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$droplabel[0]);
+            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$dropbutton[0]);
         },
 
         update_attr: function(name, value) {
@@ -411,7 +411,7 @@ define([
                 warning: ['btn-warning'],
                 danger: ['btn-danger']
             };
-            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$buttongroup.find('button'));
+            this.update_mapped_classes(class_map, 'button_style', previous_trait_value, this.$buttongroup.find('button')[0]);
         },
 
         handle_click: function (e) {

--- a/ipython_widgets/tests/widget.js
+++ b/ipython_widgets/tests/widget.js
@@ -48,15 +48,17 @@ casper.notebook_test(function () {
     this.then(function () {
         // Test multi-set, single touch code.  First create a custom widget.
         this.thenEvaluate(function() {
-            var MultiSetView = IPython.DOMWidgetView.extend({
-                render: function(){
-                    this.model.set('a', 1);
-                    this.model.set('b', 2);
-                    this.model.set('c', 3);
-                    this.touch();
-                },
+            define('MultiSetView', ['nbextensions/widgets/widgets/js/widget'], function(widget) {
+		        var MultiSetView = widget.DOMWidgetView.extend({
+		            render: function(){
+		                this.model.set('a', 1);
+		                this.model.set('b', 2);
+		                this.model.set('c', 3);
+		                this.touch();
+		            },
+		        });
+                return {MultiSetView: MultiSetView};
             });
-            IPython.WidgetManager.register_widget_view('MultiSetView', MultiSetView);
         }, {});
     });
 
@@ -66,6 +68,7 @@ casper.notebook_test(function () {
         'from traitlets import Unicode, CInt, Bool',
         'class MultiSetWidget(widgets.DOMWidget):',
         '    _view_name = Unicode("MultiSetView", sync=True)',
+        '    _view_module = Unicode("MultiSetView", sync=True)',
         '    a = CInt(0, sync=True)',
         '    b = CInt(0, sync=True)',
         '    c = CInt(0, sync=True)',


### PR DESCRIPTION
*Reopening the earlier PR on jupyter_notebook: removing dependency on jquery in Widget.js and manager.js (dumped the previous code there, will fix/rebase later.)*

I would like to eventually allow users to write widgets using [backbone native views](https://github.com/akre54/Backbone.NativeView) or [d3 views](https://github.com/akre54/Backbone.D3View) or other drop-in replacements for `Backbone.View` using the DOM manipulation library of their choice.

These replacements for backbone views share the main `View.el` attribute, which is a native DOM element. Hence it should be used to insert the widget view in the page generically rather than `View.$el` which is specific to jquery.

Besides inserting the widget in the page, jquery is only used for some basic css styling and `$.proxy`.

In this PR, I Widget.js I removed the jquery dependency in manager.js, and Widget.js. 

In the very end, I do:
```JavaScript
var WidgetView = Backbone.View.extend(WidgetInterface);
var DOMWidgetView = WidgetView.extend(DOMWidgetInterface);
```
which I would like to move to a different file. The idea, is that anyone could define their own version of DOMWidgetView based on NativeView:
 
```JavaScript
var NativeWidgetView = Backbone.NativeView.extend(WidgetInterface);
var NativeDOMWidgetView = NativeWidgetView.extend(DOMWidgetInterface);
```