### PR TITLE
WIP: Signaling with serialization

### DIFF
--- a/ipywidgets/static/widgets/js/signaling.js
+++ b/ipywidgets/static/widgets/js/signaling.js
@@ -29,8 +29,8 @@ define([], function(widget, $){
          * It is safe to connect a slot while the signal is being emitted.
          * The slot will be invoked the next time the signal is emitted.
          */
-        Signal.prototype.connect = function (slot, thisArg) {
-            var wrapper = new SlotWrapper(slot, thisArg);
+        Signal.prototype.connect = function (slot, thisArg, name) {
+            var wrapper = new SlotWrapper(slot, thisArg, name);
             var slots = this._m_slots;
             if (slots === null) {
                 this._m_slots = wrapper;
@@ -144,9 +144,10 @@ define([], function(widget, $){
         /**
          * Construct a new slot wrapper.
          */
-        function SlotWrapper(slot, thisArg) {
+        function SlotWrapper(slot, thisArg, name) {
             this._m_slot = slot;
             this._m_thisArg = thisArg;
+            this._m_name = name;
         }
         /**
          * Clear the contents of the slot wrapper.

--- a/ipywidgets/static/widgets/js/signaling.js
+++ b/ipywidgets/static/widgets/js/signaling.js
@@ -1,0 +1,181 @@
+
+// This is a duplication of phosphorjs' signaling library.
+
+define([], function(widget, $){
+
+    /**
+     * An object used for loosely coupled inter-object communication.
+     *
+     * A signal is emitted by an object in response to some event. User
+     * code may connect listener functions (slots) to the signal to be
+     * notified when that event occurs. This is a simple and efficient
+     * form of the pub-sub pattern which promotes type-safe and loosely
+     * coupled communication between objects.
+     */
+    var Signal = (function () {
+        /**
+         * Construct a new signal.
+         */
+        function Signal() {
+            this._m_slots = null;
+        }
+        /**
+         * Connect a slot to the signal.
+         *
+         * Slot connections are not de-duplicated. If the slot is connected
+         * to the signal multiple times, it will be invoked multiple times
+         * when the signal is emitted.
+         *
+         * It is safe to connect a slot while the signal is being emitted.
+         * The slot will be invoked the next time the signal is emitted.
+         */
+        Signal.prototype.connect = function (slot, thisArg) {
+            var wrapper = new SlotWrapper(slot, thisArg);
+            var slots = this._m_slots;
+            if (slots === null) {
+                this._m_slots = wrapper;
+            }
+            else if (slots instanceof SlotWrapper) {
+                this._m_slots = [slots, wrapper];
+            }
+            else {
+                slots.push(wrapper);
+            }
+        };
+        /**
+         * Disconnect a slot from the signal.
+         *
+         * This will remove all connections to the slot, even if the slot
+         * was connected multiple times. If no slot is provided, all slots
+         * will be disconnected.
+         *
+         * It is safe to disconnect a slot while the signal is being emitted.
+         * The slot is removed immediately and will not be invoked.
+         */
+        Signal.prototype.disconnect = function (slot, thisArg) {
+            var slots = this._m_slots;
+            if (slots === null) {
+                return;
+            }
+            if (slots instanceof SlotWrapper) {
+                if (!slot || slots.equals(slot, thisArg)) {
+                    slots.clear();
+                    this._m_slots = null;
+                }
+            }
+            else if (!slot) {
+                var array = slots;
+                for (var i = 0, n = array.length; i < n; ++i) {
+                    array[i].clear();
+                }
+                this._m_slots = null;
+            }
+            else {
+                var rest = [];
+                var array = slots;
+                for (var i = 0, n = array.length; i < n; ++i) {
+                    var wrapper = array[i];
+                    if (wrapper.equals(slot, thisArg)) {
+                        wrapper.clear();
+                    }
+                    else {
+                        rest.push(wrapper);
+                    }
+                }
+                if (rest.length === 0) {
+                    this._m_slots = null;
+                }
+                else if (rest.length === 1) {
+                    this._m_slots = rest[0];
+                }
+                else {
+                    this._m_slots = rest;
+                }
+            }
+        };
+        /**
+         * Test whether a slot is connected to the signal.
+         */
+        Signal.prototype.isConnected = function (slot, thisArg) {
+            var slots = this._m_slots;
+            if (slots === null) {
+                return false;
+            }
+            if (slots instanceof SlotWrapper) {
+                return slots.equals(slot, thisArg);
+            }
+            var array = slots;
+            for (var i = 0, n = array.length; i < n; ++i) {
+                if (array[i].equals(slot, thisArg)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        /**
+         * Emit the signal and invoke its connected slots. 
+         *
+         * Slots are invoked in the order in which they are connected.
+         */
+        Signal.prototype.emit = function (sender, args) {
+            var slots = this._m_slots;
+            if (slots === null) {
+                return;
+            }
+            if (slots instanceof SlotWrapper) {
+                slots.invoke(sender, args);
+            }
+            else {
+                var array = slots;
+                for (var i = 0, n = array.length; i < n; ++i) {
+                    array[i].invoke(sender, args);
+                }
+            }
+        };
+        return Signal;
+    })();
+
+
+    /**
+     * A thin wrapper around a slot function and context object.
+     */
+    var SlotWrapper = (function () {
+        /**
+         * Construct a new slot wrapper.
+         */
+        function SlotWrapper(slot, thisArg) {
+            this._m_slot = slot;
+            this._m_thisArg = thisArg;
+        }
+        /**
+         * Clear the contents of the slot wrapper.
+         */
+        SlotWrapper.prototype.clear = function () {
+            this._m_slot = null;
+            this._m_thisArg = null;
+        };
+        /**
+         * Test whether the wrapper equals a slot and context.
+         */
+        SlotWrapper.prototype.equals = function (slot, thisArg) {
+            return this._m_slot === slot && this._m_thisArg === thisArg;
+        };
+        /**
+         * Invoke the wrapper slot with the given sender and args.
+         *
+         * This is a no-op if the wrapper has been cleared.
+         */
+        SlotWrapper.prototype.invoke = function (sender, args) {
+            if (this._m_slot) {
+                this._m_slot.call(this._m_thisArg, sender, args);
+            }
+        };
+        return SlotWrapper;
+    })();
+
+    return {
+        Signal: Signal,
+        SlotWrapper: SlotWrapper,
+    };
+});

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -92,6 +92,19 @@ define(["nbextensions/widgets/widgets/js/manager",
             widget_manager.notebook.events.on('kernel_dead.Kernel', died);
         },
 
+        initialize: function() {
+            var that = this;
+            var keys = this.get('keys');
+            _.each(keys, function(key) {
+                that.slots[key] = function(value) {
+                    that.set(key, value);
+                    // FIXME: should we always save_changes?
+                    that.save_changes();
+                };
+                that.slots[key].slot_name = key;
+	        });
+        },
+
         emit: function(signal_name, value) {
             /**
              * Emit a signal and propagate message to the backend.
@@ -272,10 +285,10 @@ define(["nbextensions/widgets/widgets/js/manager",
                         if (slots === null) {
                             that.set(data.name, []);
                         } else if (slots instanceof signaling.SlotWrapper) {
-                            that.set(data.name, [[slots._m_thisArg, slots._m_slot.name]]);
+                            that.set(data.name, [[slots._m_thisArg, slots._m_slot.slot_name]]);
                         } else {
                             that.set(data.name, slots.map(function(d) {
-                                return [d._m_thisArg, slots._m_slot.name]
+                                return [d._m_thisArg, d._m_slot.slot_name]
                             }));
                         }
                         that.save_changes();
@@ -299,10 +312,10 @@ define(["nbextensions/widgets/widgets/js/manager",
                         if (slots === null) {
                             that.set(data.name, []);
                         } else if (slots instanceof SlotWrapper) {
-                            that.set(data.name, [[slots._m_thisArg, slots._n_slot.name]]);
+                            that.set(data.name, [[slots._m_thisArg, slots._m_slot.slot_name]]);
                         } else {
                             that.set(data.name, slots.map(function(d) {
-                                return [d._m_thisArg, slots._m_slot.name]
+                                return [d._m_thisArg, d._m_slot.slot_name]
                             }));
                         }
                         that.save_changes();
@@ -317,8 +330,8 @@ define(["nbextensions/widgets/widgets/js/manager",
                  for (var k=0; k<slots.length; ++k) {
                      var slot_info = slots[k];
                      var target_model = slot_info[0];
-                     var method_name = slot_info[1];
-                     that.signals[name].connect(target_model.slots[method_name], target_model);
+                     var slot_name = slot_info[1];
+                     that.signals[name].connect(target_model.slots[slot_name], target_model);
                  }
             }); 
         },

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -283,7 +283,17 @@ define(["nbextensions/widgets/widgets/js/manager",
                         console.log(data);
                         return;
                     }
-                    this.slots[data.name].invoke(data.value);
+                    // Deserialize slot argument 
+                    var serializers = that.constructor.serializers;
+                    var deserial;
+                    if (serializers && serializers[data.name] && serializers[data.name].deserialize) {
+                        deserial = (serializers[k].deserialize)(data.value, that);
+                    } else {
+                        deserial = Promise.resolve(data.value);
+                    }
+                    deserial.then(function(deserialized) {
+                        that.slots[data.name].invoke(deserialized);
+                    });
                     break;
                 case 'emit':
                     if(!that.signals[data.name]) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -216,6 +216,22 @@ define(["nbextensions/widgets/widgets/js/manager",
                         that.widget_manager.display_view(msg, that);
                     }).catch(utils.reject('Could not process display view msg', true));
                     break;
+                case 'invoke':
+                    console.log('invoke');
+                    console.log(msg.content.data);
+                    break;
+                case 'emit':
+                    console.log('emit');
+                    console.log(msg.content.data);
+                    break;
+                case 'connect':
+                    console.log('connect');
+                    console.log(msg.content.data);
+                    break;
+                case 'disconnect':
+                    console.log('disconnect');
+                    console.log(msg.content.data);
+                    break;
             }
         },
 

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -126,7 +126,7 @@ define(["nbextensions/widgets/widgets/js/manager",
              * Emit a signal and propagate message to the backend.
              */
             this.signals[name].emit(value);
-            if (this.comm !== undefined) {
+            if (this.comm !== undefined && this.comm_live) {
                 var serializers = this.constructor.serializers;
                 var serial;
                 if (serializers && serializers[name] && serializers[name].serialize) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -6,7 +6,8 @@ define(["nbextensions/widgets/widgets/js/manager",
         "backbone",
         "base/js/utils",
         "base/js/namespace",
-], function(widgetmanager, _, Backbone, utils, IPython){
+        "./signaling",
+], function(widgetmanager, _, Backbone, utils, IPython, signaling) {
     "use strict";
 
     var unpack_models = function unpack_models(value, model) {
@@ -260,8 +261,19 @@ define(["nbextensions/widgets/widgets/js/manager",
                             console.log(data);
                             return;
                         }
-                        that.signals[data.name]
-                            .connect(target_model.slots[data.slot.name], target_model);
+                        var signal = that.signals[data.name];
+                        signal.connect(target_model.slots[data.slot.name], target_model);
+                        var slots = signal._m_slots;
+                        if (slots === null) {
+                            that.set(data.name, []);
+                        } else if (slots instanceof signaling.SlotWrapper) {
+                            that.set(data.name, [slots._m_thisArg, slots._m_slot.name]);
+                        } else {
+                            that.set(data.name, slots.map(function(d) {
+                                return [d._m_thisArg, slots._m_slot.name]
+                            }));
+                        }
+                        that.save_changes();
                     });
                     break;
                 case 'disconnect':
@@ -276,8 +288,19 @@ define(["nbextensions/widgets/widgets/js/manager",
                             console.log(data);
                             return;
                         }
-                        that.signals[data.name]
-                            .disconnect(target_model.slots[data.slot.name], target_model);
+                        var signal = that.signals[data.name];
+                        signal.disconnect(target_model.slots[data.slot.name], target_model);
+                        var slots = signal._m_slots;
+                        if (slots === null) {
+                            that.set(data.name, []);
+                        } else if (slots instanceof SlotWrapper) {
+                            that.set(data.name, [slots._m_thisArg]);
+                        } else {
+                            that.set(data.name, slots.map(function(d) {
+                                return [d._m_thisArg]
+                            }));
+                        }
+                        that.save_changes();
                     });
                     break;
             }

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -91,6 +91,18 @@ define(["nbextensions/widgets/widgets/js/manager",
             widget_manager.notebook.events.on('kernel_dead.Kernel', died);
         },
 
+        emit: function(signal_name, value) {
+            /**
+             * Emit a signal and propagate message to the backend.
+             */
+            this.signals[signal_name].emit(value);
+            if (this.comm !== undefined) {
+                var data = {method: 'emit', name: signal_name, value: value};
+                this.comm.send(data);
+                this.pending_msgs++;
+            }
+        },
+
         send: function (content, callbacks, buffers) {
             /**
              * Send a custom msg over the comm.
@@ -101,6 +113,9 @@ define(["nbextensions/widgets/widgets/js/manager",
                 this.pending_msgs++;
             }
         },
+
+        signals: {},
+        slots: {},
 
         request_state: function(callbacks) {
             /** 
@@ -183,15 +198,16 @@ define(["nbextensions/widgets/widgets/js/manager",
             /**
              * Handle incoming comm msg.
              */
-            var method = msg.content.data.method;
-            
+            var target_model = null;
+            var data = msg.content.data;
+            var method = data.method;
             var that = this;
             switch (method) {
                 case 'update':
                     this.state_change = this.state_change
                         .then(function() {
-                            var state = msg.content.data.state || {};
-                            var buffer_keys = msg.content.data.buffers || [];
+                            var state = data.state || {};
+                            var buffer_keys = data.buffers || [];
                             var buffers = msg.buffers || [];
                             for (var i=0; i<buffer_keys.length; i++) {
                                 state[buffer_keys[i]] = buffers[i];
@@ -209,7 +225,7 @@ define(["nbextensions/widgets/widgets/js/manager",
                         }).catch(utils.reject("Couldn't resolve state request promise", true));
                     break;
                 case 'custom':
-                    this.trigger('msg:custom', msg.content.data.content, msg.buffers);
+                    this.trigger('msg:custom', data.content, msg.buffers);
                     break;
                 case 'display':
                     this.state_change = this.state_change.then(function() {
@@ -217,20 +233,52 @@ define(["nbextensions/widgets/widgets/js/manager",
                     }).catch(utils.reject('Could not process display view msg', true));
                     break;
                 case 'invoke':
-                    console.log('invoke');
-                    console.log(msg.content.data);
+                    if(!target_model.slots[data.slot.name]) {
+                        console.error('No such slot:');
+                        console.log(data);
+                        return;
+                    }
+                    this.slots[data.name].invoke(data.value);
                     break;
                 case 'emit':
-                    console.log('emit');
-                    console.log(msg.content.data);
+                    if(!that.signals[data.name]) {
+                        console.error('No such signal:');
+                        console.log(data);
+                        return;
+                    }
+                    this.emit(data.name, data.value);
                     break;
                 case 'connect':
-                    console.log('connect');
-                    console.log(msg.content.data);
+                    unpack_models(data.slot.model, this).then(function(target_model) {
+                        if(!that.signals[data.name]) {
+                            console.error('No such signal:');
+                            console.log(data);
+                            return;
+                        }
+                        if(!target_model.slots[data.slot.name]) {
+                            console.error('No such slot:');
+                            console.log(data);
+                            return;
+                        }
+                        that.signals[data.name]
+                            .connect(target_model.slots[data.slot.name], target_model);
+                    });
                     break;
                 case 'disconnect':
-                    console.log('disconnect');
-                    console.log(msg.content.data);
+                    unpack_models(data.slot.model, this).then(function(target_model) {
+                        if(!that.signals[data.name]) {
+                            console.error('No such signal:');
+                            console.log(data);
+                            return;
+                        }
+                        if(!target_model.slots[data.slot.name]) {
+                            console.error('No such slot:');
+                            console.log(data);
+                            return;
+                        }
+                        that.signals[data.name]
+                            .disconnect(target_model.slots[data.slot.name], target_model);
+                    });
                     break;
             }
         },

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -357,7 +357,7 @@ define(["nbextensions/widgets/widgets/js/manager",
                         var slots = signal._m_slots;
                         if (slots === null) {
                             that.set(data.name, []);
-                        } else if (slots instanceof SlotWrapper) {
+                        } else if (slots instanceof signaling.SlotWrapper) {
                             that.set(data.name, [[slots._m_thisArg, slots._m_slot.slot_name]]);
                         } else {
                             that.set(data.name, slots.map(function(d) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -95,6 +95,8 @@ define(["nbextensions/widgets/widgets/js/manager",
         initialize: function() {
             var that = this;
             var keys = this.get('keys');
+
+            // Create a slot for each key.
             _.each(keys, function(key) {
                 that.slots[key] = function(value) {
                     that.set(key, value);
@@ -103,6 +105,20 @@ define(["nbextensions/widgets/widgets/js/manager",
                 };
                 that.slots[key].slot_name = key;
 	        });
+
+            // state_changed signal
+            that.signals['state_changed'] = new signaling.Signal();
+            this.on('change', function() {
+                var changed = this.changedAttributes();
+                _.each(changed, function(v, k) {
+                    // TODO: use this.emit to propagate to the back-end
+                    this.signals['state_changed'].emit({
+                        'name': k,
+                        'old': this.previous(k),
+                        'new': v,
+                    });
+                }, this);
+            }, this);
         },
 
         emit: function(signal_name, value) {

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -4,8 +4,23 @@
 define([
     "nbextensions/widgets/widgets/js/widget",
     "jquery",
+    "./signaling",
     "bootstrap",
-], function(widget, $){
+], function(widget, $, signaling){
+
+    var ButtonModel = widget.WidgetModel.extend({
+        slots: {
+            test_slot: function(index) {
+                this.set("button_style", 
+                         ['primary', 'success', 'info',
+                          'warning', 'danger'][Math.floor(Math.random() * 5)]);
+                this.save_changes();
+            },
+        },
+        signals: {
+            clicked: new signaling.Signal(),
+        },
+    });
 
     var ButtonView = widget.DOMWidgetView.extend({
         render : function(){
@@ -65,11 +80,13 @@ define([
             /**
              * Handles when the button is clicked.
              */
+            this.model.emit('clicked');
             this.send({event: 'click'});
         },
     });
 
     return {
-        'ButtonView': ButtonView,
+        ButtonView: ButtonView,
+        ButtonModel: ButtonModel,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -10,7 +10,7 @@ define([
 
     var ButtonModel = widget.WidgetModel.extend({
         slots: {
-            test_slot: function(index) {
+            test_slot: function test_slot(index) {
                 this.set("button_style", 
                          ['primary', 'success', 'info',
                           'warning', 'danger'][Math.floor(Math.random() * 5)]);

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -9,8 +9,10 @@ define([
 ], function(widget, $, signaling){
 
     var ButtonModel = widget.WidgetModel.extend({
-        signals: {
-            clicked: new signaling.Signal(),
+        initialize: function() {
+            this.signals = {
+                clicked: new signaling.Signal(),
+            };
         },
     });
 

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -80,7 +80,7 @@ define([
             /**
              * Handles when the button is clicked.
              */
-            this.model.emit('clicked');
+            this.model.emit('clicked');  // this.model.signals['clicked'].emit();
             this.send({event: 'click'});
         },
     });

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -9,18 +9,6 @@ define([
 ], function(widget, $, signaling){
 
     var ButtonModel = widget.WidgetModel.extend({
-        slots: {
-            test_slot: (function() {
-                func = function () {
-		            this.set("button_style",
-		                     ['primary', 'success', 'info',
-		                      'warning', 'danger'][Math.floor(Math.random() * 5)]);
-		            this.save_changes();
-                };
-                func.slot_name = 'test_slot';
-                return func;
-            })(),
-        },
         signals: {
             clicked: new signaling.Signal(),
         },
@@ -84,8 +72,8 @@ define([
             /**
              * Handles when the button is clicked.
              */
-            this.model.emit('clicked');  // this.model.signals['clicked'].emit();
-            this.send({event: 'click'});
+            this.model.emit('clicked');
+            this.send({event: 'click'});  // This is deprecated
         },
     });
 

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -10,12 +10,16 @@ define([
 
     var ButtonModel = widget.WidgetModel.extend({
         slots: {
-            test_slot: function test_slot(index) {
-                this.set("button_style", 
-                         ['primary', 'success', 'info',
-                          'warning', 'danger'][Math.floor(Math.random() * 5)]);
-                this.save_changes();
-            },
+            test_slot: (function() {
+                func = function () {
+		            this.set("button_style",
+		                     ['primary', 'success', 'info',
+		                      'warning', 'danger'][Math.floor(Math.random() * 5)]);
+		            this.save_changes();
+                };
+                func.slot_name = 'test_slot';
+                return func;
+            })(),
         },
         signals: {
             clicked: new signaling.Signal(),

--- a/ipywidgets/static/widgets/js/widget_string.js
+++ b/ipywidgets/static/widgets/js/widget_string.js
@@ -160,10 +160,10 @@ define([
         },
     });
 
-    var TextModel = widget.WidgetModel.extend({  
-        signals: {
-            submit: new signaling.Signal(),
-        },
+    var TextModel = widget.WidgetModel.extend({
+        initialize: function() {
+            this.signals = { submit: new signaling.Signal(), };
+        }, 
     });
 
     var TextView = widget.DOMWidgetView.extend({  

--- a/ipywidgets/static/widgets/js/widget_string.js
+++ b/ipywidgets/static/widgets/js/widget_string.js
@@ -4,8 +4,9 @@
 define([
     "nbextensions/widgets/widgets/js/widget",
     "jquery",
+    "./signaling",
     "bootstrap",
-], function(widget, $){
+], function(widget, $, signaling) {
 
     var HTMLView = widget.DOMWidgetView.extend({  
         render : function(){
@@ -48,6 +49,13 @@ define([
         }, 
     });
 
+    var TextareaModel = widget.WidgetModel.extend({
+        slots: {
+            scroll_to_bottom: function() {
+                this.trigger('scroll_to_bottom');
+            },
+        },
+    });
 
     var TextareaView = widget.DOMWidgetView.extend({  
         render: function(){
@@ -67,6 +75,7 @@ define([
             this.update(); // Set defaults.
 
             this.listenTo(this.model, 'msg:custom', $.proxy(this._handle_textarea_msg, this));
+            this.listenTo(this.model, 'scroll_to_bottom', $.proxy(this.scroll_to_bottom, this));
             this.listenTo(this.model, 'change:placeholder', function(model, value, options) {
                 this.update_placeholder(value);
             }, this);
@@ -151,6 +160,11 @@ define([
         },
     });
 
+    var TextModel = widget.WidgetModel.extend({  
+        signals: {
+            submit: new signaling.Signal(),
+        },
+    });
 
     var TextView = widget.DOMWidgetView.extend({  
         render: function(){
@@ -245,7 +259,8 @@ define([
              * Handles text submition
              */
             if (e.keyCode == 13) { // Return key
-                this.send({event: 'submit'});
+                this.model.emit('submit');
+                this.send({event: 'submit'});  // this is deprecated
                 e.stopPropagation();
                 e.preventDefault();
                 return false;
@@ -282,7 +297,9 @@ define([
     return {
         'HTMLView': HTMLView,
         'LatexView': LatexView,
+        'TextareaModel': TextareaModel,
         'TextareaView': TextareaView,
+        'TextModel': TextModel,
         'TextView': TextView,
     };
 });

--- a/ipywidgets/tests/tests/widget_button.ts
+++ b/ipywidgets/tests/tests/widget_button.ts
@@ -46,7 +46,7 @@ base.tester
         .wait_for_output(button_index, 1)
 
         .then(function () {
-            this.test.assertEquals(this.notebook.get_output(button_index, 1).data['text/plain'], "'Clicked'",
+            this.test.assertEquals(this.notebook.get_output(button_index, 2).data['text/plain'], "'Clicked'",
                 'Button click event fires.');
         });
     }

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -10,16 +10,7 @@ import re
 import traitlets
 
 from . import eventful
-
-def _widget_to_json(x):
-    if isinstance(x, dict):
-        return {k: _widget_to_json(v) for k, v in x.items()}
-    elif isinstance(x, (list, tuple)):
-        return [_widget_to_json(v) for v in x]
-    elif isinstance(x, traitlets.HasTraits):
-        return "IPY_MODEL_" + x.model_id
-    else:
-        return x
+from .widget import serialize_widget_attribute
 
 
 class BaseSignaling(traitlets.BaseTraitType):
@@ -87,6 +78,7 @@ class _Signal(object):
     def __init__(self, model, signal):
         self.model = model
         self.signal = signal
+        self.connected_slots = []
 
     def connect(self, slot):
         """Sends a `connect` signal to the front-end. This causes the
@@ -99,7 +91,7 @@ class _Signal(object):
         self.model._send({
             'method': 'connect',
             'name': self.signal.name,
-            'slot': _widget_to_json({
+            'slot': serialize_widget_attribute({
                 'model': slot.model,
                 'name': slot.name,
             }),
@@ -114,7 +106,7 @@ class _Signal(object):
         self.model._send({
             'method': 'disconnect',
             'name': self.signal.name,
-            'slot': _widget_to_json({
+            'slot': serialize_widget_attribute({
                 'model': slot.model,
                 'name': slot.name, 
             }),

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -99,7 +99,10 @@ class _Signal(object):
         self.model._send({
             'method': 'connect',
             'name': self.signal.name,
-            'slot': _widget_to_json([slot.model, slot.name]),
+            'slot': _widget_to_json({
+                'model': slot.model,
+                'name': slot.name,
+            }),
         })
 
     def disconnect(self, slot):
@@ -111,7 +114,10 @@ class _Signal(object):
         self.model._send({
             'method': 'disconnect',
             'name': self.signal.name,
-            'slot': _widget_to_json([slot.model, slot.name]),
+            'slot': _widget_to_json({
+                'model': slot.model,
+                'name': slot.name, 
+            }),
         })
 
     def emit(self, value=None):

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -11,6 +11,153 @@ import traitlets
 
 from . import eventful
 
+def _widget_to_json(x):
+    if isinstance(x, dict):
+        return {k: _widget_to_json(v) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [_widget_to_json(v) for v in x]
+    elif isinstance(x, traitlets.HasTraits):
+        return "IPY_MODEL_" + x.model_id
+    else:
+        return x
+
+
+class BaseSignaling(traitlets.BaseTraitType):
+    """This is used as a base class for both Signals and Slots.
+    This is a hook into MetaHasTrait metaclass."""    
+ 
+    def __init__(self, trait_type=None):
+        """The constructor takes a trait type specifying
+        the signature of the signal."""
+        if trait_type is None:
+            trait_type = traitlets.Any()
+        self.trait_type = trait_type
+
+    @property
+    def this_class(self):
+        """The `this_class` property rebings to the `this_class` attribute
+        of the underlying trait type"""
+        return self.trait_type.this_class
+
+    @this_class.setter
+    def this_class(self, this_class):
+        """The setter for the `this_class` property is called in the
+        __init__ method of the MetaHasTraits class."""
+        self.trait_type.this_class = this_class
+
+    @property
+    def name(self):
+        """The `name` property rebings to the `name` attribute
+        of the underlying trait type"""
+        return self.trait_type.name
+
+    @name.setter
+    def name(self, name):
+        """The setter for the `name` property is called in the
+        __new__ method of the MetaHasTraits class."""
+        self.trait_type.name = name
+
+    def instance_init(self, obj):
+        """Part of the initialization that depend on the underlying
+        HasTrait instance
+            - calls instance_init on the underlying trait type
+        """
+        self.trait_type.instance_init(obj)
+
+    def validate(self, obj, value):
+        """Rebinds to the underlying trait type validation"""
+        return self.trait_type._validate(obj, value)
+
+    def get_metadata(self, key, default=None):
+        """Rebinds to the underlying trait type get_metadata"""
+        return self.trait_type.get_metadata(key, default)
+
+class Signal(BaseSignaling):
+
+     def instance_init(self, obj):
+         """Constructs the instance-level signal"""
+         super(Signal, self).instance_init(obj)
+         setattr(obj, self.name, _Signal(obj, self))
+
+
+class _Signal(object):
+    """Main Signal object, mirroring front-end's Signal object, this object
+    is not meant to be directly instantiated by the user."""
+
+    def __init__(self, model, signal):
+        self.model = model
+        self.signal = signal
+
+    def connect(self, slot):
+        """Sends a `connect` signal to the front-end. This causes the
+        connection of a slot to the signal in the frontend.
+
+        Slot connections are not de-duplicated. If the slot is connected
+        multiple times, it will be invoked multiple times when the signal
+        is emitted.
+        """
+        self.model._send({
+            'method': 'connect',
+            'name': self.signal.name,
+            'slot': _widget_to_json([slot.model, slot.name]),
+        })
+
+    def disconnect(self, slot):
+        """Sends a `disconnect` signal to the front-end.
+
+        This will remove all connections to the slot, even if the slot was
+        connected multple times. If no slot is provided, all slots will be
+        disconnected."""
+        self.model._send({
+            'method': 'disconnect',
+            'name': self.signal.name,
+            'slot': _widget_to_json([slot.model, slot.name]),
+        })
+
+    def emit(self, value=None):
+        """Emits a signal with the provided value. The value is validated of
+        the argument is validated.
+
+        Slots are invoked in the order in which they were connected."""
+        to_json = self.signal.trait_type.get_metadata('to_json',
+                                                      self.model._trait_to_json)
+        self.model._send({
+            'method': 'emit',
+            'name': self.signal.name,
+            'value': to_json(self.signal.validate(self.model, value)),
+        })
+
+
+class Slot(BaseSignaling):
+
+     def instance_init(self, obj):
+         """Constructs the instance-level signal"""
+         super(Slot, self).instance_init(obj)
+         setattr(obj, self.name, _Slot(obj, self))
+
+
+class _Slot(object):
+    """Main Slot object, mirroring front-end's Slot object, this object
+    is not meant to be directly instantiated by the user."""
+
+    def __init__(self, model, slot):
+        self.model = model
+        self.slot = slot
+
+    def invoke(self, value=None):
+        to_json = self.slot.trait_type.get_metadata('to_json',
+                                                    self.model._trait_to_json)
+        self.model._send({
+            'method': 'invoke',
+            'name': self.slot.name,
+            'value': to_json(self.slot.validate(self.model, value)),
+        })
+
+    @property
+    def name(self):
+        return self.slot.name
+
+
 _color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen'] 
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -90,10 +90,10 @@ class _Signal(object):
         self.model._send({
             'method': 'connect',
             'name': self.signal.name,
-            'slot': serialize_widget_attribute(self.model, {
+            'slot': serialize_widget_attribute({
                 'model': slot.model,
                 'name': slot.name,
-            }),
+            }, self.model),
         })
 
     def disconnect(self, slot):
@@ -105,10 +105,10 @@ class _Signal(object):
         self.model._send({
             'method': 'disconnect',
             'name': self.signal.name,
-            'slot': serialize_widget_attribute(self.model, {
+            'slot': serialize_widget_attribute({
                 'model': slot.model,
                 'name': slot.name, 
-            }),
+            }, self.model),
         })
 
     def emit(self, value=None):
@@ -121,8 +121,8 @@ class _Signal(object):
         self.model._send({
             'method': 'emit',
             'name': self.signal.name,
-            'value': to_json(self.model, 
-                             self.signal.validate(self.model, value)),
+            'value': to_json(self.signal.validate(self.model, value),
+                             self.model),
         })
 
 
@@ -148,8 +148,8 @@ class _Slot(object):
         self.model._send({
             'method': 'invoke',
             'name': self.slot.name,
-            'value': to_json(self.model,
-                             self.slot.validate(self.model, value)),
+            'value': to_json(self.slot.validate(self.model, value),
+                             self.model),
         })
 
     @property

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -13,55 +13,54 @@ from . import eventful
 from .widget import serialize_widget_attribute
 
 
-class BaseSignaling(traitlets.BaseTraitType):
-    """This is used as a base class for both Signals and Slots.
-    This is a hook into MetaHasTrait metaclass."""    
+class BaseSignaling(traitlets.BaseDescriptor):
+    """Base class for both Signals and Slots."""    
  
-    def __init__(self, trait_type=None):
+    def __init__(self, trait=None):
         """The constructor takes a trait type specifying
         the signature of the signal."""
-        if trait_type is None:
-            trait_type = traitlets.Any()
-        self.trait_type = trait_type
+        if trait is None:
+            trait = traitlets.Any()
+        self.trait = trait
 
     @property
     def this_class(self):
         """The `this_class` property rebings to the `this_class` attribute
         of the underlying trait type"""
-        return self.trait_type.this_class
+        return self.trait.this_class
 
     @this_class.setter
     def this_class(self, this_class):
         """The setter for the `this_class` property is called in the
         __init__ method of the MetaHasTraits class."""
-        self.trait_type.this_class = this_class
+        self.trait.this_class = this_class
 
     @property
     def name(self):
         """The `name` property rebings to the `name` attribute
         of the underlying trait type"""
-        return self.trait_type.name
+        return self.trait.name
 
     @name.setter
     def name(self, name):
         """The setter for the `name` property is called in the
         __new__ method of the MetaHasTraits class."""
-        self.trait_type.name = name
+        self.trait.name = name
 
     def instance_init(self, obj):
         """Part of the initialization that depend on the underlying
         HasTrait instance
             - calls instance_init on the underlying trait type
         """
-        self.trait_type.instance_init(obj)
+        self.trait.instance_init(obj)
 
     def validate(self, obj, value):
         """Rebinds to the underlying trait type validation"""
-        return self.trait_type._validate(obj, value)
+        return self.trait._validate(obj, value)
 
     def get_metadata(self, key, default=None):
         """Rebinds to the underlying trait type get_metadata"""
-        return self.trait_type.get_metadata(key, default)
+        return self.trait.get_metadata(key, default)
 
 class Signal(BaseSignaling):
 
@@ -117,8 +116,8 @@ class _Signal(object):
         the argument is validated.
 
         Slots are invoked in the order in which they were connected."""
-        to_json = self.signal.trait_type.get_metadata('to_json',
-                                                      self.model._trait_to_json)
+        to_json = self.signal.trait.get_metadata('to_json',
+                                                 self.model._trait_to_json)
         self.model._send({
             'method': 'emit',
             'name': self.signal.name,
@@ -143,8 +142,8 @@ class _Slot(object):
         self.slot = slot
 
     def invoke(self, value=None):
-        to_json = self.slot.trait_type.get_metadata('to_json',
-                                                    self.model._trait_to_json)
+        to_json = self.slot.trait.get_metadata('to_json',
+                                               self.model._trait_to_json)
         self.model._send({
             'method': 'invoke',
             'name': self.slot.name,

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -90,7 +90,7 @@ class _Signal(object):
         self.model._send({
             'method': 'connect',
             'name': self.signal.name,
-            'slot': serialize_widget_attribute({
+            'slot': serialize_widget_attribute(self.model, {
                 'model': slot.model,
                 'name': slot.name,
             }),
@@ -105,7 +105,7 @@ class _Signal(object):
         self.model._send({
             'method': 'disconnect',
             'name': self.signal.name,
-            'slot': serialize_widget_attribute({
+            'slot': serialize_widget_attribute(self.model, {
                 'model': slot.model,
                 'name': slot.name, 
             }),
@@ -121,7 +121,8 @@ class _Signal(object):
         self.model._send({
             'method': 'emit',
             'name': self.signal.name,
-            'value': to_json(self.signal.validate(self.model, value)),
+            'value': to_json(self.model, 
+                             self.signal.validate(self.model, value)),
         })
 
 
@@ -147,7 +148,8 @@ class _Slot(object):
         self.model._send({
             'method': 'invoke',
             'name': self.slot.name,
-            'value': to_json(self.slot.validate(self.model, value)),
+            'value': to_json(self.model,
+                             self.slot.validate(self.model, value)),
         })
 
     @property

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -474,6 +474,11 @@ class Widget(LoggingConfigurable):
         elif method == 'request_state':
             self.send_state()
 
+        # Handle signals.
+        elif method == 'emit':
+            # TODO: handle binary buffers like in the case of backbone messages
+            self._handle_signal(data['name'], data['value'])
+
         # Handle a custom msg from the front-end.
         elif method == 'custom':
             if 'content' in data:
@@ -486,6 +491,10 @@ class Widget(LoggingConfigurable):
     def _handle_custom_msg(self, content, buffers):
         """Called when a custom msg is received."""
         self._msg_callbacks(self, content, buffers)
+
+    def _handle_signal(self, name, value):
+        """"""
+        pass
 
     def _notify_trait(self, name, old_value, new_value):
         """Called when a property has been changed."""

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -13,7 +13,7 @@ from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from ipython_genutils.importstring import import_item
-from traitlets import Unicode, Dict, Instance, Bool, List, Any, \
+from traitlets import Unicode, Dict, Instance, Bool, List, \
     CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
 from ipython_genutils.py3compat import string_types
 
@@ -124,24 +124,24 @@ def register(key=None):
     return wrap
 
 
-def _state_change_to_json(self, value):
+def _state_change_to_json(value, self):
     """Convert a state change signal signature json."""
     name, old, new = value['name'], value['old'], value['new']
     to_json = self.trait_metadata(name, 'to_json', self._trait_to_json)
     return {
         'name': name,
-        'old': to_json(old),
-        'new': to_json(new),
+        'old': to_json(old, self),
+        'new': to_json(new, self),
     }
 
-def _state_change_from_json(self, x):
+def _state_change_from_json(value, self):
     """Convert json to a state change signal signature."""
     name, old, new = value['name'], value['old'], value['new']
     from_json = self.trait_metadata(name, 'from_json', self._trait_from_json)
     return {
         'name': name,
-        'old': from_json(old),
-        'new': from_json(new),
+        'old': from_json(old, self),
+        'new': from_json(new, self),
     }
 
 
@@ -310,7 +310,7 @@ class Widget(LoggingConfigurable):
             else:
                 raise ValueError("key must be a string, an iterable of keys, or None")
         connections = {
-            k: serialize_widget_attribute(self, getattr(self, k).connected_slots) for k in keys
+            k: serialize_widget_attribute(getattr(self, k).connected_slots, self) for k in keys
         }
         return connections 
 

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -170,7 +170,7 @@ class Widget(LoggingConfigurable):
         front-end can send before receiving an idle msg from the back-end.""")
 
     version = Int(0, sync=True, help="""Widget's version""")
-    keys = List()
+    keys = List(sync=True)
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]
 

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -289,7 +289,7 @@ class Widget(LoggingConfigurable):
             else:
                 raise ValueError("key must be a string, an iterable of keys, or None")
         connections = {
-            k: serialize_widget_attribute(getattr(self, k).connected_slots) for k in keys
+            k: serialize_widget_attribute(self, getattr(self, k).connected_slots) for k in keys
         }
         return connections 
 

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -13,7 +13,7 @@ from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from ipython_genutils.importstring import import_item
-from traitlets import Unicode, Dict, Instance, Bool, List, \
+from traitlets import Unicode, Dict, Instance, Bool, List, Any, \
     CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
 from ipython_genutils.py3compat import string_types
 
@@ -173,6 +173,9 @@ class Widget(LoggingConfigurable):
     keys = List(sync=True)
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]
+
+    # TODO: Replace with Signal(TypeMap(**synced_traits))
+    state_changed = Signal(Any())
 
     _property_lock = Dict()
     _holding_sync = False

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -275,14 +275,16 @@ class Widget(LoggingConfigurable):
         -------
         connections: dict of connections
         """
+        signals = self.signals()
         if key is None:
-            keys = self.signals()
-        elif isinstance(key, string_types):
-            keys = [key]
-        elif isinstance(key, collections.Iterable):
-            keys = key
+            keys = signals
         else:
-            raise ValueError("key must be a string, an iterable of keys, or None")
+            if isinstance(key, string_types):
+                keys = [key] if key in signals else []
+            elif isinstance(key, collections.Iterable):
+                keys = [k for k in key if k in signals]
+            else:
+                raise ValueError("key must be a string, an iterable of keys, or None")
         connections = {
             k: serialize_widget_attribute(getattr(self, k).connected_slots) for k in keys
         }
@@ -306,9 +308,9 @@ class Widget(LoggingConfigurable):
         if key is None:
             keys = self.keys
         elif isinstance(key, string_types):
-            keys = [key]
+            keys = [key] if key in self.keys else []
         elif isinstance(key, collections.Iterable):
-            keys = key
+            keys = [k for k in key if k in self.keys]
         else:
             raise ValueError("key must be a string, an iterable of keys, or None")
         state = {}

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -124,6 +124,27 @@ def register(key=None):
     return wrap
 
 
+def _state_change_to_json(self, value):
+    """Convert a state change signal signature json."""
+    name, old, new = value['name'], value['old'], value['new']
+    to_json = self.trait_metadata(name, 'to_json', self._trait_to_json)
+    return {
+        'name': name,
+        'old': to_json(old),
+        'new': to_json(new),
+    }
+
+def _state_change_from_json(self, x):
+    """Convert json to a state change signal signature."""
+    name, old, new = value['name'], value['old'], value['new']
+    from_json = self.trait_metadata(name, 'from_json', self._trait_from_json)
+    return {
+        'name': name,
+        'old': from_json(old),
+        'new': from_json(new),
+    }
+
+
 class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     # Class attributes
@@ -174,8 +195,8 @@ class Widget(LoggingConfigurable):
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]
 
-    # TODO: Replace with Signal(TypeMap(**synced_traits))
-    state_changed = Signal(Any())
+    state_changed = Signal(Dict(to_json=_state_change_to_json,
+                                from_json=_state_change_from_json))
 
     _property_lock = Dict()
     _holding_sync = False

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -14,9 +14,9 @@ from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from traitlets import Unicode, Dict, Instance, Bool, List, \
-    CaselessStrEnum, Tuple, CUnicode, Int, Set
+    CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
 from ipython_genutils.py3compat import string_types
-from .trait_types import Color
+from .trait_types import Color, Signal, Slot
 
 
 def _widget_to_json(x, obj):
@@ -449,6 +449,18 @@ class Widget(LoggingConfigurable):
     def _send(self, msg, buffers=None):
         """Sends a message to the model in the front-end."""
         self.comm.send(data=msg, buffers=buffers)
+
+    def signals(self):
+        """Returns a `dict` of all the signals of this widget. The dictionary
+        is keyed on the name and the values are the Signal objects."""
+        return dict([memb for memb in getmembers(self.__class__) if 
+                    isinstance(memb[1], Signal)]) 
+        
+    def slots(self):
+        """Returns a `dict` of all the slots of this widget. The dictionary
+        is keyed on the name and the values are the Slot objects."""
+        return dict([memb for memb in getmembers(self.__class__) if 
+                    isinstance(memb[1], Slot)]) 
 
 
 class DOMWidget(Widget):

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -9,7 +9,7 @@ click events on the button and trigger backend code when the clicks are fired.
 
 from .widget import DOMWidget, CallbackDispatcher, register
 from traitlets import Unicode, Bool, CaselessStrEnum
-
+from .trait_types import Signal
 
 @register('IPython.Button')
 class Button(DOMWidget):
@@ -33,6 +33,7 @@ class Button(DOMWidget):
     tooltip = Unicode(help="Tooltip caption of the button.", sync=True)
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
+    clicked = Signal(Bool())
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], 

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -9,6 +9,7 @@ click events on the button and trigger backend code when the clicks are fired.
 
 from .widget import DOMWidget, CallbackDispatcher, register
 from traitlets import Unicode, Bool, CaselessStrEnum
+from warnings import warn
 from .trait_types import Signal, Slot
 
 @register('IPython.Button')
@@ -35,7 +36,6 @@ class Button(DOMWidget):
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
     clicked = Signal()
-    test_slot = Slot()
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], 
@@ -58,6 +58,7 @@ class Button(DOMWidget):
         ----------
         remove : bool (optional)
             Set to true to remove the callback from the list of callbacks."""
+        warn('`on_click` is deprecated, use the `clicked` signal instead')
         self._click_handlers.register_callback(callback, remove=remove)
 
     def _handle_button_msg(self, _, content, buffers):

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -9,7 +9,7 @@ click events on the button and trigger backend code when the clicks are fired.
 
 from .widget import DOMWidget, CallbackDispatcher, register
 from traitlets import Unicode, Bool, CaselessStrEnum
-from .trait_types import Signal
+from .trait_types import Signal, Slot
 
 @register('IPython.Button')
 class Button(DOMWidget):
@@ -27,13 +27,15 @@ class Button(DOMWidget):
            font-awesome icon name
     """
     _view_name = Unicode('ButtonView', sync=True)
+    _model_name = Unicode('ButtonModel', sync=True)
 
     # Keys
     description = Unicode('', help="Button label.", sync=True)
     tooltip = Unicode(help="Tooltip caption of the button.", sync=True)
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
-    clicked = Signal(Bool())
+    clicked = Signal()
+    test_slot = Slot()
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], 

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -8,6 +8,8 @@ Represents a unicode string using a widget.
 
 from .widget import DOMWidget, CallbackDispatcher, register
 from traitlets import Unicode, Bool
+from warnings import warn
+from .trait_types import Signal, Slot
 
 
 class _String(DOMWidget):
@@ -39,8 +41,11 @@ class Latex(_String):
 class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView', sync=True)
+    _model_name = Unicode('TextareaModel', sync=True)
 
-    def scroll_to_bottom(self):
+    scroll_to_bottom = Slot()
+
+    def scroll_to_bottom_legacy(self):
         self.send({"method": "scroll_to_bottom"})
 
 
@@ -48,6 +53,9 @@ class Textarea(_String):
 class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)
+    _model_name = Unicode('TextModel', sync=True)
+
+    submitted = Signal()
 
     def __init__(self, *args, **kwargs):
         super(Text, self).__init__(*args, **kwargs)
@@ -75,4 +83,5 @@ class Text(_String):
             Will be called with exactly one argument: the Widget instance
         remove: bool (optional)
             Whether to unregister the callback"""
+        warn('`on_submit` is deprecated, use the `submitted` signal instead') 
         self._submission_callbacks.register_callback(callback, remove=remove)


### PR DESCRIPTION
Traitlets are a high-level API allowing the synchronization of state. The link and dlink functions allow for state synchronization between HasTraits' attributes with a very simple syntax.

There is not such high-level API for non-state related events, and we miss such an interface for building more complex GUIs.

This work is meant to allow simple Python Qt-style syntax for JavaScript-side signal and slot connections, which use the Phosphorjs' implementation of JavaScript signals and Slots.

The Python side API carries some static typing of the signature of signals and slots which are matched on connection, and validated using the traitlets mechanics.

- Signals and slots. are declared as class-level attributes, and inherit from the same `BaseDescriptor` as `TraitType`, and therefore benefit from the meta-class magics setting the value of `this_class` and `name`. The `instance_init` triggers the creation of corresponding instance-level attributes (signals and slots).

- These attributes are essentially placeholders for their JavaScript  counterparts. For example, in the case of a Button widget having a `clicked` event, connecting it to the `toggle` slot of another widget `foo` would look like: `btn.clicked.connect(foo.toggle)`. This actually sends a `connect` message to the front-end triggering the connection of the JavaScript signal to the corresponding JavaScript slot.

- Besides the `connect` event, I also added the `disconnect` and `emit` messages for signals and the `invoke` message for slots. (These correspond o the method name, and come alongside the already existing `display`, `custom`, and backbone `update` messages. 

'connect' message
```js
{
    'method': 'connect',
    'name': self.signal.name,
    'slot': serialize_widget_attribute({
             'model': slot.model,
             'name': slot.name,
    }, self.model),
}
```

'disconnect' message
```js
{
    'method': 'diconnect',
    'name': self.signal.name,
    'slot': serialize_widget_attribute({
             'model': slot.model,
             'name': slot.name,
    }, self.model),
}
```

'invoke' message
```js
{
    'method': 'invoke',
    'name': self.slot.name,
    'value': to_json(self.slot.validate(self.model, value),  self.model),
}
```

'emit' message
```js
{
    'method': 'emit',
    'name': self.signal.name,
    'value': to_json(self.signal.validate(self.model, value), self.model),
}
```

- Signals and slots hold a trait type, which is the *signature* type of the signal. Passed arguments are validated and serialized with this trait types.

- This new signaling mechanism is not completely decoupled from the state-related widget attributes.
    - Every widget attribute can be used as a slot of the corresponding signature.
    - Every widget has a `state_changed` signal that fires on any state change and contains the name, of the updated attribute together with the old and the new value. The `state_changed` signal has a signature that corresponds to the `observe` callback handler signature, i.e. a dictionary with `owner` , `old`, `new` and `name` keys corresponding respectively to (the serialized values of)
 - the HasTraits instance
 - the old value
 - the new value
 - the name of the changing attribute

That is:
```js
name, old, new = value['name'], value['old'], value['new']
to_json = self.trait_metadata(name, 'to_json', self._trait_to_json)
return {
    'owner': self,
    'old': to_json(old, self),
    'new': to_json(new, self),
    'name': name,
}
```
the custom serializer for the changed attribute is used in the `state_changed` signal signature serialization as one would expect. This is similar to WPF's StateChanged.

- The connections are persistent to page reload, and the mechanism is the same as for regular widget state.

## Examples

- Connecting the `clicked` signal of a Button to a `scroll_to_bottom` slot of a Textarea:

```Python
from ipywidgets import *
from ipython.display import display
btn = Button()
area = Textarea(value='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum')
btn.clicked.connect(area.scroll_to_bottom)
display(HBox([btn, area]))
```

- Listing the signals of `Button`
```Python
btn.signals()
```
```
{'clicked': <ipywidgets.widgets.trait_types.Signal at 0x7fe0ac78a890>,
 'state_changed': <ipywidgets.widgets.trait_types.Signal at 0x7fe0ac781b10>}
```

- disconnecting 

```Python
btn.clicked.disconnect(area.scroll_to_bottom)
```

*This depends on the traitlets PRs https://github.com/ipython/traitlets/pull/22, https://github.com/ipython/traitlets/pull/26, https://github.com/ipython/traitlets/pull/27 - now all merged.*

- declaring signals and slots in a custom widget

```Python
class ToggleFoo(Widget):
    hovered = Signal()   # A signal can be declared aside of regular widget attributes,
    value = Bool(sync=True)
```

## TODOs

- [x] Make connections persistent to page reload (store them in the object model).
- [x] Allow using widget attributes as slots (to connect a non-state signal to an attribute).
- [x] Create a general `state_changed` signal
- [x] Infer the JavaScript serializers / deserializers of the `state_changed` signal from the widget attribute serializers / deserializers.
- [x] Only send messages to backend if the comm is live.
- [x] Create signals for `Button.click` *(done)*, `Text.submit` and `TextArea.scroll_to_bottom`
- [ ] Use the latest version of phosphor's slots and signals.
- [ ] Handle disconnections correctly on widget destruction to allow the garbage collector to do its job.
    This is related to the use of the latest version of phosphor slots and signals.
