### PR TITLE
prepare for release

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "less_include/components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/gh-pages
 ipywidgets/static/components
 ipywidgets/static/widgets/css
 ipywidgets/tests/bin
+less_include
 node_modules
 *.py[co]
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ docs/man/*.gz
 docs/source/api/generated
 docs/gh-pages
 ipywidgets/static/components
-ipywidgets/static/widgets/css/*.min.css*
+ipywidgets/static/widgets/css
+ipywidgets/tests/bin
 node_modules
 *.py[co]
 __pycache__
@@ -20,4 +21,3 @@ __pycache__
 .#*
 .coverage
 .xunit.xml
-bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
     - pip install -f travis-wheels/wheelhouse -r requirements.txt
-    - pip install -f travis-wheels/wheelhouse file://$PWD#egg=ipywidgets[test] coveralls
+    - pip install -vv -f travis-wheels/wheelhouse file://$PWD#egg=ipywidgets[test] coveralls
 script:
     - mkdir /tmp/ipywidgets && cd /tmp/ipywidgets
     - 'if [[ $GROUP == js ]]; then python -m ipywidgets.jstest; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
     - pip install -f travis-wheels/wheelhouse -r requirements.txt
-    - pip install -f travis-wheels/wheelhouse -e file://$PWD#egg=ipywidgets[test] coveralls
+    - pip install -f travis-wheels/wheelhouse file://$PWD#egg=ipywidgets[test] coveralls
 script:
+    - mkdir /tmp/ipywidgets && cd /tmp/ipywidgets
     - 'if [[ $GROUP == js ]]; then python -m ipywidgets.jstest; fi'
     - 'if [[ $GROUP == python ]]; then nosetests --with-coverage --cover-package=ipywidgets ipywidgets; fi'
 matrix:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ include COPYING.md
 include CONTRIBUTING.md
 include README.md
 include package.json
+include bower.json
+include .bowerrc
 include build_css.js
 
 # Documentation

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include COPYING.md
 include CONTRIBUTING.md
 include README.md
+include package.json
+include build_css.js
 
 # Documentation
 graft docs
@@ -8,6 +10,8 @@ exclude docs/\#*
 
 # Examples
 graft examples
+graft ipywidgets/tests
+graft ipywidgets/static
 
 # docs subdirs we want to skip
 prune docs/build

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "ipywidget-less-deps",
+  "version": "0.0.1",
+  "dependencies": {
+    "bootstrap": "components/bootstrap#~3.3",
+    "font-awesome": "components/font-awesome#~4.2.0"
+  }
+}

--- a/build_css.js
+++ b/build_css.js
@@ -24,8 +24,8 @@ function run(cmd) {
 
 run(['lessc',
     '--include-path=' + [
-        './jsdeps/notebook/notebook/static',
-        './jsdeps',
+        './less_include/notebook/notebook/static',
+        './less_include',
         ].join(path.delimiter),
     source,
     css_destination,

--- a/build_css.js
+++ b/build_css.js
@@ -1,16 +1,37 @@
+var path = require('path');
+
+var spawn = require('spawn-sync');
+
 var source = './ipywidgets/static/widgets/less/widgets.less';
 var css_destination = './ipywidgets/static/widgets/css/widgets.css';
 var min_destination = './ipywidgets/static/widgets/css/widgets.min.css';
 
-var spawn = require('spawn-sync');
-var p = spawn('python', ['-c',
-  "import os,notebook; print(os.path.join(notebook.DEFAULT_STATIC_FILES_PATH))"]);
-spawn('lessc', [
-    '--include-path=' + p.stdout.toString().trim(),
+function run(cmd) {
+    // run a command, with some help:
+    // - echo command
+    // - die on failure
+    // - show stdout/err
+    console.log('> ' + cmd.join(' '));
+    var p = spawn(cmd[0], cmd.slice(1));
+    process.stdout.write(p.stdout.toString());
+    process.stderr.write(p.stderr.toString());
+    if (p.status !== 0) {
+        console.error("`%s` failed with status=%s", cmd.join(' '), p.status);
+        process.exit(p.status);
+    }
+    return p.stdout.toString();
+}
+
+run(['lessc',
+    '--include-path=' + [
+        './jsdeps/notebook/notebook/static',
+        './jsdeps',
+        ].join(path.delimiter),
     source,
-    css_destination
+    css_destination,
 ]);
-spawn('cleancss', [
+
+run(['cleancss',
     '--source-map',
     '--skip-restructuring ',
     '-o',

--- a/ipywidgets/jstest.py
+++ b/ipywidgets/jstest.py
@@ -25,7 +25,7 @@ class WidgetTestController(jstest.JSController):
         extra_args = kwargs.pop('extra_args', None)
         super(WidgetTestController, self).__init__(section, *args, **kwargs)
         
-        test_cases = os.path.join(here, '..', 'bin', 'tests', 'tests', self.section)
+        test_cases = os.path.join(here, 'tests', 'bin', 'tests', self.section)
         self.cmd = ['casperjs', 'test', test_cases, '--engine=%s' % self.engine]
 
         if extra_args is not None:

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "url": "https://github.com/ipython/ipywidgets.git"
   },
   "scripts": {
-    "build": "npm run bower && npm run css && npm run buildtests",
+    "build": "npm run css && npm run buildtests",
     "bower": "bower install",
     "precss": "rimraf ./ipywidgets/static/widgets/css/",
     "css": "node build_css.js",
     "prebuildtests": "rimraf ./ipywidgets/tests/bin/tests",
     "buildtests": "tsc ./ipywidgets/tests/**/*.ts --outDir ./ipywidgets/tests/bin -d -m commonjs -t ES5",
