### PR TITLE
Fix serialization of javascript link

### DIFF
--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -41,6 +41,10 @@ define([
                    }, this);
             this.updating = false;
         },
+    }, {
+        serializers: _.extend({
+            widgets: {deserialize: widget.unpack_models}
+        }, widget.WidgetModel.serializers)
     });
 
     var DirectionalLinkModel = widget.WidgetModel.extend({
@@ -77,6 +81,11 @@ define([
                    }, this);
             this.updating = false;
         },
+    }, { 
+        serializers: _.extend({
+            source: {deserialize: widget.unpack_models},
+            targets: {deserialize: widget.unpack_models},
+        }, widget.WidgetModel.serializers)
     });
 
     return {

--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -6,7 +6,7 @@ Propagate changes between widgets on the javascript side
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import Widget
+from .widget import Widget, widget_serialization
 from traitlets import Unicode, Tuple, List,Instance, TraitError
 
 class WidgetTraitTuple(Tuple):
@@ -37,7 +37,7 @@ class Link(Widget):
     widgets, a list of (widget, 'trait_name') tuples which should be linked in the frontend.
     """
     _model_name = Unicode('LinkModel', sync=True)
-    widgets = List(WidgetTraitTuple, sync=True)
+    widgets = List(WidgetTraitTuple, sync=True, **widget_serialization)
 
     def __init__(self, widgets, **kwargs):
         if len(widgets) < 2:
@@ -73,8 +73,8 @@ class DirectionalLink(Widget):
     when the source trait changes.
     """
     _model_name = Unicode('DirectionalLinkModel', sync=True)
-    targets = List(WidgetTraitTuple, sync=True)
-    source = WidgetTraitTuple(sync=True)
+    targets = List(WidgetTraitTuple, sync=True, **widget_serialization)
+    source = WidgetTraitTuple(sync=True, **widget_serialization)
 
     # Does not quite behave like other widgets but reproduces
     # the behavior of traitlets.directional_link


### PR DESCRIPTION
The attributes of the js link were not being serialized / deserialized correctly since the custom serialization PR.