### PR TITLE
Proxy widget

### DIFF
--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -70,6 +70,18 @@ define([
         },
     });
 
+    var PlaceView = ProxyView.extend({
+        initialize: function() {
+            PlaceView.__super__.initialize.apply(this, arguments);
+            this.update_selector(this.model, this.model.get("selector"));
+            this.listenTo(this.model, "change:selector", this.update_selector);
+        },
+
+        update_selector: function(model, selector) {
+            this.$box = selector ? $(selector) : this.$el;
+        },
+    });
+
     var BoxView = widget.DOMWidgetView.extend({
         initialize: function() {
             /**

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -75,9 +75,9 @@ define([
         },
     });
 
-    var PlaceView = ProxyView.extend({
+    var PlaceProxyView = ProxyView.extend({
         initialize: function() {
-            PlaceView.__super__.initialize.apply(this, arguments);
+            PlaceProxyView.__super__.initialize.apply(this, arguments);
             this.update_selector(this.model, this.model.get("selector"));
             this.listenTo(this.model, "change:selector", this.update_selector);
         },
@@ -226,6 +226,6 @@ define([
         BoxView: BoxView,
         FlexBoxView: FlexBoxView,
         ProxyView: ProxyView,
-        PlaceView: PlaceView,
+        PlaceProxyView: PlaceProxyView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -41,7 +41,12 @@ define([
 
         remove: function() {
             ProxyView.__super__.remove.apply(this, arguments);
-            this.child_promise.then(this.child.remove);
+            var that = this;
+            this.child_promise.then(function() {
+                if (that.child) {
+                    that.child.remove();
+                }
+            });
         },
 
         set_child: function(value) {
@@ -79,6 +84,7 @@ define([
 
         update_selector: function(model, selector) {
             this.$box = selector ? $(selector) : this.$el;
+            this.set_child(this.model.get("child"));
         },
     });
 

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -4,7 +4,7 @@ from .trait_types import Color, EventfulDict, EventfulList
 
 from .widget_bool import Checkbox, ToggleButton, Valid
 from .widget_button import Button
-from .widget_box import Box, FlexBox, HBox, VBox
+from .widget_box import Box, FlexBox, Proxy, HBox, VBox
 from .widget_float import FloatText, BoundedFloatText, FloatSlider, FloatProgress, FloatRangeSlider
 from .widget_image import Image
 from .widget_int import IntText, BoundedIntText, IntSlider, IntProgress, IntRangeSlider

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -4,7 +4,7 @@ from .trait_types import Color, EventfulDict, EventfulList
 
 from .widget_bool import Checkbox, ToggleButton, Valid
 from .widget_button import Button
-from .widget_box import Box, FlexBox, Proxy, Place, HBox, VBox
+from .widget_box import Box, FlexBox, Proxy, PlaceProxy, HBox, VBox
 from .widget_float import FloatText, BoundedFloatText, FloatSlider, FloatProgress, FloatRangeSlider
 from .widget_image import Image
 from .widget_int import IntText, BoundedIntText, IntSlider, IntProgress, IntRangeSlider

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -4,7 +4,7 @@ from .trait_types import Color, EventfulDict, EventfulList
 
 from .widget_bool import Checkbox, ToggleButton, Valid
 from .widget_button import Button
-from .widget_box import Box, FlexBox, Proxy, HBox, VBox
+from .widget_box import Box, FlexBox, Proxy, Place, HBox, VBox
 from .widget_float import FloatText, BoundedFloatText, FloatSlider, FloatProgress, FloatRangeSlider
 from .widget_image import Image
 from .widget_int import IntText, BoundedIntText, IntSlider, IntProgress, IntRangeSlider

--- a/ipywidgets/widgets/widget.py.orig
+++ b/ipywidgets/widgets/widget.py.orig
@@ -1,0 +1,626 @@
+"""Base Widget class.  Allows user to create widgets in the back-end that render
+in the IPython notebook front-end.
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+
+from contextlib import contextmanager
+import collections
+
+from IPython.core.getipython import get_ipython
+from ipykernel.comm import Comm
+from traitlets.config import LoggingConfigurable
+from ipython_genutils.importstring import import_item
+<<<<<<< HEAD
+from traitlets import Unicode, Dict, Instance, Bool, List, Any, \
+    CaselessStrEnum, Tuple, CUnicode, Int, Set, getmembers
+=======
+from traitlets import Unicode, Dict, Instance, Bool, List, \
+    CaselessStrEnum, Tuple, CUnicode, Int, Set, TraitError, getmembers
+>>>>>>> obj <-> self
+from ipython_genutils.py3compat import string_types
+
+
+def serialize_widget_attribute(x, obj):
+    """Serialization of widget attributes that may contain widget models.
+
+    Notes
+    -----
+    Widgetmodels are serialized into the string "IPY_MODEL_" + model_id.
+    """
+    if isinstance(x, dict):
+        return {k: serialize_widget_attribute(v, obj) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [serialize_widget_attribute(v, obj) for v in x]
+    elif isinstance(x, Widget):
+        return "IPY_MODEL_" + x.model_id
+    else:
+        return x
+
+
+def deserialize_widget_attribute(x, obj):
+    """Deserialization of widget attributes that may contain widget models
+
+    Notes
+    -----
+    Strings in the form of "IPY_MODEL_" + model_id are deserialized into a the
+    corresponding widget model if it exists.
+    """
+    if isinstance(x, dict):
+        return {k: deserialize_widget_attribute(v, obj) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [deserialize_widget_attribute(v, obj) for v in x]
+    elif isinstance(x, string_types) and x.startswith('IPY_MODEL_') and x[10:] in Widget.widgets:
+        return Widget.widgets[x[10:]]
+    else:
+        return x
+
+
+widget_serialization = {
+    'from_json': deserialize_widget_attribute,
+    'to_json': serialize_widget_attribute,
+}
+
+
+from .trait_types import Color, Signal, Slot
+
+
+class CallbackDispatcher(LoggingConfigurable):
+    """A structure for registering and running callbacks"""
+    callbacks = List()
+
+    def __call__(self, *args, **kwargs):
+        """Call all of the registered callbacks."""
+        value = None
+        for callback in self.callbacks:
+            try:
+                local_value = callback(*args, **kwargs)
+            except Exception as e:
+                ip = get_ipython()
+                if ip is None:
+                    self.log.warn("Exception in callback %s: %s", callback, e, exc_info=True)
+                else:
+                    ip.showtraceback()
+            else:
+                value = local_value if local_value is not None else value
+        return value
+
+    def register_callback(self, callback, remove=False):
+        """(Un)Register a callback
+
+        Parameters
+        ----------
+        callback: method handle
+            Method to be registered or unregistered.
+        remove=False: bool
+            Whether to unregister the callback."""
+
+        # (Un)Register the callback.
+        if remove and callback in self.callbacks:
+            self.callbacks.remove(callback)
+        elif not remove and callback not in self.callbacks:
+            self.callbacks.append(callback)
+
+def _show_traceback(method):
+    """decorator for showing tracebacks in IPython"""
+    def m(self, *args, **kwargs):
+        try:
+            return(method(self, *args, **kwargs))
+        except Exception as e:
+            ip = get_ipython()
+            if ip is None:
+                self.log.warn("Exception in widget method %s: %s", method, e, exc_info=True)
+            else:
+                ip.showtraceback()
+    return m
+
+
+def register(key=None):
+    """Returns a decorator registering a widget class in the widget registry.
+    If no key is provided, the class name is used as a key. A key is
+    provided for each core IPython widget so that the frontend can use
+    this key regardless of the language of the kernel"""
+    def wrap(widget):
+        l = key if key is not None else widget.__module__ + widget.__name__
+        Widget.widget_types[l] = widget
+        return widget
+    return wrap
+
+
+def _state_change_to_json(value, self):
+    """Convert a state change signal signature json."""
+    name, old, new = value['name'], value['old'], value['new']
+    to_json = self.trait_metadata(name, 'to_json', self._trait_to_json)
+    return {
+        'name': name,
+        'old': to_json(old, self),
+        'new': to_json(new, self),
+    }
+
+def _state_change_from_json(value, self):
+    """Convert json to a state change signal signature."""
+    name, old, new = value['name'], value['old'], value['new']
+    from_json = self.trait_metadata(name, 'from_json', self._trait_from_json)
+    return {
+        'name': name,
+        'old': from_json(old, self),
+        'new': from_json(new, self),
+    }
+
+
+class Widget(LoggingConfigurable):
+    #-------------------------------------------------------------------------
+    # Class attributes
+    #-------------------------------------------------------------------------
+    _widget_construction_callback = None
+    widgets = {}
+    widget_types = {}
+
+    @staticmethod
+    def on_widget_constructed(callback):
+        """Registers a callback to be called when a widget is constructed.
+
+        The callback must have the following signature:
+        callback(widget)"""
+        Widget._widget_construction_callback = callback
+
+    @staticmethod
+    def _call_widget_constructed(widget):
+        """Static method, called when a widget is constructed."""
+        if Widget._widget_construction_callback is not None and callable(Widget._widget_construction_callback):
+            Widget._widget_construction_callback(widget)
+
+    @staticmethod
+    def handle_comm_opened(comm, msg):
+        """Static method, called when a widget is constructed."""
+        widget_class = import_item(str(msg['content']['data']['widget_class']))
+        widget = widget_class(comm=comm)
+
+
+    #-------------------------------------------------------------------------
+    # Traits
+    #-------------------------------------------------------------------------
+    _model_module = Unicode(None, allow_none=True, help="""A requirejs module name
+        in which to find _model_name. If empty, look in the global registry.""", sync=True)
+    _model_name = Unicode('WidgetModel', help="""Name of the backbone model
+        registered in the front-end to create and sync this widget with.""", sync=True)
+    _view_module = Unicode(help="""A requirejs module in which to find _view_name.
+        If empty, look in the global registry.""", sync=True)
+    _view_name = Unicode(None, allow_none=True, help="""Default view registered in the front-end
+        to use to represent the widget.""", sync=True)
+    comm = Instance('ipykernel.comm.Comm', allow_none=True)
+
+    msg_throttle = Int(3, sync=True, help="""Maximum number of msgs the
+        front-end can send before receiving an idle msg from the back-end.""")
+
+    version = Int(0, sync=True, help="""Widget's version""")
+    keys = List(sync=True)
+    def _keys_default(self):
+        return [name for name in self.traits(sync=True)]
+
+    state_changed = Signal(Dict(to_json=_state_change_to_json,
+                                from_json=_state_change_from_json))
+
+    _property_lock = Dict()
+    _holding_sync = False
+    _states_to_send = Set()
+    _display_callbacks = Instance(CallbackDispatcher, ())
+    _msg_callbacks = Instance(CallbackDispatcher, ())
+
+    #-------------------------------------------------------------------------
+    # (Con/de)structor
+    #-------------------------------------------------------------------------
+    def __init__(self, **kwargs):
+        """Public constructor"""
+        self._model_id = kwargs.pop('model_id', None)
+        super(Widget, self).__init__(**kwargs)
+
+        Widget._call_widget_constructed(self)
+        self.open()
+
+    def __del__(self):
+        """Object disposal"""
+        self.close()
+
+    #-------------------------------------------------------------------------
+    # Properties
+    #-------------------------------------------------------------------------
+
+    def open(self):
+        """Open a comm to the frontend if one isn't already open."""
+        if self.comm is None:
+            args = dict(target_name='ipython.widget',
+                        data=self.get_state())
+            if self._model_id is not None:
+                args['comm_id'] = self._model_id
+            self.comm = Comm(**args)
+
+    def _comm_changed(self, name, new):
+        """Called when the comm is changed."""
+        if new is None:
+            return
+        self._model_id = self.model_id
+
+        self.comm.on_msg(self._handle_msg)
+        Widget.widgets[self.model_id] = self
+
+    @property
+    def model_id(self):
+        """Gets the model id of this widget.
+
+        If a Comm doesn't exist yet, a Comm will be created automagically."""
+        return self.comm.comm_id
+
+    #-------------------------------------------------------------------------
+    # Methods
+    #-------------------------------------------------------------------------
+
+    def close(self):
+        """Close method.
+
+        Closes the underlying comm.
+        When the comm is closed, all of the widget views are automatically
+        removed from the front-end."""
+        if self.comm is not None:
+            Widget.widgets.pop(self.model_id, None)
+            self.comm.close()
+            self.comm = None
+
+    def send_state(self, key=None):
+        """Sends the widget state and connections, or a piece of it, to the front-end.
+
+        Parameters
+        ----------
+        key : unicode, or iterable (optional)
+            A single property's name or iterable of property names to sync with the front-end.
+        """
+        state = self.get_state(key=key)
+        buffer_keys, buffers = [], []
+        for k, v in state.items():
+            if isinstance(v, memoryview):
+                state.pop(k)
+                buffers.append(v)
+                buffer_keys.append(k)
+        connections = self.get_connections(key=key)
+        msg = {
+            'method': 'update',
+            'state': state,
+            'buffers': buffer_keys,
+            'connections': connections,
+        }
+        self._send(msg, buffers=buffers)
+
+    def get_connections(self, key=None):
+        """Gets the widget signal connections, or a piece of it.
+
+        Parameters
+        ----------
+        key : unicode or iterable (optional)
+            A single signal name or iterable of signal names to get
+
+        Returns
+        -------
+        connections: dict of connections
+        """
+        signals = self.signals()
+        if key is None:
+            keys = signals
+        else:
+            if isinstance(key, string_types):
+                keys = [key] if key in signals else []
+            elif isinstance(key, collections.Iterable):
+                keys = [k for k in key if k in signals]
+            else:
+                raise ValueError("key must be a string, an iterable of keys, or None")
+        connections = {
+            k: serialize_widget_attribute(getattr(self, k).connected_slots, self) for k in keys
+        }
+        return connections 
+
+
+    def get_state(self, key=None):
+        """Gets the widget state, or a piece of it.
+
+        Parameters
+        ----------
+        key : unicode or iterable (optional)
+            A single property name or iterable of property names to get.
+
+        Returns
+        -------
+        state : dict of states
+        metadata : dict
+            metadata for each field: {key: metadata}
+        """
+        if key is None:
+            keys = self.keys
+        elif isinstance(key, string_types):
+            keys = [key] if key in self.keys else []
+        elif isinstance(key, collections.Iterable):
+            keys = [k for k in key if k in self.keys]
+        else:
+            raise ValueError("key must be a string, an iterable of keys, or None")
+        state = {}
+        for k in keys:
+            to_json = self.trait_metadata(k, 'to_json', self._trait_to_json)
+            state[k] = to_json(getattr(self, k), self)
+        return state
+
+    def set_state(self, sync_data):
+        """Called when a state is received from the front-end."""
+        # The order of these context managers is important. Properties must
+        # be locked when the hold_trait_notification context manager is
+        # released and notifications are fired.
+        with self._lock_property(**sync_data), self.hold_trait_notifications():
+            for name in sync_data:
+                if name in self.keys:
+                    from_json = self.trait_metadata(name, 'from_json',
+                                                    self._trait_from_json)
+                    # traitlets < 4.1 don't support read-only attributes
+                    if hasattr(self, 'set_trait'):
+                        self.set_trait(name, from_json(sync_data[name], self))
+                    else:
+                        setattr(self, name, from_json(sync_data[name], self))
+                if name in self.signals():
+                    getattr(self, name).connected_slots = deserialize_widget_attribute(sync_data[name], self)
+
+    def send(self, content, buffers=None):
+        """Sends a custom msg to the widget model in the front-end.
+
+        Parameters
+        ----------
+        content : dict
+            Content of the message to send.
+        buffers : list of binary buffers
+            Binary buffers to send with message
+        """
+        self._send({"method": "custom", "content": content}, buffers=buffers)
+
+    def on_msg(self, callback, remove=False):
+        """(Un)Register a custom msg receive callback.
+
+        Parameters
+        ----------
+        callback: callable
+            callback will be passed three arguments when a message arrives::
+
+                callback(widget, content, buffers)
+
+        remove: bool
+            True if the callback should be unregistered."""
+        self._msg_callbacks.register_callback(callback, remove=remove)
+
+    def on_displayed(self, callback, remove=False):
+        """(Un)Register a widget displayed callback.
+
+        Parameters
+        ----------
+        callback: method handler
+            Must have a signature of::
+
+                callback(widget, **kwargs)
+
+            kwargs from display are passed through without modification.
+        remove: bool
+            True if the callback should be unregistered."""
+        self._display_callbacks.register_callback(callback, remove=remove)
+
+    def add_traits(self, **traits):
+        """Dynamically add trait attributes to the Widget."""
+        super(Widget, self).add_traits(**traits)
+        for name, trait in traits.items():
+            if trait.get_metadata('sync'):
+                 self.keys.append(name)
+                 self.send_state(name)
+
+    #-------------------------------------------------------------------------
+    # Support methods
+    #-------------------------------------------------------------------------
+    @contextmanager
+    def _lock_property(self, **properties):
+        """Lock a property-value pair.
+
+        The value should be the JSON state of the property.
+
+        NOTE: This, in addition to the single lock for all state changes, is
+        flawed.  In the future we may want to look into buffering state changes
+        back to the front-end."""
+        self._property_lock = properties
+        try:
+            yield
+        finally:
+            self._property_lock = {}
+
+    @contextmanager
+    def hold_sync(self):
+        """Hold syncing any state until the outermost context manager exits"""
+        if self._holding_sync is True:
+            yield
+        else:
+            try:
+                self._holding_sync = True
+                yield
+            finally:
+                self._holding_sync = False
+                self.send_state(self._states_to_send)
+                self._states_to_send.clear()
+
+    def _should_send_property(self, key, value):
+        """Check the property lock (property_lock)"""
+        to_json = self.trait_metadata(key, 'to_json', self._trait_to_json)
+        if (key in self._property_lock
+            and to_json(value, self) == self._property_lock[key]):
+            return False
+        elif self._holding_sync:
+            self._states_to_send.add(key)
+            return False
+        else:
+            return True
+
+    # Event handlers
+    @_show_traceback
+    def _handle_msg(self, msg):
+        """Called when a msg is received from the front-end"""
+        data = msg['content']['data']
+        method = data['method']
+
+        # Handle backbone sync methods CREATE, PATCH, and UPDATE all in one.
+        if method == 'backbone':
+            if 'sync_data' in data:
+                # get binary buffers too
+                sync_data = data['sync_data']
+                for i, k in enumerate(data.get('buffer_keys', [])):
+                    sync_data[k] = msg['buffers'][i]
+                self.set_state(sync_data)  # handles all methods
+
+        # Handle a state request.
+        elif method == 'request_state':
+            self.send_state()
+
+        # Handle signals.
+        elif method == 'emit':
+            # TODO: handle binary buffers like in the case of backbone messages
+            self._handle_signal(data['name'], data['value'])
+
+        # Handle a custom msg from the front-end.
+        elif method == 'custom':
+            if 'content' in data:
+                self._handle_custom_msg(data['content'], msg['buffers'])
+
+        # Catch remainder.
+        else:
+            self.log.error('Unknown front-end to back-end widget msg with method "%s"' % method)
+
+    def _handle_custom_msg(self, content, buffers):
+        """Called when a custom msg is received."""
+        self._msg_callbacks(self, content, buffers)
+
+    def _handle_signal(self, name, value):
+        """"""
+        pass
+
+    def _notify_trait(self, name, old_value, new_value):
+        """Called when a property has been changed."""
+        # Trigger default traitlet callback machinery.  This allows any user
+        # registered validation to be processed prior to allowing the widget
+        # machinery to handle the state.
+        LoggingConfigurable._notify_trait(self, name, old_value, new_value)
+
+        # Send the state after the user registered callbacks for trait changes
+        # have all fired (allows for user to validate values).
+        if self.comm is not None and name in self.keys:
+            # Make sure this isn't information that the front-end just sent us.
+            if self._should_send_property(name, new_value):
+                # Send new state to front-end
+                self.send_state(key=name)
+
+    def _handle_displayed(self, **kwargs):
+        """Called when a view has been displayed for this widget instance"""
+        self._display_callbacks(self, **kwargs)
+
+    @staticmethod
+    def _trait_to_json(x, self):
+        """Convert a trait value to json."""
+        return x
+
+    @staticmethod
+    def _trait_from_json(x, self):
+        """Convert json values to objects."""
+        return x
+
+    def _ipython_display_(self, **kwargs):
+        """Called when `IPython.display.display` is called on the widget."""
+        # Show view.
+        if self._view_name is not None:
+            self._send({"method": "display"})
+            self._handle_displayed(**kwargs)
+
+    def _send(self, msg, buffers=None):
+        """Sends a message to the model in the front-end."""
+        self.comm.send(data=msg, buffers=buffers)
+
+    def signals(self):
+        """Returns a `dict` of all the signals of this widget. The dictionary
+        is keyed on the name and the values are the Signal objects."""
+        return dict([memb for memb in getmembers(self.__class__) if 
+                    isinstance(memb[1], Signal)]) 
+        
+    def slots(self):
+        """Returns a `dict` of all the slots of this widget. The dictionary
+        is keyed on the name and the values are the Slot objects."""
+        return dict([memb for memb in getmembers(self.__class__) if 
+                    isinstance(memb[1], Slot)]) 
+
+    def signal_metadata(self, name, key, default=None):
+        """Get metadata values for signal by key."""
+        try:
+            signal = getattr(self.__class__, name)
+        except AttributeError:
+            raise TraitError("Class %s does not have a signal named %s" %
+                                (self.__class__.__name__, name))
+        else:
+            return signal.trait.get_metadata(key, default)
+
+
+class DOMWidget(Widget):
+    visible = Bool(True, allow_none=True, help="Whether the widget is visible.  False collapses the empty space, while None preserves the empty space.", sync=True)
+    _css = Tuple(sync=True, help="CSS property list: (selector, key, value)")
+    _dom_classes = Tuple(sync=True, help="DOM classes applied to widget.$el.")
+
+    width = CUnicode(sync=True)
+    height = CUnicode(sync=True)
+    # A default padding of 2.5 px makes the widgets look nice when displayed inline.
+    padding = CUnicode(sync=True)
+    margin = CUnicode(sync=True)
+
+    color = Color(None, allow_none=True, sync=True)
+    background_color = Color(None, allow_none=True, sync=True)
+    border_color = Color(None, allow_none=True, sync=True)
+
+    border_width = CUnicode(sync=True)
+    border_radius = CUnicode(sync=True)
+    border_style = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_border-style.asp
+        'none',
+        'hidden',
+        'dotted',
+        'dashed',
+        'solid',
+        'double',
+        'groove',
+        'ridge',
+        'inset',
+        'outset',
+        'initial',
+        'inherit', ''],
+        default_value='', sync=True)
+
+    font_style = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_font_font-style.asp
+        'normal',
+        'italic',
+        'oblique',
+        'initial',
+        'inherit', ''],
+        default_value='', sync=True)
+    font_weight = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_font_weight.asp
+        'normal',
+        'bold',
+        'bolder',
+        'lighter',
+        'initial',
+        'inherit', ''] + list(map(str, range(100,1000,100))),
+        default_value='', sync=True)
+    font_size = CUnicode(sync=True)
+    font_family = Unicode(sync=True)
+
+    def __init__(self, *pargs, **kwargs):
+        super(DOMWidget, self).__init__(*pargs, **kwargs)
+
+        def _validate_border(name, old, new):
+            if new is not None and new != '':
+                if name != 'border_width' and not self.border_width:
+                    self.border_width = 1
+                if name != 'border_style' and self.border_style == '':
+                    self.border_style = 'solid'
+        self.on_trait_change(_validate_border, ['border_width', 'border_style', 'border_color'])

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -66,10 +66,10 @@ class Proxy(Widget):
             self.child._handle_displayed()
 
 
-@register('IPython.Place')
-class Place(Proxy):
+@register('IPython.PlaceProxy')
+class PlaceProxy(Proxy):
     """Renders the child widget at the specified selector."""
-    _view_name = Unicode('PlaceView', sync=True)
+    _view_name = Unicode('PlaceProxyView', sync=True)
     selector = Unicode(sync=True)
 
 

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -66,6 +66,13 @@ class Proxy(Widget):
             self.child._handle_displayed()
 
 
+@register('IPython.Place')
+class Place(Proxy):
+    """Renders the child widget at the specified selector."""
+    _view_name = Unicode('PlaceView', sync=True)
+    selector = Unicode(sync=True)
+
+
 @register('IPython.FlexBox')
 class FlexBox(Box):
     """Displays multiple widgets using the flexible box model."""


### PR DESCRIPTION
The `Proxy` widget is a simple container holding a DOMWidget or None. 

It is generally used as a base class handling the life time of a child widget which we mostly use for layout and positioning.

The commit authored by @jasongrout is a simple specialization of the Proxy widget. The `Place` widget allows you to render the widget at any place specified with a css selector. This is especially useful for rendering things in the middle of rendered Markdown.

**Example:**
In Markdown
```Markdown
Some slider next to a rich text <div class='foobar'> </div>
```
In Python
```Python
Place(IntSlider(), selector='.foobar')
```

Other specializations of the Proxy to come in different PRs.