### PR TITLE
Solve persistence bug in first cell

### DIFF
--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -396,7 +396,7 @@ define([
                                 for (var id in model_views) {
                                     if (model_views.hasOwnProperty(id)) {
                                         var view = model_views[id];
-                                        if (view.options.cell_index) {
+                                        if (view.options.cell_index !== undefined) {
                                             local_state.views.push(view.options.cell_index);
                                         }
                                     }


### PR DESCRIPTION
If `view.options.cell_index` was equal to 0, the state was never being saved to the local storage.