### PR TITLE
WIP: Signals and Slots for ipython widgets.

### DIFF
--- a/ipywidgets/static/widgets/js/signaling.js
+++ b/ipywidgets/static/widgets/js/signaling.js
@@ -1,0 +1,181 @@
+
+// This is a duplication of phosphorjs' signaling library.
+
+define([], function(widget, $){
+
+    /**
+     * An object used for loosely coupled inter-object communication.
+     *
+     * A signal is emitted by an object in response to some event. User
+     * code may connect listener functions (slots) to the signal to be
+     * notified when that event occurs. This is a simple and efficient
+     * form of the pub-sub pattern which promotes type-safe and loosely
+     * coupled communication between objects.
+     */
+    var Signal = (function () {
+        /**
+         * Construct a new signal.
+         */
+        function Signal() {
+            this._m_slots = null;
+        }
+        /**
+         * Connect a slot to the signal.
+         *
+         * Slot connections are not de-duplicated. If the slot is connected
+         * to the signal multiple times, it will be invoked multiple times
+         * when the signal is emitted.
+         *
+         * It is safe to connect a slot while the signal is being emitted.
+         * The slot will be invoked the next time the signal is emitted.
+         */
+        Signal.prototype.connect = function (slot, thisArg) {
+            var wrapper = new SlotWrapper(slot, thisArg);
+            var slots = this._m_slots;
+            if (slots === null) {
+                this._m_slots = wrapper;
+            }
+            else if (slots instanceof SlotWrapper) {
+                this._m_slots = [slots, wrapper];
+            }
+            else {
+                slots.push(wrapper);
+            }
+        };
+        /**
+         * Disconnect a slot from the signal.
+         *
+         * This will remove all connections to the slot, even if the slot
+         * was connected multiple times. If no slot is provided, all slots
+         * will be disconnected.
+         *
+         * It is safe to disconnect a slot while the signal is being emitted.
+         * The slot is removed immediately and will not be invoked.
+         */
+        Signal.prototype.disconnect = function (slot, thisArg) {
+            var slots = this._m_slots;
+            if (slots === null) {
+                return;
+            }
+            if (slots instanceof SlotWrapper) {
+                if (!slot || slots.equals(slot, thisArg)) {
+                    slots.clear();
+                    this._m_slots = null;
+                }
+            }
+            else if (!slot) {
+                var array = slots;
+                for (var i = 0, n = array.length; i < n; ++i) {
+                    array[i].clear();
+                }
+                this._m_slots = null;
+            }
+            else {
+                var rest = [];
+                var array = slots;
+                for (var i = 0, n = array.length; i < n; ++i) {
+                    var wrapper = array[i];
+                    if (wrapper.equals(slot, thisArg)) {
+                        wrapper.clear();
+                    }
+                    else {
+                        rest.push(wrapper);
+                    }
+                }
+                if (rest.length === 0) {
+                    this._m_slots = null;
+                }
+                else if (rest.length === 1) {
+                    this._m_slots = rest[0];
+                }
+                else {
+                    this._m_slots = rest;
+                }
+            }
+        };
+        /**
+         * Test whether a slot is connected to the signal.
+         */
+        Signal.prototype.isConnected = function (slot, thisArg) {
+            var slots = this._m_slots;
+            if (slots === null) {
+                return false;
+            }
+            if (slots instanceof SlotWrapper) {
+                return slots.equals(slot, thisArg);
+            }
+            var array = slots;
+            for (var i = 0, n = array.length; i < n; ++i) {
+                if (array[i].equals(slot, thisArg)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        /**
+         * Emit the signal and invoke its connected slots. 
+         *
+         * Slots are invoked in the order in which they are connected.
+         */
+        Signal.prototype.emit = function (sender, args) {
+            var slots = this._m_slots;
+            if (slots === null) {
+                return;
+            }
+            if (slots instanceof SlotWrapper) {
+                slots.invoke(sender, args);
+            }
+            else {
+                var array = slots;
+                for (var i = 0, n = array.length; i < n; ++i) {
+                    array[i].invoke(sender, args);
+                }
+            }
+        };
+        return Signal;
+    })();
+
+
+    /**
+     * A thin wrapper around a slot function and context object.
+     */
+    var SlotWrapper = (function () {
+        /**
+         * Construct a new slot wrapper.
+         */
+        function SlotWrapper(slot, thisArg) {
+            this._m_slot = slot;
+            this._m_thisArg = thisArg;
+        }
+        /**
+         * Clear the contents of the slot wrapper.
+         */
+        SlotWrapper.prototype.clear = function () {
+            this._m_slot = null;
+            this._m_thisArg = null;
+        };
+        /**
+         * Test whether the wrapper equals a slot and context.
+         */
+        SlotWrapper.prototype.equals = function (slot, thisArg) {
+            return this._m_slot === slot && this._m_thisArg === thisArg;
+        };
+        /**
+         * Invoke the wrapper slot with the given sender and args.
+         *
+         * This is a no-op if the wrapper has been cleared.
+         */
+        SlotWrapper.prototype.invoke = function (sender, args) {
+            if (this._m_slot) {
+                this._m_slot.call(this._m_thisArg, sender, args);
+            }
+        };
+        return SlotWrapper;
+    })();
+
+    return {
+        Signal: Signal,
+        SlotWrapper: SlotWrapper,
+    };
+});

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -95,6 +95,19 @@ define(["nbextensions/widgets/widgets/js/manager",
             return Backbone.Model.apply(this);
         },
 
+        initialize: function() {
+            var that = this;
+            var keys = this.get('keys');
+            _.each(keys, function(key) {
+                that.slots[key] = function(value) {
+                    that.set(key, value);
+                    // FIXME: should we always save_changes?
+                    that.save_changes();
+                };
+                that.slots[key].slot_name = key;
+	        });
+        },
+
         emit: function(signal_name, value) {
             /**
              * Emit a signal and propagate message to the backend.
@@ -269,10 +282,10 @@ define(["nbextensions/widgets/widgets/js/manager",
                         if (slots === null) {
                             that.set(data.name, []);
                         } else if (slots instanceof signaling.SlotWrapper) {
-                            that.set(data.name, [[slots._m_thisArg, slots._m_slot.name]]);
+                            that.set(data.name, [[slots._m_thisArg, slots._m_slot.slot_name]]);
                         } else {
                             that.set(data.name, slots.map(function(d) {
-                                return [d._m_thisArg, slots._m_slot.name]
+                                return [d._m_thisArg, d._m_slot.slot_name]
                             }));
                         }
                         that.save_changes();
@@ -296,10 +309,10 @@ define(["nbextensions/widgets/widgets/js/manager",
                         if (slots === null) {
                             that.set(data.name, []);
                         } else if (slots instanceof SlotWrapper) {
-                            that.set(data.name, [[slots._m_thisArg, slots._n_slot.name]]);
+                            that.set(data.name, [[slots._m_thisArg, slots._m_slot.slot_name]]);
                         } else {
                             that.set(data.name, slots.map(function(d) {
-                                return [d._m_thisArg, slots._m_slot.name]
+                                return [d._m_thisArg, d._m_slot.slot_name]
                             }));
                         }
                         that.save_changes();
@@ -314,8 +327,8 @@ define(["nbextensions/widgets/widgets/js/manager",
                  for (var k=0; k<slots.length; ++k) {
                      var slot_info = slots[k];
                      var target_model = slot_info[0];
-                     var method_name = slot_info[1];
-                     that.signals[name].connect(target_model.slots[method_name], target_model);
+                     var slot_name = slot_info[1];
+                     that.signals[name].connect(target_model.slots[slot_name], target_model);
                  }
             }); 
         },

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -280,7 +280,17 @@ define(["nbextensions/widgets/widgets/js/manager",
                         console.log(data);
                         return;
                     }
-                    this.slots[data.name].invoke(data.value);
+                    // Deserialize slot argument 
+                    var serializers = that.constructor.serializers;
+                    var deserial;
+                    if (serializers && serializers[data.name] && serializers[data.name].deserialize) {
+                        deserial = (serializers[k].deserialize)(data.value, that);
+                    } else {
+                        deserial = Promise.resolve(data.value);
+                    }
+                    deserial.then(function(deserialized) {
+                        that.slots[data.name].invoke(deserialized);
+                    });
                     break;
                 case 'emit':
                     if(!that.signals[data.name]) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -210,6 +210,22 @@ define(["nbextensions/widgets/widgets/js/manager",
                         that.widget_manager.display_view(msg, that);
                     }).catch(utils.reject('Could not process display view msg', true));
                     break;
+                case 'invoke':
+                    console.log('invoke');
+                    console.log(msg.content.data);
+                    break;
+                case 'emit':
+                    console.log('emit');
+                    console.log(msg.content.data);
+                    break;
+                case 'connect':
+                    console.log('connect');
+                    console.log(msg.content.data);
+                    break;
+                case 'disconnect':
+                    console.log('disconnect');
+                    console.log(msg.content.data);
+                    break;
             }
         },
 

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -114,7 +114,7 @@ define(["nbextensions/widgets/widgets/js/manager",
             this.on('change', function() {
                 var changed = this.changedAttributes();
                 _.each(changed, function(v, k) {
-                    // TODO: use this.emit to propagate to the back-end
+                    // TODO: use `this.emit('state_changed', {` to propagate to the back-end
                     this.signals['state_changed'].emit({
                         'name': k,
                         'old': this.previous(k),
@@ -124,15 +124,25 @@ define(["nbextensions/widgets/widgets/js/manager",
             }, this);
         },
 
-        emit: function(signal_name, value) {
+        emit: function(name, value, callbacks, buffers) {
             /**
              * Emit a signal and propagate message to the backend.
              */
-            this.signals[signal_name].emit(value);
+            this.signals[name].emit(value);
             if (this.comm !== undefined) {
-                var data = {method: 'emit', name: signal_name, value: value};
-                this.comm.send(data);
-                this.pending_msgs++;
+                var serializers = this.constructor.serializers;
+                var serial;
+                if (serializers && serializers[name] && serializers[name].serialize) {
+                    serial = (serializers[name].serialize)(value, this);
+                } else {
+                    serial = Promise.resolve(value)
+                }
+                var that = this;
+                serial.then(function(serialized) {
+                    var data = {method: 'emit', name: name, value: serialized};
+                    that.comm.send(data, callbacks || that.widget_manager.callbacks(), {}, buffers);
+                    that.pending_msgs++;
+                });
             }
         },
 
@@ -278,7 +288,17 @@ define(["nbextensions/widgets/widgets/js/manager",
                         console.log(data);
                         return;
                     }
-                    this.emit(data.name, data.value);
+                    // Deserialize signal
+                    var serializers = that.constructor.serializers;
+                    var deserial;
+                    if (serializers && serializers[data.name] && serializers[data.name].deserialize) {
+                        deserial = (serializers[k].deserialize)(data.value, that);
+                    } else {
+                        deserial = Promise.resolve(data.value);
+                    }
+                    deserial.then(function(deserialized) {
+                        that.emit(data.name, deserialized);
+                    });
                     break;
                 case 'connect':
                     unpack_models(data.slot.model, this).then(function(target_model) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -98,6 +98,8 @@ define(["nbextensions/widgets/widgets/js/manager",
         initialize: function() {
             var that = this;
             var keys = this.get('keys');
+
+            // Create a slot for each key.
             _.each(keys, function(key) {
                 that.slots[key] = function(value) {
                     that.set(key, value);
@@ -106,6 +108,20 @@ define(["nbextensions/widgets/widgets/js/manager",
                 };
                 that.slots[key].slot_name = key;
 	        });
+
+            // state_changed signal
+            that.signals['state_changed'] = new signaling.Signal();
+            this.on('change', function() {
+                var changed = this.changedAttributes();
+                _.each(changed, function(v, k) {
+                    // TODO: use this.emit to propagate to the back-end
+                    this.signals['state_changed'].emit({
+                        'name': k,
+                        'old': this.previous(k),
+                        'new': v,
+                    });
+                }, this);
+            }, this);
         },
 
         emit: function(signal_name, value) {

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -4,8 +4,23 @@
 define([
     "nbextensions/widgets/widgets/js/widget",
     "jquery",
+    "./signaling",
     "bootstrap",
-], function(widget, $){
+], function(widget, $, signaling){
+
+    var ButtonModel = widget.WidgetModel.extend({
+        slots: {
+            test_slot: function(index) {
+                this.set("button_style", 
+                         ['primary', 'success', 'info',
+                          'warning', 'danger'][Math.floor(Math.random() * 5)]);
+                this.save_changes();
+            },
+        },
+        signals: {
+            clicked: new signaling.Signal(),
+        },
+    });
 
     var ButtonView = widget.DOMWidgetView.extend({
         render : function(){
@@ -65,11 +80,13 @@ define([
             /**
              * Handles when the button is clicked.
              */
+            this.model.emit('clicked');
             this.send({event: 'click'});
         },
     });
 
     return {
-        'ButtonView': ButtonView,
+        ButtonView: ButtonView,
+        ButtonModel: ButtonModel,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -10,7 +10,7 @@ define([
 
     var ButtonModel = widget.WidgetModel.extend({
         slots: {
-            test_slot: function(index) {
+            test_slot: function test_slot(index) {
                 this.set("button_style", 
                          ['primary', 'success', 'info',
                           'warning', 'danger'][Math.floor(Math.random() * 5)]);

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -80,7 +80,7 @@ define([
             /**
              * Handles when the button is clicked.
              */
-            this.model.emit('clicked');
+            this.model.emit('clicked');  // this.model.signals['clicked'].emit();
             this.send({event: 'click'});
         },
     });

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -10,12 +10,16 @@ define([
 
     var ButtonModel = widget.WidgetModel.extend({
         slots: {
-            test_slot: function test_slot(index) {
-                this.set("button_style", 
-                         ['primary', 'success', 'info',
-                          'warning', 'danger'][Math.floor(Math.random() * 5)]);
-                this.save_changes();
-            },
+            test_slot: (function() {
+                func = function () {
+		            this.set("button_style",
+		                     ['primary', 'success', 'info',
+		                      'warning', 'danger'][Math.floor(Math.random() * 5)]);
+		            this.save_changes();
+                };
+                func.slot_name = 'test_slot';
+                return func;
+            })(),
         },
         signals: {
             clicked: new signaling.Signal(),

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -10,16 +10,7 @@ import re
 import traitlets
 
 from . import eventful
-
-def _widget_to_json(x):
-    if isinstance(x, dict):
-        return {k: _widget_to_json(v) for k, v in x.items()}
-    elif isinstance(x, (list, tuple)):
-        return [_widget_to_json(v) for v in x]
-    elif isinstance(x, traitlets.HasTraits):
-        return "IPY_MODEL_" + x.model_id
-    else:
-        return x
+from .widget import serialize_widget_attribute
 
 
 class BaseSignaling(traitlets.BaseTraitType):
@@ -87,6 +78,7 @@ class _Signal(object):
     def __init__(self, model, signal):
         self.model = model
         self.signal = signal
+        self.connected_slots = []
 
     def connect(self, slot):
         """Sends a `connect` signal to the front-end. This causes the
@@ -99,7 +91,7 @@ class _Signal(object):
         self.model._send({
             'method': 'connect',
             'name': self.signal.name,
-            'slot': _widget_to_json({
+            'slot': serialize_widget_attribute({
                 'model': slot.model,
                 'name': slot.name,
             }),
@@ -114,7 +106,7 @@ class _Signal(object):
         self.model._send({
             'method': 'disconnect',
             'name': self.signal.name,
-            'slot': _widget_to_json({
+            'slot': serialize_widget_attribute({
                 'model': slot.model,
                 'name': slot.name, 
             }),

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -99,7 +99,10 @@ class _Signal(object):
         self.model._send({
             'method': 'connect',
             'name': self.signal.name,
-            'slot': _widget_to_json([slot.model, slot.name]),
+            'slot': _widget_to_json({
+                'model': slot.model,
+                'name': slot.name,
+            }),
         })
 
     def disconnect(self, slot):
@@ -111,7 +114,10 @@ class _Signal(object):
         self.model._send({
             'method': 'disconnect',
             'name': self.signal.name,
-            'slot': _widget_to_json([slot.model, slot.name]),
+            'slot': _widget_to_json({
+                'model': slot.model,
+                'name': slot.name, 
+            }),
         })
 
     def emit(self, value=None):

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -11,6 +11,153 @@ import traitlets
 
 from . import eventful
 
+def _widget_to_json(x):
+    if isinstance(x, dict):
+        return {k: _widget_to_json(v) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [_widget_to_json(v) for v in x]
+    elif isinstance(x, traitlets.HasTraits):
+        return "IPY_MODEL_" + x.model_id
+    else:
+        return x
+
+
+class BaseSignaling(traitlets.BaseTraitType):
+    """This is used as a base class for both Signals and Slots.
+    This is a hook into MetaHasTrait metaclass."""    
+ 
+    def __init__(self, trait_type=None):
+        """The constructor takes a trait type specifying
+        the signature of the signal."""
+        if trait_type is None:
+            trait_type = traitlets.Any()
+        self.trait_type = trait_type
+
+    @property
+    def this_class(self):
+        """The `this_class` property rebings to the `this_class` attribute
+        of the underlying trait type"""
+        return self.trait_type.this_class
+
+    @this_class.setter
+    def this_class(self, this_class):
+        """The setter for the `this_class` property is called in the
+        __init__ method of the MetaHasTraits class."""
+        self.trait_type.this_class = this_class
+
+    @property
+    def name(self):
+        """The `name` property rebings to the `name` attribute
+        of the underlying trait type"""
+        return self.trait_type.name
+
+    @name.setter
+    def name(self, name):
+        """The setter for the `name` property is called in the
+        __new__ method of the MetaHasTraits class."""
+        self.trait_type.name = name
+
+    def instance_init(self, obj):
+        """Part of the initialization that depend on the underlying
+        HasTrait instance
+            - calls instance_init on the underlying trait type
+        """
+        self.trait_type.instance_init(obj)
+
+    def validate(self, obj, value):
+        """Rebinds to the underlying trait type validation"""
+        return self.trait_type._validate(obj, value)
+
+    def get_metadata(self, key, default=None):
+        """Rebinds to the underlying trait type get_metadata"""
+        return self.trait_type.get_metadata(key, default)
+
+class Signal(BaseSignaling):
+
+     def instance_init(self, obj):
+         """Constructs the instance-level signal"""
+         super(Signal, self).instance_init(obj)
+         setattr(obj, self.name, _Signal(obj, self))
+
+
+class _Signal(object):
+    """Main Signal object, mirroring front-end's Signal object, this object
+    is not meant to be directly instantiated by the user."""
+
+    def __init__(self, model, signal):
+        self.model = model
+        self.signal = signal
+
+    def connect(self, slot):
+        """Sends a `connect` signal to the front-end. This causes the
+        connection of a slot to the signal in the frontend.
+
+        Slot connections are not de-duplicated. If the slot is connected
+        multiple times, it will be invoked multiple times when the signal
+        is emitted.
+        """
+        self.model._send({
+            'method': 'connect',
+            'name': self.signal.name,
+            'slot': _widget_to_json([slot.model, slot.name]),
+        })
+
+    def disconnect(self, slot):
+        """Sends a `disconnect` signal to the front-end.
+
+        This will remove all connections to the slot, even if the slot was
+        connected multple times. If no slot is provided, all slots will be
+        disconnected."""
+        self.model._send({
+            'method': 'disconnect',
+            'name': self.signal.name,
+            'slot': _widget_to_json([slot.model, slot.name]),
+        })
+
+    def emit(self, value=None):
+        """Emits a signal with the provided value. The value is validated of
+        the argument is validated.
+
+        Slots are invoked in the order in which they were connected."""
+        to_json = self.signal.trait_type.get_metadata('to_json',
+                                                      self.model._trait_to_json)
+        self.model._send({
+            'method': 'emit',
+            'name': self.signal.name,
+            'value': to_json(self.signal.validate(self.model, value)),
+        })
+
+
+class Slot(BaseSignaling):
+
+     def instance_init(self, obj):
+         """Constructs the instance-level signal"""
+         super(Slot, self).instance_init(obj)
+         setattr(obj, self.name, _Slot(obj, self))
+
+
+class _Slot(object):
+    """Main Slot object, mirroring front-end's Slot object, this object
+    is not meant to be directly instantiated by the user."""
+
+    def __init__(self, model, slot):
+        self.model = model
+        self.slot = slot
+
+    def invoke(self, value=None):
+        to_json = self.slot.trait_type.get_metadata('to_json',
+                                                    self.model._trait_to_json)
+        self.model._send({
+            'method': 'invoke',
+            'name': self.slot.name,
+            'value': to_json(self.slot.validate(self.model, value)),
+        })
+
+    @property
+    def name(self):
+        return self.slot.name
+
+
 _color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen'] 
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -13,55 +13,54 @@ from . import eventful
 from .widget import serialize_widget_attribute
 
 
-class BaseSignaling(traitlets.BaseTraitType):
-    """This is used as a base class for both Signals and Slots.
-    This is a hook into MetaHasTrait metaclass."""    
+class BaseSignaling(traitlets.BaseDescriptor):
+    """Base class for both Signals and Slots."""    
  
-    def __init__(self, trait_type=None):
+    def __init__(self, trait=None):
         """The constructor takes a trait type specifying
         the signature of the signal."""
-        if trait_type is None:
-            trait_type = traitlets.Any()
-        self.trait_type = trait_type
+        if trait is None:
+            trait = traitlets.Any()
+        self.trait = trait
 
     @property
     def this_class(self):
         """The `this_class` property rebings to the `this_class` attribute
         of the underlying trait type"""
-        return self.trait_type.this_class
+        return self.trait.this_class
 
     @this_class.setter
     def this_class(self, this_class):
         """The setter for the `this_class` property is called in the
         __init__ method of the MetaHasTraits class."""
-        self.trait_type.this_class = this_class
+        self.trait.this_class = this_class
 
     @property
     def name(self):
         """The `name` property rebings to the `name` attribute
         of the underlying trait type"""
-        return self.trait_type.name
+        return self.trait.name
 
     @name.setter
     def name(self, name):
         """The setter for the `name` property is called in the
         __new__ method of the MetaHasTraits class."""
-        self.trait_type.name = name
+        self.trait.name = name
 
     def instance_init(self, obj):
         """Part of the initialization that depend on the underlying
         HasTrait instance
             - calls instance_init on the underlying trait type
         """
-        self.trait_type.instance_init(obj)
+        self.trait.instance_init(obj)
 
     def validate(self, obj, value):
         """Rebinds to the underlying trait type validation"""
-        return self.trait_type._validate(obj, value)
+        return self.trait._validate(obj, value)
 
     def get_metadata(self, key, default=None):
         """Rebinds to the underlying trait type get_metadata"""
-        return self.trait_type.get_metadata(key, default)
+        return self.trait.get_metadata(key, default)
 
 class Signal(BaseSignaling):
 
@@ -117,8 +116,8 @@ class _Signal(object):
         the argument is validated.
 
         Slots are invoked in the order in which they were connected."""
-        to_json = self.signal.trait_type.get_metadata('to_json',
-                                                      self.model._trait_to_json)
+        to_json = self.signal.trait.get_metadata('to_json',
+                                                 self.model._trait_to_json)
         self.model._send({
             'method': 'emit',
             'name': self.signal.name,
@@ -143,8 +142,8 @@ class _Slot(object):
         self.slot = slot
 
     def invoke(self, value=None):
-        to_json = self.slot.trait_type.get_metadata('to_json',
-                                                    self.model._trait_to_json)
+        to_json = self.slot.trait.get_metadata('to_json',
+                                               self.model._trait_to_json)
         self.model._send({
             'method': 'invoke',
             'name': self.slot.name,

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -13,7 +13,7 @@ from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from ipython_genutils.importstring import import_item
-from traitlets import Unicode, Dict, Instance, Bool, List, \
+from traitlets import Unicode, Dict, Instance, Bool, List, Any, \
     CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
 from ipython_genutils.py3compat import string_types
 
@@ -173,6 +173,9 @@ class Widget(LoggingConfigurable):
     keys = List(sync=True)
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]
+
+    # TODO: Replace with Signal(TypeMap(**synced_traits))
+    state_changed = Signal(Any())
     
     _property_lock = Dict()
     _send_state_lock = Int(0)

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -14,9 +14,9 @@ from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from traitlets import Unicode, Dict, Instance, Bool, List, \
-    CaselessStrEnum, Tuple, CUnicode, Int, Set
+    CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
 from ipython_genutils.py3compat import string_types
-from .trait_types import Color
+from .trait_types import Color, Signal, Slot
 
 
 def _widget_to_json(x):
@@ -455,6 +455,18 @@ class Widget(LoggingConfigurable):
     def _send(self, msg, buffers=None):
         """Sends a message to the model in the front-end."""
         self.comm.send(data=msg, buffers=buffers)
+
+    def signals(self):
+        """Returns a `dict` of all the signals of this widget. The dictionary
+        is keyed on the name and the values are the Signal objects."""
+        return dict([memb for memb in getmembers(self.__class__) if 
+                    isinstance(memb[1], Signal)]) 
+        
+    def slots(self):
+        """Returns a `dict` of all the slots of this widget. The dictionary
+        is keyed on the name and the values are the Slot objects."""
+        return dict([memb for memb in getmembers(self.__class__) if 
+                    isinstance(memb[1], Slot)]) 
 
 
 class DOMWidget(Widget):

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -170,7 +170,7 @@ class Widget(LoggingConfigurable):
         front-end can send before receiving an idle msg from the back-end.""")
     
     version = Int(0, sync=True, help="""Widget's version""")
-    keys = List()
+    keys = List(sync=True)
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]
     

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -16,33 +16,50 @@ from ipython_genutils.importstring import import_item
 from traitlets import Unicode, Dict, Instance, Bool, List, \
     CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
 from ipython_genutils.py3compat import string_types
-from .trait_types import Color, Signal, Slot
 
 
-def _widget_to_json(x):
+def serialize_widget_attribute(x):
+    """Serialization of widget attributes that may contain widget models.
+
+    Notes
+    -----
+    Widgetmodels are serialized into the string "IPY_MODEL_" + model_id.
+    """
     if isinstance(x, dict):
-        return {k: _widget_to_json(v) for k, v in x.items()}
+        return {k: serialize_widget_attribute(v) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
-        return [_widget_to_json(v) for v in x]
+        return [serialize_widget_attribute(v) for v in x]
     elif isinstance(x, Widget):
         return "IPY_MODEL_" + x.model_id
     else:
         return x
 
-def _json_to_widget(x):
+
+def deserialize_widget_attribute(x):
+    """Deserialization of widget attributes that may contain widget models
+
+    Notes
+    -----
+    Strings in the form of "IPY_MODEL_" + model_id are deserialized into a the
+    corresponding widget model if it exists.
+    """
     if isinstance(x, dict):
-        return {k: _json_to_widget(v) for k, v in x.items()}
+        return {k: deserialize_widget_attribute(v) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
-        return [_json_to_widget(v) for v in x]
+        return [deserialize_widget_attribute(v) for v in x]
     elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
         return Widget.widgets[x[10:]]
     else:
         return x
 
+
 widget_serialization = {
-    'from_json': _json_to_widget,
-    'to_json': _widget_to_json
+    'from_json': serialize_widget_attribute,
+    'to_json': deserialize_widget_attribute,
 }
+
+
+from .trait_types import Color, Signal, Slot
 
 
 class CallbackDispatcher(LoggingConfigurable):
@@ -291,6 +308,8 @@ class Widget(LoggingConfigurable):
                     from_json = self.trait_metadata(name, 'from_json',
                                                     self._trait_from_json)
                     setattr(self, name, from_json(sync_data[name]))
+                if name in self.signals():
+                    getattr(self, name).connected_slots = deserialize_widget_attribute(sync_data[name])
 
     def send(self, content, buffers=None):
         """Sends a custom msg to the widget model in the front-end.
@@ -397,9 +416,9 @@ class Widget(LoggingConfigurable):
             if 'sync_data' in data:
                 # get binary buffers too
                 sync_data = data['sync_data']
-                for i,k in enumerate(data.get('buffer_keys', [])):
+                for i, k in enumerate(data.get('buffer_keys', [])):
                     sync_data[k] = msg['buffers'][i]
-                self.set_state(sync_data) # handles all methods
+                self.set_state(sync_data)  # handles all methods
 
         # Handle a state request.
         elif method == 'request_state':

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -274,14 +274,16 @@ class Widget(LoggingConfigurable):
         -------
         connections: dict of connections
         """
+        signals = self.signals()
         if key is None:
-            keys = self.signals()
-        elif isinstance(key, string_types):
-            keys = [key]
-        elif isinstance(key, collections.Iterable):
-            keys = key
+            keys = signals
         else:
-            raise ValueError("key must be a string, an iterable of keys, or None")
+            if isinstance(key, string_types):
+                keys = [key] if key in signals else []
+            elif isinstance(key, collections.Iterable):
+                keys = [k for k in key if k in signals]
+            else:
+                raise ValueError("key must be a string, an iterable of keys, or None")
         connections = {
             k: serialize_widget_attribute(getattr(self, k).connected_slots) for k in keys
         }
@@ -309,9 +311,9 @@ class Widget(LoggingConfigurable):
         if key is None:
             keys = self.keys
         elif isinstance(key, string_types):
-            keys = [key]
+            keys = [key] if key in self.keys else []
         elif isinstance(key, collections.Iterable):
-            keys = key
+            keys = [k for k in key if k in self.keys]
         else:
             raise ValueError("key must be a string, an iterable of keys, or None")
         state = {}
@@ -319,8 +321,6 @@ class Widget(LoggingConfigurable):
         buffer_keys = []
         for k in keys:
             f = self.trait_metadata(k, 'to_json', self._trait_to_json)
-            if f != self._trait_to_json:
-                print f
             value = getattr(self, k)
             serialized = f(value)
             if isinstance(serialized, memoryview):

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -10,7 +10,7 @@ click events on the button and trigger backend code when the clicks are fired.
 from .widget import DOMWidget, CallbackDispatcher, register
 from traitlets import Unicode, Bool, CaselessStrEnum
 from .deprecated import DeprecatedClass
-from .trait_types import Signal
+from .trait_types import Signal, Slot
 
 @register('IPython.Button')
 class Button(DOMWidget):
@@ -28,13 +28,15 @@ class Button(DOMWidget):
            font-awesome icon name
     """
     _view_name = Unicode('ButtonView', sync=True)
+    _model_name = Unicode('ButtonModel', sync=True)
 
     # Keys
     description = Unicode('', help="Button label.", sync=True)
     tooltip = Unicode(help="Tooltip caption of the button.", sync=True)
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
-    clicked = Signal(Bool())
+    clicked = Signal()
+    test_slot = Slot()
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], 

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -10,7 +10,7 @@ click events on the button and trigger backend code when the clicks are fired.
 from .widget import DOMWidget, CallbackDispatcher, register
 from traitlets import Unicode, Bool, CaselessStrEnum
 from .deprecated import DeprecatedClass
-
+from .trait_types import Signal
 
 @register('IPython.Button')
 class Button(DOMWidget):
@@ -34,6 +34,7 @@ class Button(DOMWidget):
     tooltip = Unicode(help="Tooltip caption of the button.", sync=True)
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
+    clicked = Signal(Bool())
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], 


### PR DESCRIPTION
*Do not merge - work in progress
This depends on the traitlets PRs https://github.com/ipython/traitlets/pull/22, https://github.com/ipython/traitlets/pull/26, https://github.com/ipython/traitlets/pull/27 - now merged.*

Communication between Widget Signals and Slots happens on the front-end. The user does the wiring on the Python side. This uses Phosphorjs' signals and slots.

Example: 
- Listing the signals of `Button`

```Python
from ipywidgets import *
btn = Button()
btn.signals()
```
```
{'clicked': <ipywidgets.widgets.trait_types.Signal at 0x7f901c5314d0>}
```

- Connecting to a test slot
```Python
btn.clicked.connect(btn.test_slot)
```

- Forcibly emitting a signal from the Python side
```Python
btn.clicked.emit()
```

TODO: 

- [x] Make connections persistent to page reload (store them in the object model).
- [x] Allow using widget attributes as slots (to connect a non-state signal to an attribute).
- [x] Create a general `state_changed` signal
- [ ] Use the latest version of phosphor's slots and signals.