### PR TITLE
Move calls to resolve_promise_dict

### DIFF
--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -433,8 +433,7 @@ define([
                     model_module: state[model_id].model_module,
                 }).then(function(model) {
                     model.set_comm_live(false);
-                    var deserialized = model._deserialize_state(state[model.id].state);
-                    return utils.resolve_promises_dict(deserialized).then(function(state) {
+                    return model._deserialize_state(state[model.id].state).then(function(state) {
                         model.set_state(state);
                         return model.request_state().then(function() {
                             model.set_comm_live(true);

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -176,10 +176,10 @@ define(["nbextensions/widgets/widgets/js/manager",
                          deserialized[k] = state[k];
                     }
                 }
-                return deserialized;
             } else {
-                return state;
+                deserialized = state;
             }
+            return utils.resolve_promises_dict(deserialized);
         },
         _handle_comm_msg: function (msg) {
             /**
@@ -198,8 +198,7 @@ define(["nbextensions/widgets/widgets/js/manager",
                             for (var i=0; i<buffer_keys.length; i++) {
                                 state[buffer_keys[i]] = buffers[i];
                             }
-                            state = that._deserialize_state(state); 
-                            return utils.resolve_promises_dict(state);
+                            return that._deserialize_state(state); 
                         }).then(function(state) {
                             return that.set_state(state);
                         }).catch(utils.reject("Couldn't process update msg for model id '" + String(that.id) + "'", true))


### PR DESCRIPTION
`model._deserialize_state` currently returns a dictionary containing values and promises (in the case of a deserializers). Hence, it is always used with `utils.resolve_promises_dict`. I just moved `resolve_promises_dict` to the function so that it always returns a promise.