### PR TITLE
Unregister all instances of the callback

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -68,6 +68,9 @@ class CallbackDispatcher(LoggingConfigurable):
     def register_callback(self, callback, remove=False):
         """(Un)Register a callback
 
+        If remove is True, this will completely unregister the callback, even
+        if it was registered multiple times.
+
         Parameters
         ----------
         callback: method handle
@@ -77,7 +80,7 @@ class CallbackDispatcher(LoggingConfigurable):
         
         # (Un)Register the callback.
         if remove and callback in self.callbacks:
-            self.callbacks.remove(callback)
+            self.callbacks = [cb for cb in self.callbacks if cb!=callback]
         elif not remove and callback not in self.callbacks:
             self.callbacks.append(callback)
 


### PR DESCRIPTION
When setting `remove` to True, all the instances of the callback get unregistered.