### PR TITLE
Carefully preserve spaces in Select widgets

### DIFF
--- a/ipywidgets/static/widgets/js/widget_selection.js
+++ b/ipywidgets/static/widgets/js/widget_selection.js
@@ -461,9 +461,9 @@ define([
                    var item_query = 'option[data-value="' + encodeURIComponent(item) + '"]';
                     if (that.$listbox.find(item_query).length === 0) {
                         $('<option />')
-                            .text(item)
+                            .text(item.replace(/ /g, '\xa0')) // replace spaces with &nbsp; for correct rendering
                             .attr('data-value', encodeURIComponent(item))
-                            .attr('selected_label', item)
+                            .val(item)
                             .on("click", $.proxy(that.handle_click, that))
                             .appendTo(that.$listbox);
                     } 
@@ -478,7 +478,7 @@ define([
 
                 // Remove items that no longer exist.
                 this.$listbox.find('option').each(function(i, obj) {
-                    var value = $(obj).text();
+                    var value = $(obj).val();
                     var found = false;
                     _.each(items, function(item, index) {
                         if (item == value) {

--- a/ipywidgets/tests/tests/widget_selection.ts
+++ b/ipywidgets/tests/tests/widget_selection.ts
@@ -46,6 +46,7 @@ base.tester
 
 .cell(`
     options=["` + selection_values + `"[i] for i in range(4)]
+    options.append('  spaces  ')
     selection = [widgets.Dropdown(options=options),
         widgets.ToggleButtons(options=options),
         widgets.RadioButtons(options=options),
@@ -119,6 +120,13 @@ base.tester
         .wait_for_idle()
         .then(function () {
             this.test.assert(verify_selection(selection_index, this, 2), 'List selection updated view states correctly.');
+
+            // Verify that selecting the option with spaces works
+            this.notebook.cell_element_function(selection_index, list_selector + ' option:nth-child(5)', 'click');
+        })
+        .wait_for_idle()
+        .then(function () {
+            this.test.assert(verify_selection(selection_index, this, 4), 'List selection of space element updated view states correctly.');
 
             // Verify that selecting a multibutton option updates all of the others.
             // Bootstrap3 has changed the toggle button group behavior.  Two clicks


### PR DESCRIPTION
Spaces should be displayed (so we replace spaces with \xa0, which is
`&nbsp;`).  We also set the value of an option with jquery syntax.

Fixes #70