### PR TITLE
Allow specifying a Python interpreter for gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Interactive HTML widgets for Jupyter notebooks and the IPython kernel.
         gulp css
         pip install -e .
 
+    gulp uses the Python interpreter to find the path for the jupyter notebook.
+    If a different interpreter from the one specified in PATH is used, one may
+    write
+
+        gulp css --interpreter /path/to/python
+        /path/to/pip install -e .
+
 2. Install and register the notebook extension:
 
         python -m ipywidgets.install --enable

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-var gulp = require('gulp');
+var gulp = require('gulp-param')(require('gulp'), process.argv);
 var less = require('gulp-less');
 var path = require('path');
 var minifyCSS = require('gulp-minify-css');
@@ -24,8 +24,8 @@ gulp.task('watch', function() {
 
 
 // Compile less into css.
-gulp.task('css', function (cb) {
-  var p = spawn('python', ['-c',
+gulp.task('css', function (cb, interpreter) {
+  var p = spawn(interpreter || 'python', ['-c',
     "import os,notebook; print(os.path.join(notebook.DEFAULT_STATIC_FILES_PATH))"]);
   var nb_static_path = p.stdout.toString().trim();
   return gulp.src('./ipywidgets/static/widgets/less/widgets.less')

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-minify-css": "^1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.5.1",
+    "gulp-param": "^0.6.3",
     "less": "~2",
     "source-map": "^0.4.2",
     "typescript": "~1.5.0-beta",


### PR DESCRIPTION
I always work with multiple python installs.

The current gulp file for ipywidgets uses the Python interpreter to fetch the notebook static directory. It assumes that we use the python interpreter which is in PATH.

This change allows specifying which Python interpreter to use when running `gulp css`.