### PR TITLE
Only one target in jslink / jsdlink

### DIFF
--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -5,49 +5,62 @@ define([
     "nbextensions/widgets/widgets/js/widget",
     "jquery",
 ], function(widget, $){
-    var LinkModel = widget.WidgetModel.extend({
-        initialize: function() {
-            this.on("change:widgets", function(model, value, options) {
-                this.update_bindings(model.previous("widgets") || [], value);
-                this.update_value(this.get("widgets")[0]);
-            }, this);
-            this.once("destroy", function(model, collection, options) {
-                this.update_bindings(this.get("widgets"), []);
-            }, this);
-        },
-        update_bindings: function(oldlist, newlist) {
-            var that = this;
-            _.each(oldlist, function(elt) {elt[0].off("change:" + elt[1], null, that);});
-            _.each(newlist, function(elt) {elt[0].on("change:" + elt[1],
-                                                     function(model, value, options) {
-                                                         that.update_value(elt);
-                                                     }, that);
-                                           // TODO: register for any destruction handlers
-                                           // to take an item out of the list
-                                          });
-        },
-        update_value: function(elt) {
-            if (this.updating) {return;}
-            var model = elt[0];
-            var attr = elt[1];
-            var new_value = model.get(attr);
+
+    var BaseLinkModel = widget.WidgetModel.extend({
+        update_value: function(source, target) {
+            if (this.updating) {
+                return;
+            }
             this.updating = true;
-            _.each(_.without(this.get("widgets"), elt),
-                   function(element, index, list) {
-                       if (element[0]) {
-                           element[0].set(element[1], new_value);
-                           element[0].save_changes();
-                       }
-                   }, this);
+            if (target[0]) {
+                target[0].set(target[1], source[0].get(source[1]));
+                target[0].save_changes();
+            }
             this.updating = false;
-        },
+        }
     }, {
         serializers: _.extend({
-            widgets: {deserialize: widget.unpack_models}
-        }, widget.WidgetModel.serializers)
+            target: {deserialize: widget.unpack_models},
+            source: {deserialize: widget.unpack_models},
+        }, widget.WidgetModel.serializers),
     });
 
-    var DirectionalLinkModel = widget.WidgetModel.extend({
+    var LinkModel = BaseLinkModel.extend({
+        initialize: function() {
+            this.on("change", this.update_bindings, this);
+            this.once("destroy", function() {
+                if (this.source){
+                    this.source[0].off("change:" + this.source[1], null, this);
+                }
+                if (this.target){
+                    this.tatget[0].off("change:" + this.target[1], null, this);
+                }
+            }, this);
+        },
+        update_bindings: function() {
+            if (this.source) {
+                this.source[0].off("change:" + this.source[1], null, this);
+            }
+            if (this.target) {
+                this.target[0].off("change:" + this.target[1], null, this);
+            }
+            this.source = this.get("source");
+            this.target = this.get("target");
+            if (this.source) {
+                this.source[0].on("change:" + this.source[1], function() {
+                    this.update_value(this.source, this.target);
+                }, this);
+                this.update_value(this.source, this.target);
+            }
+            if (this.target) {
+                this.target[0].on("change:" + this.target[1], function() {
+                    this.update_value(this.target, this.source);
+                }, this);
+            }
+        },
+    });
+
+    var DirectionalLinkModel = BaseLinkModel.extend({
         initialize: function() {
             this.on("change", this.update_bindings, this);
             this.once("destroy", function() {
@@ -61,31 +74,14 @@ define([
                 this.source[0].off("change:" + this.source[1], null, this);
             }
             this.source = this.get("source");
+            this.target = this.get("target");
             if (this.source) {
-                this.source[0].on("change:" + this.source[1], function() { this.update_value(this.source); }, this);
-                this.update_value(this.source);
+                this.source[0].on("change:" + this.source[1], function() {
+                    this.update_value(this.source, this.target);
+                }, this);
+                this.update_value(this.source, this.target);
             }
         },
-        update_value: function(elt) {
-            if (this.updating) {return;}
-            var model = elt[0];
-            var attr = elt[1];
-            var new_value = model.get(attr);
-            this.updating = true;
-            _.each(this.get("targets"),
-                   function(element, index, list) {
-                       if (element[0]) {
-                           element[0].set(element[1], new_value);
-                           element[0].save_changes();
-                       }
-                   }, this);
-            this.updating = false;
-        },
-    }, { 
-        serializers: _.extend({
-            source: {deserialize: widget.unpack_models},
-            targets: {deserialize: widget.unpack_models},
-        }, widget.WidgetModel.serializers)
     });
 
     return {

--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -33,7 +33,7 @@ define([
                     this.source[0].off("change:" + this.source[1], null, this);
                 }
                 if (this.target){
-                    this.tatget[0].off("change:" + this.target[1], null, this);
+                    this.target[0].off("change:" + this.target[1], null, this);
                 }
             }, this);
         },

--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -12,11 +12,14 @@ define([
                 return;
             }
             this.updating = true;
-            if (target[0]) {
-                target[0].set(target[1], source[0].get(source[1]));
-                target[0].save_changes();
+            try {
+                if (target[0]) {
+                    target[0].set(target[1], source[0].get(source[1]));
+                    target[0].save_changes();
+                }
+            } finally {
+                this.updating = false;
             }
-            this.updating = false;
         }
     }, {
         serializers: _.extend({

--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -34,15 +34,16 @@ class Link(Widget):
     """Link Widget
     
     one trait:
-    widgets, a list of (widget, 'trait_name') tuples which should be linked in the frontend.
+    source: a (Widget, 'trait_name') tuple for the source trait
+    target: a (Widget, 'trait_name') tuple that should be updated
     """
     _model_name = Unicode('LinkModel', sync=True)
-    widgets = List(WidgetTraitTuple, sync=True, **widget_serialization)
+    target = WidgetTraitTuple(sync=True, **widget_serialization)
+    source = WidgetTraitTuple(sync=True, **widget_serialization)
 
-    def __init__(self, widgets, **kwargs):
-        if len(widgets) < 2:
-            raise TypeError("Require at least two widgets to link")
-        kwargs['widgets'] = widgets
+    def __init__(self, source, target, **kwargs):
+        kwargs['source'] = source
+        kwargs['target'] = target
         super(Link, self).__init__(**kwargs)
 
     # for compatibility with traitlet links
@@ -50,59 +51,45 @@ class Link(Widget):
         self.close()
 
 
-def jslink(*args):
-    """Link traits from different widgets together on the frontend so they remain in sync.
+def jslink(attr1, attr2):
+    """Link two widget attributes on the frontend so they remain in sync.
 
     Parameters
     ----------
-    *args : two or more (Widget, 'trait_name') tuples that should be kept in sync.
+    source : a (Widget, 'trait_name') tuple for the first trait
+    target : a (Widget, 'trait_name') tuple for the second trait
 
     Examples
     --------
 
-    >>> c = link((widget1, 'value'), (widget2, 'value'), (widget3, 'value'))
+    >>> c = link((widget1, 'value'), (widget2, 'value'))
     """
-    return Link(widgets=args)
+    return Link(attr1, attr2)
 
 
-class DirectionalLink(Widget):
+class DirectionalLink(Link):
     """A directional link
     
     source: a (Widget, 'trait_name') tuple for the source trait
-    targets: one or more (Widget, 'trait_name') tuples that should be updated
+    target: a (Widget, 'trait_name') tuple that should be updated
     when the source trait changes.
     """
     _model_name = Unicode('DirectionalLinkModel', sync=True)
-    targets = List(WidgetTraitTuple, sync=True, **widget_serialization)
-    source = WidgetTraitTuple(sync=True, **widget_serialization)
 
-    # Does not quite behave like other widgets but reproduces
-    # the behavior of traitlets.directional_link
-    def __init__(self, source, targets, **kwargs):
-        if len(targets) < 1:
-            raise TypeError("Require at least two widgets to link")
-        
-        kwargs['source'] = source
-        kwargs['targets'] = targets
-        super(DirectionalLink, self).__init__(**kwargs)
 
-    # for compatibility with traitlet links
-    def unlink(self):
-        self.close()
-
-def jsdlink(source, *targets):
-    """Link the trait of a source widget with traits of target widgets in the frontend.
+def jsdlink(source, target):
+    """Link a source widget attribute with a target widget attribute on the
+    frontend.
 
     Parameters
     ----------
     source : a (Widget, 'trait_name') tuple for the source trait
-    *targets : one or more (Widget, 'trait_name') tuples that should be updated
-    when the source trait changes.
+    target : a (Widget, 'trait_name') tuple for the target trait
 
     Examples
     --------
 
-    >>> c = dlink((src_widget, 'value'), (tgt_widget1, 'value'), (tgt_widget2, 'value'))
+    >>> c = dlink((src_widget, 'value'), (tgt_widget, 'value'))
     """
-    return DirectionalLink(source=source, targets=targets)
+    return DirectionalLink(source, target)
 


### PR DESCRIPTION
`jslink` and `jsdlink` should have the same API as the traitlet's `link` and `dlink`, which now allow only one target, cf PR https://github.com/ipython/traitlets/pull/19. 
This also simplifies the code.