### PR TITLE
Custom widget persistence

### DIFF
--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -447,22 +447,17 @@ define([
             // Display all the views
             return all_models.then(function(models) {
                 var all_views = [];
-                var model;
-                for (var i = 0; i < models.length; i++) {
-                    model = Promise.resolve(models[i]);
-                    var views = model.then(function(model) {
-                        // Display the views of the model.
-                        var views = [];
-                        var model_views = state[model.id].views;
-                        for (var j = 0; j < model_views.length; j++) {
-                            var cell_index = model_views[j];
-                            var cell = that.notebook.get_cell(cell_index);
-                            views.push(that.display_view_in_cell(cell, model));
-                        }
-                        return Promise.all(views);
-                    });
-                    all_views.push(views);
-                }
+                _.each(models, function(model) {
+                    // Display the views of the model.
+                    var views = [];
+                    var model_views = state[model.id].views;
+                    for (var j = 0; j < model_views.length; j++) {
+                        var cell_index = model_views[j];
+                        var cell = that.notebook.get_cell(cell_index);
+                        views.push(that.display_view_in_cell(cell, model));
+                    }
+                    all_views.push(Promise.all(views));
+                });
                 return Promise.all(all_views);
             });
         }).catch(utils.reject('Could not set widget manager state.', true));

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -448,21 +448,18 @@ define([
                 for (var i = 0; i < models.length; i++) {
                     model = Promise.resolve(models[i]);
                     var views = model.then(function(model) {
-                        var view_promise = Promise.resolve().then(function() {
-                            return model.request_state().then(function() {
-                                model.set_comm_live(true);
-                                // Display the views of the model.
-                                var views = [];
-                                var model_views = state[model.id].views;
-                                for (var j = 0; j < model_views.length; j++) {
-                                    var cell_index = model_views[j];
-                                    var cell = that.notebook.get_cell(cell_index);
-                                    views.push(that.display_view_in_cell(cell, model));
-                                }
-                                return Promise.all(views);
-                            });
+                        return model.request_state().then(function() {
+                            model.set_comm_live(true);
+                            // Display the views of the model.
+                            var views = [];
+                            var model_views = state[model.id].views;
+                            for (var j = 0; j < model_views.length; j++) {
+                                var cell_index = model_views[j];
+                                var cell = that.notebook.get_cell(cell_index);
+                                views.push(that.display_view_in_cell(cell, model));
+                            }
+                            return Promise.all(views);
                         });
-                        return view_promise;
                     });
                     that.all_views.push(views);
                 }

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -431,6 +431,13 @@ define([
                     comm: new_comm,
                     model_name: state[model_id].model_name,
                     model_module: state[model_id].model_module,
+                }).then(function(model) {
+                    model.set_comm_live(false);
+                    var deserialized = model._deserialize_state(state[model.id].state);
+                    return utils.resolve_promises_dict(deserialized).then(function(state) {
+                        model.set_state(state);
+                        return model;
+                    });
                 });
             }, this));
 
@@ -441,16 +448,9 @@ define([
                 for (var i = 0; i < models.length; i++) {
                     model = Promise.resolve(models[i]);
                     var views = model.then(function(model) {
-                        model.set_comm_live(false);
                         var view_promise = Promise.resolve().then(function() {
-                            var deserialized = model._deserialize_state(state[model.id].state);
-                            return utils.resolve_promises_dict(deserialized);
-                        }).then(function(deserialized) {
-                             model.set_state(deserialized);
-                        }).then(function() {
                             return model.request_state().then(function() {
                                 model.set_comm_live(true);
-
                                 // Display the views of the model.
                                 var views = [];
                                 var model_views = state[model.id].views;

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -281,9 +281,10 @@ define([
          * Handle when a comm is opened.
          */
         return this.create_model({
-            model_name: msg.content.data.model_name, 
-            model_module: msg.content.data.model_module, 
-            comm: comm}).catch(utils.reject("Couldn't create a model.", true));
+            model_name: msg.content.data.model_name,
+            model_module: msg.content.data.model_module,
+            comm: comm,
+        }).catch(utils.reject("Couldn't create a model.", true));
     };
 
     WidgetManager.prototype.create_model = function (options) {
@@ -298,9 +299,10 @@ define([
          * JS:
          * IPython.notebook.kernel.widget_manager.create_model({
          *      model_name: 'WidgetModel',
-         *      widget_class: 'ipywidgets.IntSlider'})
-         *      .then(function(model) { console.log('Create success!', model); },
-         *      _.bind(console.error, console));
+         *      widget_class: 'ipywidgets.IntSlider'
+         *  })
+         *  .then(function(model) { console.log('Create success!', model); },
+         *  _.bind(console.error, console));
          *
          * Parameters
          * ----------
@@ -402,7 +404,7 @@ define([
             return Promise.all(model_promises).then(function() { return state; });
         }).catch(utils.reject('Could not get state of widget manager', true));
     };
-    
+
     WidgetManager.prototype.set_state = function(state) {
         /**
          * Set the notebook's state.
@@ -410,18 +412,13 @@ define([
          * Reconstructs all of the widget models and attempts to redisplay the
          * widgets in the appropriate cells by cell index.
          */
-        
+
         // Get the kernel when it's available.
         var that = this;
         return this._get_connected_kernel().then(function(kernel) {
-            
-            // Recreate all the widget models for the given state and 
-            // display the views.
-            that.all_views = [];
-            var model_ids = Object.keys(state);
-            for (var i = 0; i < model_ids.length; i++) {
-                var model_id = model_ids[i];
-                
+
+            // Recreate all the widget models for the given notebook state.
+            var all_models = Promise.all(_.map(Object.keys(state), function (model_id) {
                 // Recreate a comm using the widget's model id (model_id == comm_id).
                 var new_comm = new comm.Comm(kernel.widget_manager.comm_target_name, model_id);
                 kernel.comm_manager.register_comm(new_comm);
@@ -430,39 +427,48 @@ define([
                 // created we don't know yet if the comm is valid so set_comm_live
                 // false.  Once we receive the first state push from the back-end
                 // we know the comm is alive.
-                var views = kernel.widget_manager.create_model({
-                    comm: new_comm, 
-                    model_name: state[model_id].model_name, 
-                    model_module: state[model_id].model_module})
-                .then(function(model) {
-
-                    model.set_comm_live(false);
-                    var view_promise = Promise.resolve().then(function() {
-                        var deserialized = model._deserialize_state(state[model.id].state);
-                        return utils.resolve_promises_dict(deserialized);
-                    }).then(function(deserialized) {
-                        model.set_state(deserialized);
-                    }).then(function() {
-                        model.request_state().then(function() {
-                            model.set_comm_live(true);
-                        });
-
-                        // Display the views of the model.
-                        var views = [];
-                        var model_views = state[model.id].views;
-                        for (var j=0; j<model_views.length; j++) {
-                            var cell_index = model_views[j];
-                            var cell = that.notebook.get_cell(cell_index);
-                            views.push(that.display_view_in_cell(cell, model));
-                        }
-                        return Promise.all(views);
-                    });
-                    return view_promise;
+                return kernel.widget_manager.create_model({
+                    comm: new_comm,
+                    model_name: state[model_id].model_name,
+                    model_module: state[model_id].model_module,
                 });
-                that.all_views.push(views);
-            }
-            return Promise.all(that.all_views);
-        }).catch(utils.reject('Could not set widget manager state.', true));  
+            }, this));
+
+            // Display all the views
+            return all_models.then(function(models) {
+                that.all_views = [];
+                var model;
+                for (var i = 0; i < models.length; i++) {
+                    model = Promise.resolve(models[i]);
+                    var views = model.then(function(model) {
+                        model.set_comm_live(false);
+                        var view_promise = Promise.resolve().then(function() {
+                            var deserialized = model._deserialize_state(state[model.id].state);
+                            return utils.resolve_promises_dict(deserialized);
+                        }).then(function(deserialized) {
+                             model.set_state(deserialized);
+                        }).then(function() {
+                            return model.request_state().then(function() {
+                                model.set_comm_live(true);
+
+                                // Display the views of the model.
+                                var views = [];
+                                var model_views = state[model.id].views;
+                                for (var j = 0; j < model_views.length; j++) {
+                                    var cell_index = model_views[j];
+                                    var cell = that.notebook.get_cell(cell_index);
+                                    views.push(that.display_view_in_cell(cell, model));
+                                }
+                                return Promise.all(views);
+                            });
+                        });
+                        return view_promise;
+                    });
+                    that.all_views.push(views);
+                }
+                return Promise.all(that.all_views);
+            });
+        }).catch(utils.reject('Could not set widget manager state.', true));
     };
 
     WidgetManager.prototype._get_connected_kernel = function() {
@@ -471,8 +477,8 @@ define([
          */
         var that = this;
         return new Promise(function(resolve, reject) {
-            if (that.comm_manager && 
-                that.comm_manager.kernel && 
+            if (that.comm_manager &&
+                that.comm_manager.kernel &&
                 that.comm_manager.kernel.is_connected()) {
 
                 resolve(that.comm_manager.kernel);
@@ -480,7 +486,7 @@ define([
                 that.notebook.events.on('kernel_connected.Kernel', function(event, data) {
                     resolve(data.kernel);
                 });
-            }    
+            }
         });
     };
 

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -446,16 +446,13 @@ define([
 
             // Display all the views
             return all_models.then(function(models) {
-                var all_views = [];
-                _.each(models, function(model) {
+                return Promise.all(_.map(models, function(model) {
                     // Display the views of the model.
-                    var views = Promise.all(_.map(state[model.id].views, function(cell_index) {
+                    return Promise.all(_.map(state[model.id].views, function(cell_index) {
                         var cell = that.notebook.get_cell(cell_index);
                         return that.display_view_in_cell(cell, model);
                     }));
-                    all_views.push(views);
-                });
-                return Promise.all(all_views);
+                }));
             });
         }).catch(utils.reject('Could not set widget manager state.', true));
     };

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -449,14 +449,11 @@ define([
                 var all_views = [];
                 _.each(models, function(model) {
                     // Display the views of the model.
-                    var views = [];
-                    var model_views = state[model.id].views;
-                    for (var j = 0; j < model_views.length; j++) {
-                        var cell_index = model_views[j];
+                    var views = Promise.all(_.map(state[model.id].views, function(cell_index) {
                         var cell = that.notebook.get_cell(cell_index);
-                        views.push(that.display_view_in_cell(cell, model));
-                    }
-                    all_views.push(Promise.all(views));
+                        return that.display_view_in_cell(cell, model);
+                    }));
+                    all_views.push(views);
                 });
                 return Promise.all(all_views);
             });

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -436,34 +436,34 @@ define([
                     var deserialized = model._deserialize_state(state[model.id].state);
                     return utils.resolve_promises_dict(deserialized).then(function(state) {
                         model.set_state(state);
-                        return model;
+                        return model.request_state().then(function() {
+                            model.set_comm_live(true);
+                            return model;
+                        });
                     });
                 });
             }, this));
 
             // Display all the views
             return all_models.then(function(models) {
-                that.all_views = [];
+                var all_views = [];
                 var model;
                 for (var i = 0; i < models.length; i++) {
                     model = Promise.resolve(models[i]);
                     var views = model.then(function(model) {
-                        return model.request_state().then(function() {
-                            model.set_comm_live(true);
-                            // Display the views of the model.
-                            var views = [];
-                            var model_views = state[model.id].views;
-                            for (var j = 0; j < model_views.length; j++) {
-                                var cell_index = model_views[j];
-                                var cell = that.notebook.get_cell(cell_index);
-                                views.push(that.display_view_in_cell(cell, model));
-                            }
-                            return Promise.all(views);
-                        });
+                        // Display the views of the model.
+                        var views = [];
+                        var model_views = state[model.id].views;
+                        for (var j = 0; j < model_views.length; j++) {
+                            var cell_index = model_views[j];
+                            var cell = that.notebook.get_cell(cell_index);
+                            views.push(that.display_view_in_cell(cell, model));
+                        }
+                        return Promise.all(views);
                     });
-                    that.all_views.push(views);
+                    all_views.push(views);
                 }
-                return Promise.all(that.all_views);
+                return Promise.all(all_views);
             });
         }).catch(utils.reject('Could not set widget manager state.', true));
     };


### PR DESCRIPTION
- Currently, there is the following bug in the widget persistence.

If `Foobar`is a custom widget that has a model defined in a requirejs module, specified in the `_model_module` widget attribute, then something like `HBox([Foobar()])` won't survive a page reload.
However, `Foobar()` alone does persist when it is not a child of a container.

In short, *custom widgets having custom models don't persist when they are children other widgets*.

The symptom in the js console is the `load_class` complaining that `undefined is not in the registry`.

- The reason is that that the creation of child widget views is done by the parent widget, at a time when their state, including `_view_name` and `_view_module` has not yet been set in the model.

Hence I changed the widget persistence mechanism, to first fetch the states of *all* the persisted models before instantiating any view.

Besides, the code is quite simpler, and it significantly reduces the line count.

- Finally, this should probably be backported to 3.x.