### PR TITLE
Zombie models, avoid memory leaks because of references in callbacks

### DIFF
--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -20,33 +20,38 @@ define([
             } finally {
                 this.updating = false;
             }
-        }
+        },
+
+        cleanup: function() {
+            // Unregister from change and destroy events of source and target.
+            if (this.source) {
+                this.source[0].off("change:" + this.source[1], null, this);
+                this.source[0].off("destroy", null, this);
+            }
+            if (this.target) {
+                this.target[0].off("change:" + this.target[1], null, this);
+                this.target[0].off("destroy", null, this);
+            }
+        },
+
     }, {
+
         serializers: _.extend({
             target: {deserialize: widget.unpack_models},
             source: {deserialize: widget.unpack_models},
         }, widget.WidgetModel.serializers),
+
     });
 
     var LinkModel = BaseLinkModel.extend({
+
         initialize: function() {
             this.on("change", this.update_bindings, this);
-            this.once("destroy", function() {
-                if (this.source){
-                    this.source[0].off("change:" + this.source[1], null, this);
-                }
-                if (this.target){
-                    this.target[0].off("change:" + this.target[1], null, this);
-                }
-            }, this);
+            this.once("destroy", this.cleanup, this);
         },
+
         update_bindings: function() {
-            if (this.source) {
-                this.source[0].off("change:" + this.source[1], null, this);
-            }
-            if (this.target) {
-                this.target[0].off("change:" + this.target[1], null, this);
-            }
+            this.cleanup();
             this.source = this.get("source");
             this.target = this.get("target");
             if (this.source) {
@@ -54,28 +59,27 @@ define([
                     this.update_value(this.source, this.target);
                 }, this);
                 this.update_value(this.source, this.target);
+                this.source[0].once("destroy", this.cleanup, this);
             }
             if (this.target) {
                 this.target[0].on("change:" + this.target[1], function() {
                     this.update_value(this.target, this.source);
                 }, this);
+                this.target[0].once("destroy", this.cleanup, this);
             }
         },
+
     });
 
     var DirectionalLinkModel = BaseLinkModel.extend({
+
         initialize: function() {
             this.on("change", this.update_bindings, this);
-            this.once("destroy", function() {
-                if (this.source) {
-                    this.source[0].off("change:" + this.source[1], null, this);
-                }
-            }, this);
+            this.once("destroy", this.cleanup, this);
         },
+
         update_bindings: function() {
-            if (this.source) {
-                this.source[0].off("change:" + this.source[1], null, this);
-            }
+            this.cleanup();
             this.source = this.get("source");
             this.target = this.get("target");
             if (this.source) {
@@ -83,8 +87,13 @@ define([
                     this.update_value(this.source, this.target);
                 }, this);
                 this.update_value(this.source, this.target);
+                this.source[0].once("destroy", this.cleanup, this);
+            }
+            if (this.target) {
+                this.target[0].once("destroy", this.cleanup, this);
             }
         },
+
     });
 
     return {

--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -7,6 +7,7 @@ define([
 ], function(widget, $){
 
     var BaseLinkModel = widget.WidgetModel.extend({
+
         update_value: function(source, target) {
             if (this.updating) {
                 return;
@@ -23,14 +24,14 @@ define([
         },
 
         cleanup: function() {
-            // Unregister from change and destroy events of source and target.
+            // Stop listening to "change" and "destroy" events of the source and target
             if (this.source) {
-                this.source[0].off("change:" + this.source[1], null, this);
-                this.source[0].off("destroy", null, this);
+                this.stopListening(this.source[0], "change:" + this.source[1], null, this);
+                this.stopListening(this.source[0], "destroy", null, this);
             }
             if (this.target) {
-                this.target[0].off("change:" + this.target[1], null, this);
-                this.target[0].off("destroy", null, this);
+                this.stopListening(this.target[0], "change:" + this.target[1], null, this);
+                this.stopListening(this.target[0], "destroy", null, this);
             }
         },
 
@@ -47,7 +48,6 @@ define([
 
         initialize: function() {
             this.on("change", this.update_bindings, this);
-            this.once("destroy", this.cleanup, this);
         },
 
         update_bindings: function() {
@@ -55,17 +55,17 @@ define([
             this.source = this.get("source");
             this.target = this.get("target");
             if (this.source) {
-                this.source[0].on("change:" + this.source[1], function() {
+                this.listenTo(this.source[0], "change:" + this.source[1], function() {
                     this.update_value(this.source, this.target);
                 }, this);
                 this.update_value(this.source, this.target);
-                this.source[0].once("destroy", this.cleanup, this);
+                this.listenToOnce(this.source[0], "destroy", this.cleanup, this);
             }
             if (this.target) {
-                this.target[0].on("change:" + this.target[1], function() {
+                this.listenTo(this.target[0], "change:" + this.target[1], function() {
                     this.update_value(this.target, this.source);
                 }, this);
-                this.target[0].once("destroy", this.cleanup, this);
+                this.listenToOnce(this.target[0], "destroy", this.cleanup, this);
             }
         },
 
@@ -75,7 +75,6 @@ define([
 
         initialize: function() {
             this.on("change", this.update_bindings, this);
-            this.once("destroy", this.cleanup, this);
         },
 
         update_bindings: function() {
@@ -83,14 +82,14 @@ define([
             this.source = this.get("source");
             this.target = this.get("target");
             if (this.source) {
-                this.source[0].on("change:" + this.source[1], function() {
+                this.listenTo(this.source[0], "change:" + this.source[1], function() {
                     this.update_value(this.source, this.target);
                 }, this);
                 this.update_value(this.source, this.target);
-                this.source[0].once("destroy", this.cleanup, this);
+                this.listenToOnce(this.source[0], "destroy", this.cleanup, this);
             }
             if (this.target) {
-                this.target[0].once("destroy", this.cleanup, this);
+                this.listenToOnce(this.target[0], "destroy", this.cleanup, this);
             }
         },
 


### PR DESCRIPTION
#### `ListenTo` vs `on`
Backbonejs has two methods to register callbacks: `on` and `listenTo`. (There are also the `once` and `listenToOnce` conterparts).

- When one does `emitter.on('some_event', listener.foo, listener)`, the emitter has a reference to the listener, and unless we call `off` explicitly, it will keep it when the listener is destroyed, preventing the garbage collector to remove it completely.

- When one does `listener.listenTo(emitter, 'some_event', listener.foo, listener)`, the listener has a reference to the emitter. When the listener is destroyed, backbone calls `stopListening` and all these references disappear. 

Hence, in the case of a listener having a shorter lifespan than the emitter, like a backbone view with respect to its model, we should use `listenTo`. The models should not have to call `off` when a view dies.

#### The case of `jslink` and `jsdlink`
However, in the case of the jslink, the link listens to changes in two models that may or may not be destroyed first. 

- When the link is destroyed, linked models should not keep references to the link. Hence `ListenTo` is the right choice.
- However, one of the two  models dies, we should remove that reference the we have on it due to the previous listenTo, to allow it to be collected by the garbage collector. Thus, we must listen to the linked models' 'destroy' events.
- Furthermore, as soon as we receive a destroy event from one of the two linked model, we should also stop listening to it in order to not keep a reference to it.