### PR TITLE
Fix nested widgets persistence

### DIFF
--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -438,7 +438,10 @@ define([
 
                     model.set_comm_live(false);
                     var view_promise = Promise.resolve().then(function() {
-                        return model.set_state(state[model.id].state);
+                        var deserialized = model._deserialize_state(state[model.id].state);
+                        return utils.resolve_promises_dict(deserialized);
+                    }).then(function(deserialized) {
+                        model.set_state(deserialized);
                     }).then(function() {
                         model.request_state().then(function() {
                             model.set_comm_live(true);


### PR DESCRIPTION
@jdfreder  This fixes widget persistence for widgets using custom [de]serializers such as `Box` (which unpack models at deserialization). 

Without this PR, the following note would fail to persist the HBox on page reload.

```Python
from ipywidgets import *
HBox([IntSlider(), Button()])
```