### PR TITLE
Widget persistence: only create comm for widgets having valid widget ids

### DIFF
--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -34,3 +34,15 @@ def _handle_ipython():
     load_ipython_extension(ip)
 
 _handle_ipython()
+
+
+# Workaround for the absence of a comm_info_[request/reply] shell message
+class CommInfo(Widget):
+    """CommInfo widgets are is typically instantiated by the front-end. As soon as it is instantiated, it sends the collection of valid comms, and kills itself. It is a workaround to the absence of comm_info shell message."""
+    
+    def __init__(self, **kwargs):
+        super(CommInfo, self).__init__(**kwargs)
+        self.send(dict(comms={
+            k: dict(target_name=v.target_name) for (k, v) in self.comm.kernel.comm_manager.comms.items()
+        }))
+        self.close()

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -504,10 +504,28 @@ define([
         /**
          * Gets a promise for the open comms in the backend
          */
+
+        // Version using the comm_list_[request/reply] shell message.
+        /*var that = this;
         return new Promise(function(resolve, reject) {
              kernel.comm_info(function(msg) {
                  resolve(msg['content']['comms']);
              });
+        });*/
+
+        // Workaround for absence of comm_list_[request/reply] shell message.
+        // Create a new widget that gives the comm list and commits suicide.
+        var that = this;
+        return new Promise(function(resolve, reject) {
+            var comm = that.comm_manager.new_comm('ipython.widget',
+                                {'widget_class': 'ipywidgets.CommInfo'},
+                                'comm_info');
+            comm.on_msg(function(msg) {
+                var data = msg.content.data;
+                if (data.content && data.method === 'custom') {
+                    resolve(data.content.comms);
+                }
+            });
         });
     };
 

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -320,7 +320,7 @@ define([
          *      widget_class: (optional) string
          *          Target name of the widget in the back-end.
          *      comm: (optional) Comm
-         *
+         *          Comm of the widget. If not provided, a new Comm is created.
          * Create a comm if it wasn't provided.
          */
         var comm = options.comm;
@@ -446,7 +446,7 @@ define([
                         });
                     });
                 });
