### PR TITLE
Pass widget instance to trait serializer

### DIFF
--- a/ipywidgets/tests/tests/widget.ts
+++ b/ipywidgets/tests/tests/widget.ts
@@ -210,7 +210,7 @@ base.tester
     from traitlets import Unicode, Instance, List
     from IPython.display import display
     from array import array
-    def _array_to_memoryview(x):
+    def _array_to_memoryview(obj, x):
         if x is None: return None
         try:
             y = memoryview(x)
@@ -218,7 +218,7 @@ base.tester
             # in python 2, arrays do not support the new buffer protocol
             y = memoryview(buffer(x))
         return y
-    def _memoryview_to_array(x):
+    def _memoryview_to_array(obj, x):
         if x is None: return None
         return array("d", x.tobytes())
     arrays_binary = {
@@ -226,9 +226,9 @@ base.tester
         "to_json": _array_to_memoryview
     }
     
-    def _array_to_list(x):
+    def _array_to_list(obj, x):
         return list(x)
-    def _list_to_array(x):
+    def _list_to_array(obj, x):
         return array("d",x)
     arrays_list = {
         "from_json": _list_to_array,

--- a/ipywidgets/tests/tests/widget.ts
+++ b/ipywidgets/tests/tests/widget.ts
@@ -210,7 +210,7 @@ base.tester
     from traitlets import Unicode, Instance, List
     from IPython.display import display
     from array import array
-    def _array_to_memoryview(obj, x):
+    def _array_to_memoryview(x, obj):
         if x is None: return None
         try:
             y = memoryview(x)
@@ -218,7 +218,7 @@ base.tester
             # in python 2, arrays do not support the new buffer protocol
             y = memoryview(buffer(x))
         return y
-    def _memoryview_to_array(obj, x):
+    def _memoryview_to_array(x, obj):
         if x is None: return None
         return array("d", x.tobytes())
     arrays_binary = {
@@ -226,9 +226,9 @@ base.tester
         "to_json": _array_to_memoryview
     }
     
-    def _array_to_list(obj, x):
+    def _array_to_list(x, obj):
         return list(x)
-    def _list_to_array(obj, x):
+    def _list_to_array(x, obj):
         return array("d",x)
     arrays_list = {
         "from_json": _list_to_array,

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -19,21 +19,21 @@ from ipython_genutils.py3compat import string_types
 from .trait_types import Color
 
 
-def _widget_to_json(obj, x):
+def _widget_to_json(x, obj):
     if isinstance(x, dict):
-        return {k: _widget_to_json(obj, v) for k, v in x.items()}
+        return {k: _widget_to_json(v, obj) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
-        return [_widget_to_json(obj, v) for v in x]
+        return [_widget_to_json(v, obj) for v in x]
     elif isinstance(x, Widget):
         return "IPY_MODEL_" + x.model_id
     else:
         return x
 
-def _json_to_widget(obj, x):
+def _json_to_widget(x, obj):
     if isinstance(x, dict):
-        return {k: _json_to_widget(obj, v) for k, v in x.items()}
+        return {k: _json_to_widget(v, obj) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
-        return [_json_to_widget(obj, v) for v in x]
+        return [_json_to_widget(v, obj) for v in x]
     elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
         return Widget.widgets[x[10:]]
     else:
@@ -269,7 +269,7 @@ class Widget(LoggingConfigurable):
         state = {}
         for k in keys:
             to_json = self.trait_metadata(k, 'to_json', self._trait_to_json)
-            state[k] = to_json(self, getattr(self, k))
+            state[k] = to_json(getattr(self, k), self)
         return state
 
     def set_state(self, sync_data):
@@ -282,7 +282,7 @@ class Widget(LoggingConfigurable):
                 if name in self.keys:
                     from_json = self.trait_metadata(name, 'from_json',
                                                     self._trait_from_json)
-                    setattr(self, name, from_json(self, sync_data[name]))
+                    setattr(self, name, from_json(sync_data[name], self))
 
     def send(self, content, buffers=None):
         """Sends a custom msg to the widget model in the front-end.
@@ -369,7 +369,7 @@ class Widget(LoggingConfigurable):
         """Check the property lock (property_lock)"""
         to_json = self.trait_metadata(key, 'to_json', self._trait_to_json)
         if (key in self._property_lock
-            and to_json(self, value) == self._property_lock[key]):
+            and to_json(value, self) == self._property_lock[key]):
             return False
         elif self._send_state_lock > 0:
             self._states_to_send.add(key)
@@ -430,12 +430,12 @@ class Widget(LoggingConfigurable):
         self._display_callbacks(self, **kwargs)
 
     @staticmethod
-    def _trait_to_json(self, x):
+    def _trait_to_json(x, self):
         """Convert a trait value to json."""
         return x
 
     @staticmethod
-    def _trait_from_json(self, x):
+    def _trait_from_json(x, self):
         """Convert json values to objects."""
         return x
 


### PR DESCRIPTION
Adding the widget instance to the signature of custom widget attribute [de]serializers. 
This is meant to enable things like 7e6bb27, where the way things are deserialized depend on the widget instance.