### PR TITLE
Undefined default value for the color trait

### DIFF
--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -17,8 +17,9 @@ _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 
 class Color(traitlets.Unicode):
     """A string holding a valid HTML color such as 'blue', '#060482', '#A80'"""
- 
+
     info_text = 'a valid HTML color'
+    default_value = traitlets.Undefined
 
     def validate(self, obj, value):
         if value.lower() in _color_names or _color_re.match(value):


### PR DESCRIPTION
Since the latest improvement in traitlets default value validation by @takluyver , we need to set the default value of `Color` to `Undefined` for the following code to not raise a `TraitError`. 

Otherwise, the default value ` ''`  for the base Unicode trait type will be instantiated and validation will raise a trait error.

```Python
from ipywidgets import Widget, Color
from traitlets import List

class Foo(Widget):
    bar = List(trait=Color())

Foo()
```