-    "postinstall": "npm run build"
+    "postinstall": "npm run bower"
   },
   "devDependencies": {
     "bower": "*",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "ipython-widget-deps",
   "version": "4.0.0",
-  "description": "IPython widget nodejs dependencies",
+  "description": "IPython widget nodejs build dependencies",
   "author": "IPython Developers",
   "license": "BSD",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ipython/ipython_widget.git"
+    "url": "https://github.com/ipython/ipywidgets.git"
   },
   "scripts": {
-    "build": "npm run css && npm run buildtests",
+    "build": "npm run bower && npm run css && npm run buildtests",
+    "bower": "bower install",
     "precss": "rimraf ./ipywidgets/static/widgets/css/",
     "css": "node build_css.js",
     "prebuildtests": "rimraf ./ipywidgets/tests/bin/tests",
@@ -17,10 +18,11 @@
     "postinstall": "npm run build"
   },
   "devDependencies": {
+    "bower": "*",
+    "clean-css": "*",
     "less": "~2",
-    "typescript": "~1.5.0-beta",
     "rimraf": "^2.4.1",
     "spawn-sync": "*",
-    "clean-css": "*"
+    "typescript": "~1.5.0-beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build": "npm run css && npm run buildtests",
     "precss": "rimraf ./ipywidgets/static/widgets/css/",
     "css": "node build_css.js",
-    "prebuildtests": "rimraf ./bin/tests",
-    "buildtests": "tsc ./ipywidgets/tests/**/*.ts --outDir ./bin/tests -d -m commonjs -t ES5",
+    "prebuildtests": "rimraf ./ipywidgets/tests/bin/tests",
+    "buildtests": "tsc ./ipywidgets/tests/**/*.ts --outDir ./ipywidgets/tests/bin -d -m commonjs -t ES5",
     "postinstall": "npm run build"
   },
   "devDependencies": {

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,23 @@ PY3 = (sys.version_info[0] >= 3)
 # get on with it
 #-----------------------------------------------------------------------------
 
+import errno
+import os
+import shutil
 from distutils import log
 from distutils.core import setup, Command
 from distutils.command.build_py import build_py
 from distutils.command.sdist import sdist
 from glob import glob
-import os
 from os.path import join as pjoin
 from subprocess import check_call
+from zipfile import ZipFile
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
 
 repo_root = os.path.dirname(os.path.abspath(__file__))
 is_repo = os.path.exists(pjoin(repo_root, '.git'))
@@ -147,6 +156,46 @@ def update_package_data(distribution):
     # re-init build_py options which load package_data
     build_py.finalize_options()
 
+class FetchNotebook(Command):
+    description = "Fetch Notebook source, needed for LESS sources"
+
+    user_options = []
+    
+    def initialize_options(self):
+        pass
+    
+    def finalize_options(self):
+        pass
+    
+    # FIXME: update url to 4.0 when notebook is released
+    url = "https://github.com/jupyter/notebook/archive/master.zip"
+    
+    def run(self):
+        nb_dir = pjoin('less_include', 'notebook')
+        nb_zip = pjoin('less_include', 'notebook.zip')
+        if os.path.exists(nb_dir):
+            return
+        try:
+            os.mkdir('less_include')
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+        if not os.path.exists(nb_zip):
+            log.info("downloading %s" % self.url)
+            r = urlopen(self.url)
+            with open(nb_zip, 'wb') as f:
+                for chunk in r:
+                    f.write(chunk)
+        log.info("unzipping notebook")
+        zf = ZipFile(nb_zip)
+        if os.path.exists('notebook-tmp'):
+            shutil.rmtree('notebook-tmp')
+        zf.extractall('notebook-tmp')
+        d = glob(pjoin('notebook-tmp', '*'))[0]
+        shutil.move(d, nb_dir)
+        os.rmdir('notebook-tmp')
+    
+
 class NPM(Command):
     description = "install package,json dependencies using npm"
 
@@ -164,7 +213,7 @@ class NPM(Command):
 
     def finalize_options(self):
         pass
-        
+
     def should_run_npm(self):
         if not which('npm'):
             print("npm unavailable", file=sys.stderr)
@@ -174,6 +223,7 @@ class NPM(Command):
         return mtime(self.node_modules) < mtime(pjoin(repo_root, 'package.json'))
     
     def run(self):
+        self.distribution.run_command('fetch_notebook')
         if self.should_run_npm():
             print("installing build dependencies with npm")
             check_call(['npm', 'install'], cwd=repo_root)
@@ -235,7 +285,8 @@ setup_args = dict(
     cmdclass        = {
         'build_py': js_prerelease(build_py),
         'sdist': js_prerelease(sdist, strict=True),
-        'jsdeps': NPM
+        'jsdeps': NPM,
+        'fetch_notebook': FetchNotebook,
     },
 )
 

--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ for d, _, _ in os.walk(pjoin(here, name)):
         packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
 
 package_data = {
-    'ipywidgets': ['static/*/*/*.*', 'tests/**/*.js'],
+    'ipywidgets': ['static/*/*/*.*', 'tests/bin/*.js', 'tests/bin/*/*.js'],
 }
 
 version_ns = {}


### PR DESCRIPTION
- add js-releated files to package_data, manifest
- `npm run build` as part of build
- skip npm when run from sdists
- build_css should fail when its suprocesses fail
- fetch less dependencies for building CSS (rather than extracting from the notebook, which doesn't install LESS sources)