### PR TITLE
Fix css ui-slider

### DIFF
--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -114,11 +114,11 @@
 
     .ui-slider {
         /* Inner, invisible slide div */
-        border     : 0px;
-        background : none;
-        
         .hbox();
         .box-flex1();
+
+        border     : 0px;
+        background : none;
 
         .ui-slider-handle {
             width: 12px;
@@ -157,13 +157,13 @@
     
     .ui-slider {
         /* Inner, invisible slide div */
+        .vbox();
+        .box-flex1();
+
         border      : 0px;
         background  : none;
         margin-left : -4px;
         margin-top  : 5px;
-        
-        .vbox();
-        .box-flex1();
 
         .ui-slider-handle {
             width       : 28px;


### PR DESCRIPTION
Fixes #77. (Order matters in less.)

Before,
![before-slider](https://cloud.githubusercontent.com/assets/2397974/8563953/b68ff41e-2513-11e5-9671-a02d5ccbdf85.png)

After,
![after-slider](https://cloud.githubusercontent.com/assets/2397974/8563954/b94f0d84-2513-11e5-9765-35314499e617.png)

