### PR TITLE
The `request_state` promise now resolves to the model itself.

### DIFF
--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -313,9 +313,7 @@ define([
         }
         return this.new_model(options).then(function(model) {
             // Requesting the state to populate default values.
-            return model.request_state().then(function() {
-                return model;
-            });
+            return model.request_state();
         });
     };
 
@@ -460,9 +458,8 @@ define([
                             model_name: state[model_id].model_name,
                             model_module: state[model_id].model_module,
                         }).then(function(model) {
-                            return model.request_state().then(function() {
-                                return model;
-                            });
+                            // Request the state from the backend
+                            return model.request_state();
                         });
                     } else { // dead comm
                         return kernel.widget_manager.new_model({

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -115,13 +115,14 @@ define(["nbextensions/widgets/widgets/js/manager",
                 method: 'request_state'
             }, callbacks || this.widget_manager.callbacks());
 
-            // Promise that is resolved when a state is received
+            // Promise that resolves to the model when the state is received
             // from the back-end.
             var that = this;
-            var received_state = new Promise(function(resolve) {
+            return (new Promise(function(resolve) {
                 that._resolve_received_state[msg_id] = resolve;
+            })).then(function () {
+                return that;
             });
-            return received_state;
         },
 
         set_comm_live: function(live) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -118,10 +118,8 @@ define(["nbextensions/widgets/widgets/js/manager",
             // Promise that resolves to the model when the state is received
             // from the back-end.
             var that = this;
-            return (new Promise(function(resolve) {
+            return new Promise(function(resolve) {
                 that._resolve_received_state[msg_id] = resolve;
-            })).then(function () {
-                return that;
             });
         },
 
@@ -205,7 +203,7 @@ define(["nbextensions/widgets/widgets/js/manager",
                         .then(function() {
                             var parent_id = msg.parent_header.msg_id;
                             if (that._resolve_received_state[parent_id] !== undefined) {
-                                that._resolve_received_state[parent_id].call();
+                                that._resolve_received_state[parent_id](that);
                                 delete that._resolve_received_state[parent_id];
                             }
                         }).catch(utils.reject("Couldn't resolve state request promise", true));


### PR DESCRIPTION
This simplifies the client code since we were always doing 

```Python
return model.request_state().then(function() {
    return model;		
});
```

This becomes:

```Python
return model.request_state();
```