### PR TITLE
Use a promise rather than after_displayed

### DIFF
--- a/ipywidgets/static/widgets/js/widget_bool.js
+++ b/ipywidgets/static/widgets/js/widget_bool.js
@@ -178,7 +178,7 @@ define([
             } 
             this.$el.text(readout);
             $('<i class="fa"></i>').prependTo(this.$el).addClass(icon);
-            this.after_displayed(function() {
+            this.displayed.then(function() {
                 this.$el.css("color", color);
             }, this);
         }

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -91,7 +91,7 @@ define([
                 dummy.replaceWith(view.el);
 
                 // Trigger the displayed event of the child view.
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     view.trigger('displayed');
                 });
                 return view;

--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -141,7 +141,7 @@ define([
                 that.update_titles();
 
                 // Trigger the displayed event of the child view.
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     view.trigger('displayed');
                 });
                 return view;
@@ -251,7 +251,7 @@ define([
                 view.parent_container = contents_div;
 
                 // Trigger the displayed event of the child view.
-                that.after_displayed(function() {
+                that.displayed.then(function() {
                     view.trigger('displayed');
                     that.update();
                 });


### PR DESCRIPTION
We currently have a `WidgetView.after_displayed` method, which executes the specified callback right away is the view is already inserted in the DOM, or registers the callback to the `displayed` event otherwise.

This adds a new `displayed` Promise to the View, which resolves when the view is inserted into the DOM.
