### PR TITLE
Display return value in interact

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -218,6 +218,7 @@ def interactive(__interact_f, **kwargs):
             manual_button.disabled = True
         try:
             container.result = f(**container.kwargs)
+            display(container.result)
         except Exception as e:
             ip = get_ipython()
             if ip is None:


### PR DESCRIPTION
As discussed at the dev meeting on Tuesday, you need to write rather odd functions for interact because it doesn't display the return value. No-one at the time could think of a good reason why it shouldn't.

This will probably create some unexpected results for existing code, but we've said widgets are unstable.

Ping @fperez 