### PR TITLE
Unregister all instances of the callback

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -68,6 +68,9 @@ class CallbackDispatcher(LoggingConfigurable):
     def register_callback(self, callback, remove=False):
         """(Un)Register a callback
 
+        If remove is True, this will completely unregister the callback, even
+        if it was registered multiple times.
+
         Parameters
         ----------
         callback: method handle
@@ -77,8 +80,8 @@ class CallbackDispatcher(LoggingConfigurable):
         
         # (Un)Register the callback.
         if remove and callback in self.callbacks:
-            self.callbacks.remove(callback)
-        elif not remove and callback not in self.callbacks:
+            self.callbacks = [cb for cb in self.callbacks if cb is not callback]
+        elif not remove:
             self.callbacks.append(callback)
 
 def _show_traceback(method):


### PR DESCRIPTION
*WIP* This is a new version of #80, which for some reason I cannot reopen... I took into account the comment of @minrk.

The goal was to get callback_dispatcher to behave like phosphor signaling in that you can register a callback (connect a slot to a signal) multiple times, but when un-registering a callback (disconnecting a slot), all instances get disconnected even if it was connected multiple times. 