-            }, this));
+            }));
 
             // Display all the views
             return all_models.then(function(models) {
@@ -477,6 +477,17 @@ define([
                     resolve(data.kernel);
                 });
             }
+        });
+    };
+
+    WidgetManager.prototype._get_comm_info = function(kernel) {
+        /**
+         * Gets a promise for the open comms in the backend
+         */
+        return new Promise(function(resolve, reject) {
+             kernel.comm_info(function(msg) {
+                 resolve(msg['content']['comms']);
+             });
         });
     };
 

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -294,6 +294,22 @@ define([
 
     WidgetManager.prototype.create_model = function (options) {
         /**
+         * For backward compatibility. Custom widgets may be relying on the fact
+         * that create_model was creating a comm if none was provided in options.
+         * Unlike the old version of create_model, if no comm is passed,
+         * options.model_id is used to create the new comm.
+         */
+        console.warn('WidgetManager.create_model is deprecated. Use WidgetManager.new_model');
+        if (!options.comm) {
+            options.comm = this.comm_manager.new_comm('ipython.widget',
+                                                      {'widget_class': options.widget_class},
+                                                       options.model_id);
+        }
+        return this.new_model(options);
+    }
+
+    WidgetManager.prototype.new_model = function (options) {
+        /**
          * Create and return a promise for a new widget model
          *
          * Minimally, one must provide the model_name and widget_class
@@ -302,7 +318,7 @@ define([
          * Example
          * --------
          * JS:
-         * IPython.notebook.kernel.widget_manager.create_model({
+         * IPython.notebook.kernel.widget_manager.new_model({
          *      model_name: 'WidgetModel',
          *      widget_class: 'ipywidgets.IntSlider'
          *  })
@@ -320,19 +336,19 @@ define([
          *      widget_class: (optional) string
          *          Target name of the widget in the back-end.
          *      comm: (optional) Comm
-         *          Comm of the widget. If not provided, a new Comm is created.
-         * Create a comm if it wasn't provided.
+         *           Comm object associated with the widget.
+         *      model_id: (optional) string
+         *           If not provided, the comm id is used.
+         *
+         * Either a comm or a model_id must be provided.
          */
-        var comm = options.comm;
-        if (!comm) {
-            comm = this.comm_manager.new_comm('ipython.widget', {'widget_class': options.widget_class});
-        }
-
         var that = this;
-        var model_id = comm.comm_id;
-        var model_promise =  utils.load_class(options.model_name, options.model_module, WidgetManager._model_types)
+        var model_id = options.model_id || options.comm.comm_id;
+        var model_promise = utils.load_class(options.model_name,
+                                             options.model_module,
+                                             WidgetManager._model_types)
             .then(function(ModelType) {
-                var widget_model = new ModelType(that, model_id, comm);
+                var widget_model = new ModelType(that, model_id, options.comm);
                 widget_model.once('comm:close', function () {
                     delete that._models[model_id];
                 });
@@ -423,30 +439,34 @@ define([
         return this._get_connected_kernel().then(function(kernel) {
 
             // Recreate all the widget models for the given notebook state.
-            var all_models = Promise.all(_.map(Object.keys(state), function (model_id) {
-                // Recreate a comm using the widget's model id (model_id == comm_id).
-                var new_comm = new comm.Comm(kernel.widget_manager.comm_target_name, model_id);
-                kernel.comm_manager.register_comm(new_comm);
-
-                // Create the model using the recreated comm.  When the model is
-                // created we don't know yet if the comm is valid so set_comm_live
-                // false.  Once we receive the first state push from the back-end
-                // we know the comm is alive.
-                return kernel.widget_manager.create_model({
-                    comm: new_comm,
-                    model_name: state[model_id].model_name,
-                    model_module: state[model_id].model_module,
-                }).then(function(model) {
-                    model.set_comm_live(false);
-                    return model._deserialize_state(state[model.id].state).then(function(state) {
-                        model.set_state(state);
-                        return model.request_state().then(function() {
-                            model.set_comm_live(true);
-                            return model;
+            var all_models = that._get_comm_info(kernel).then(function(live_comms) {
+                return Promise.all(_.map(Object.keys(state), function (model_id) {
+                    if (live_comms.hasOwnProperty(model_id)) {  // live comm
+                        var new_comm = new comm.Comm(kernel.widget_manager.comm_target_name, model_id);
+                        kernel.comm_manager.register_comm(new_comm);
+                        return kernel.widget_manager.new_model({
+                            comm: new_comm,
+                            model_name: state[model_id].model_name,
+                            model_module: state[model_id].model_module,
+                        }).then(function(model) {
+                            return model.request_state().then(function() {
+                                return model;
+                            });
                         });
-                    });
-                });
-            }));
+                    } else { // dead comm
+                        return kernel.widget_manager.new_model({
+                            model_id: model_id,
+                            model_name: state[model_id].model_name,
+                            model_module: state[model_id].model_module,
+                        }).then(function(model) {
+                            return model._deserialize_state(state[model_id].state).then(function(state) {
+                                model.set_state(state);
+                                return model;
+                            });
+                        });
+                    }
+                }));
+            });
 
             // Display all the views
             return all_models.then(function(models) {


### PR DESCRIPTION
This PR has two part:

 - it implements a workaround only based on comms to the absence of `comm_info_[request/reply]` message. The workaround works as follow: instead of sending a `comm_info_request`, the front-end opens a comm whose target is a widget that sends back the list of live comms and commits suicide.

*This initially required the following PRs related to the `comm_info_[request/reply]` messages: https://github.com/jupyter/jupyter_client/pull/34, https://github.com/ipython/ipykernel/pull/25, https://github.com/jupyter/notebook/pull/166. The code using this proper version is committed and commented out.*

- then it deals with persistence: 
    - comms are only created for valid ids
    - request_state is not called for invalid ids.
    - create_model is decomposed into the creation of the comm and new_model, which does not create a comm when it is not provided with one.