### PR TITLE
Update example notebooks

### DIFF
--- a/examples/Custom Widget - Hello World.ipynb
+++ b/examples/Custom Widget - Hello World.ipynb
@@ -771,21 +771,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Custom Widget - Hello World.ipynb
+++ b/examples/Custom Widget - Hello World.ipynb
@@ -33,11 +33,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The widget framework is built **on top of the Comm framework** (short for communication).  The Comm framework is a framework that **allows you send/receive JSON messages** to/from the front-end (as seen below).\n",
+    "The widget framework is built on top of the Comm framework (short for communication).  The Comm framework is a framework that allows you send/receive JSON messages to/from the front end (as seen below).\n",
     "\n",
     "![Widget layer](images/WidgetArch.png)\n",
     "\n",
-    "To create a custom widget, you need to **define the widget both in the back-end and in the front-end**.  "
+    "To create a custom widget, you need to define the widget both in the browser and in the python kernel."
    ]
   },
   {
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get started, you'll create a **simple hello world widget**.  Later you'll build on this foundation to make more complex widgets."
+    "To get started, you'll create a simple hello world widget.  Later you'll build on this foundation to make more complex widgets."
    ]
   },
   {
@@ -66,7 +66,7 @@
     }
    },
    "source": [
-    "## Back-end (Python)"
+    "## Python Kernel"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To define a widget, you must inherit from the **Widget or DOMWidget** base class.  If you intend for your widget to be **displayed in the IPython notebook**, you'll need to **inherit from the DOMWidget**.  The DOMWidget class itself inherits from the Widget class.  The Widget class is useful for cases in which the **Widget is not meant to be displayed directly in the notebook**, but **instead as a child of another rendering environment**.  For example, if you wanted to create a three.js widget (a popular WebGL library), you would implement the rendering window as a DOMWidget and any 3D objects or lights meant to be rendered in that window as Widgets."
+    "To define a widget, you must inherit from the Widget or DOMWidget base class.  If you intend for your widget to be displayed in the Jupyter notebook, you'll want to inherit from the DOMWidget.  The DOMWidget class itself inherits from the Widget class.  The Widget class is useful for cases in which the Widget is not meant to be displayed directly in the notebook, but instead as a child of another rendering environment.  For example, if you wanted to create a three.js widget (a popular WebGL library), you would implement the rendering window as a DOMWidget and any 3D objects or lights meant to be rendered in that window as Widgets."
    ]
   },
   {
@@ -98,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Inheriting from the DOMWidget does not tell the widget framework what front-end widget to associate with your back-end widget.  Instead, you must tell it yourself by defining a **specially named Traitlet, `_view_name`** (as seen below)."
+    "Inheriting from the DOMWidget does not tell the widget framework what front end widget to associate with your back end widget.  Instead, you must tell it yourself by defining a specially named traitlet, `_view_name` (as seen below)."
    ]
   },
   {
@@ -131,7 +131,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Traitlets is** an IPython library for defining **type-safe properties** on configurable objects.  For this tutorial you do not need to worry about the *configurable* piece of the traitlets machinery.   The **`sync=True` keyword argument** tells the widget framework to **handle synchronizing that value to the front-end**.  Without `sync=True`, the front-end would have no knowledge of `_view_name`."
+    "Traitlets is an IPython library for defining type-safe properties on configurable objects.  For this tutorial you do not need to worry about the *configurable* piece of the traitlets machinery.   The `sync=True` keyword argument tells the widget framework to handle synchronizing that value to the browser.  Without `sync=True`, the browser would have no knowledge of `_view_name`."
    ]
   },
   {
@@ -182,7 +182,7 @@
     "- Union\n",
     "\n",
     "\n",
-    "**Not all of these traitlets can be synchronized** across the network, **only the JSON-able** traits and **Widget instances** will be synchronized."
+    "Not all of these traitlets can be synchronized across the network, only the JSON-able traits and Widget instances will be synchronized."
    ]
   },
   {
@@ -193,7 +193,7 @@
     }
    },
    "source": [
-    "## Front-end (JavaScript)"
+    "## Front end (JavaScript)"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The IPython widget framework front-end relies heavily on [Backbone.js](http://backbonejs.org/).  **Backbone.js is an MVC (model view controller) framework**.  Widgets defined in the back-end are automatically **synchronized with generic Backbone.js models** in the front-end.  The traitlets are added to the front-end instance **automatically on first state push**.  The **`_view_name` trait** that you defined earlier is used by the widget framework to create the corresponding Backbone.js view and **link that view to the model**."
+    "The IPython widget framework front end relies heavily on [Backbone.js](http://backbonejs.org/).  Backbone.js is an MVC (model view controller) framework.  Widgets defined in the back end are automatically synchronized with generic Backbone.js models in the front end.  The traitlets are added to the front end instance automatically on first state push.  The `_view_name` trait that you defined earlier is used by the widget framework to create the corresponding Backbone.js view and link that view to the model."
    ]
   },
   {
@@ -225,7 +225,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You first need to **import the `widget` and `manager` modules**.  You will use the manager later to register your view by name (the same name you used in the back-end).  To import the modules, use the `require` method of [require.js](http://requirejs.org/) (as seen below).\n"
+    "You first need to import the `widget` and `manager` modules.  You will use the manager later to register your view by name (the same name you used in the back end).  To import the modules, use the `require` method of [require.js](http://requirejs.org/) (as seen below).\n"
    ]
   },
   {
@@ -257,7 +257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next define your widget view class.  **Inherit from the `DOMWidgetView`** by using the `.extend` method.  Register the view class with the widget manager by calling **`.register_widget_view`**.  The **first parameter is the widget view name** (`_view_name` that you defined earlier in Python) and the **second is a handle to the class type**."
+    "Next define your widget view class.  Inherit from the `DOMWidgetView` by using the `.extend` method.  Register the view class with the widget manager by calling `.register_widget_view`.  The first parameter is the widget view name (`_view_name` that you defined earlier in Python) and the second is a handle to the class type."
    ]
   },
   {
@@ -296,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lastly, **override the base `render` method** of the view to define custom rendering logic.  A handle to the widget's default div element can be acquired via **`this.$el`**.  The `$el` property is a **[jQuery](http://jquery.com/) object handle** (which can be thought of as a supercharged version of the normal DOM element's handle)."
+    "Lastly, override the base `render` method of the view to define custom rendering logic.  A handle to the widget's default div element can be acquired via `this.$el`.  The `$el` property is a [jQuery](http://jquery.com/) object handle (which can be thought of as a supercharged version of the normal DOM element's handle)."
    ]
   },
   {
@@ -366,7 +366,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is not much that you can do with the above example that you can't do with the IPython display framework.  To change this, you will make the widget stateful.  Instead of displaying a static \"hello world\" message, it will **display a string set by the back-end**.  First you need to **add a traitlet in the back-end**.  Use the name of **`value` to stay consistent** with the rest of the widget framework and to **allow your widget to be used with interact**."
+    "There is not much that you can do with the above example that you can't do with the IPython display framework.  To change this, you will make the widget stateful.  Instead of displaying a static \"hello world\" message, it will display a string set by the back end.  First you need to add a traitlet in the back end.  Use the name of `value` to stay consistent with the rest of the widget framework and to allow your widget to be used with interact."
    ]
   },
   {
@@ -397,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To access the model associate with a view instance, use the **`model` property** of the view.  **`get` and `set`** methods are used to interact with the Backbone model.  **`get` is trivial**, however you have to **be careful when using `set`**.  **After calling the model `set`** you need call the **view's `touch` method**.  This associates the `set` operation with a particular view so **output will be routed to the correct cell**.  The model also has a **`on` method** which allows you to listen to events triggered by the model (like value changes)."
+    "To access the model associate with a view instance, use the `model` property of the view.  `get` and `set` methods are used to interact with the Backbone model.  `get` is trivial, however you have to be careful when using `set`.  After calling the model `set` you need call the view's `touch` method.  This associates the `set` operation with a particular view so output will be routed to the correct cell.  The model also has an `on` method which allows you to listen to events triggered by the model (like value changes)."
    ]
   },
   {
@@ -415,7 +415,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By **replacing the string literal with a call to `model.get`**, the view will now display the **value of the back-end upon display**.  However, it will not update itself to a new value when the value changes."
+    "By replacing the string literal with a call to `model.get`, the view will now display the value of the back end upon display.  However, it will not update itself to a new value when the value changes."
    ]
   },
   {
@@ -455,7 +455,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get the view to **update itself dynamically**, register a function to update the view's value when the model's `value` property changes.  This can be done using the **`model.on` method**.  The `on` method takes three parameters, an event name, callback handle, and callback context.   The Backbone **event named `change`** will fire whenever the model changes.  By **appending `:value`** to it, you tell Backbone to only listen to the change event of the `value` property (as seen below)."
+    "To get the view to update itself dynamically, register a function to update the view's value when the model's `value` property changes.  This can be done using the `model.on` method.  The `on` method takes three parameters, an event name, callback handle, and callback context.   The Backbone event named `change` will fire whenever the model changes.  By appending `:value` to it, you tell Backbone to only listen to the change event of the `value` property (as seen below)."
    ]
   },
   {
@@ -541,7 +541,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The examples above dump the value directly into the DOM.  There is no way for you to interact with this dumped data in the front-end.  To create an example that **accepts input**, you will have to do something more than blindly dumping the contents of value into the DOM.  In this part of the tutorial, you will **use a jQuery spinner** to display and accept input in the front-end.  IPython currently lacks a spinner implementation so this widget will be unique."
+    "The examples above dump the value directly into the DOM.  There is no way for you to interact with this dumped data in the front end.  To create an example that accepts input, you will have to do something more than blindly dumping the contents of value into the DOM.  In this part of the tutorial, you will use a jQuery spinner to display and accept input in the front end."
    ]
   },
   {
@@ -559,7 +559,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You will need to change the type of the **value traitlet to `Int`**.  It also makes sense to **change the name of the widget** to something more appropriate, like `SpinnerWidget`."
+    "You will need to change the type of the value traitlet to `Int`.  It also makes sense to change the name of the widget to something more appropriate, like `SpinnerWidget`."
    ]
   },
   {
@@ -591,7 +591,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [jQuery docs for the spinner control](https://jqueryui.com/spinner/) say to use **`.spinner` to create a spinner** in an element.  Calling **`.spinner` on `$el` will create a spinner inside `$el`**.  Make sure to **update the widget name here too** so it's the same as `_view_name` in the back-end."
+    "The [jQuery docs for the spinner control](https://jqueryui.com/spinner/) say to use `.spinner` to create a spinner in an element.  Calling `.spinner` on `$el` will create a spinner inside `$el`.  Make sure to update the widget name here too so it's the same as `_view_name` in the back end."
    ]
   },
   {
@@ -644,7 +644,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To **set the value of the spinner on update from the back-end**, you need to use **jQuery's `spinner` API**.  `spinner.spinner('value', new)` will set the value of the spinner.  Add that code to the **`value_changed` method** to make the spinner **update with the value stored in the back-end((.  Using jQuery's spinner API, you can add a function to handle the **spinner `change` event** by passing it in when constructing the spinner.  Inside the `change` event, call **`model.set`** to set the value and then **`touch`** to inform the framework that this view was the view that caused the change to the model.  **Note: The `var that = this;` is a JavaScript trick to pass the current context into closures.**"
+    "To set the value of the spinner on update from the back end, you need to use jQuery's `spinner` API.  `spinner.spinner('value', new)` will set the value of the spinner.  Add that code to the `value_changed` method to make the spinner update with the value stored in the back end.  Using jQuery's spinner API, you can add a function to handle the spinner `change` event by passing it in when constructing the spinner.  Inside the `change` event, call `model.set` to set the value and then `touch` to inform the framework that this view was the view that caused the change to the model.  Note: The `var that = this;` is a JavaScript trick to pass the current context into closures."
    ]
   },
   {
@@ -741,7 +741,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Trying to **use the spinner with another widget**."
+    "Trying to use the spinner with another widget."
    ]
   },
   {
@@ -771,21 +771,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/File Upload Widget.ipynb
+++ b/examples/File Upload Widget.ipynb
@@ -174,21 +174,21 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/File Upload Widget.ipynb
+++ b/examples/File Upload Widget.ipynb
@@ -155,15 +155,6 @@
     "\n",
     "file_widget"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/File Upload Widget.ipynb
+++ b/examples/File Upload Widget.ipynb
@@ -111,7 +111,7 @@
     "        },\n",
     "    });\n",
     "        \n",
-    "    // Register the DatePickerView with the widget manager.\n",
+    "    // Register the FilePickerView with the widget manager.\n",
     "    manager.WidgetManager.register_widget_view('FilePickerView', FilePickerView);\n",
     "});"
    ]
@@ -155,6 +155,15 @@
     "\n",
     "file_widget"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -165,21 +174,21 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Image Processing.ipynb
+++ b/examples/Image Processing.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "import skimage\n",
-    "from skimage import data, filter, io"
+    "from skimage import data, filters, io"
    ]
   },
   {
@@ -134,25 +134,34 @@
     "    new_image = io.Image(new_image)\n",
     "    return new_image"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Image Processing.ipynb
+++ b/examples/Image Processing.ipynb
@@ -147,21 +147,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Image Processing.ipynb
+++ b/examples/Image Processing.ipynb
@@ -134,15 +134,6 @@
     "    new_image = io.Image(new_image)\n",
     "    return new_image"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Using Interact.ipynb
+++ b/examples/Using Interact.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-success\">\n",
-    "As of IPython 3.0, the widgets in this notebook won't show up on http://nbviewer.ipython.org. To view the widgets and interact with them, you will need to download this notebook and run it with an IPython Notebook server.\n",
+    "As of IPython 3.0, the widgets in this notebook won't show up on http://nbviewer.ipython.org. To view the widgets and interact with them, you will need to download this notebook and run it with an IPython or Jupyter Notebook server.\n",
     "\n",
     "</div>"
    ]
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you pass this function as the first argument to `interact` along with an integer keyword argument (`x=10`), a slider is generated and bound to the function."
+    "When you pass this function as the first argument to `interact` along with an integer keyword argument (`x=10`), a slider is generated and bound to the function parameter."
    ]
   },
   {
@@ -78,14 +78,14 @@
    },
    "outputs": [],
    "source": [
-    "interact(f, x=10);"
+    "interact(f, x=-1);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you move the slider, the function is called and the current value of `x` is printed.\n",
+    "When you move the slider, the function is called, which prints the current value of `x`.\n",
     "\n",
     "If you pass `True` or `False`, `interact` will generate a checkbox:"
    ]
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you pass an integer valued keyword argument (`x=10`) to `interact`, it generates an integer valued slider control with a range of $[-10,+3\\times10]$. In this case `10` is an *abbreviation* for an actual slider widget:\n",
+    "When you pass an integer-valued keyword argument of `10` (`x=10`) to `interact`, it generates an integer-valued slider control with a range of $[-10,+3\\times10]$. In this case, `10` is an *abbreviation* for an actual slider widget:\n",
     "\n",
     "```python\n",
     "IntSlider(min=-10,max=30,step=1,value=10)\n",
@@ -227,7 +227,7 @@
    "source": [
     "This examples clarifies how `interact` proceses its keyword arguments:\n",
     "\n",
-    "1. If the keyword argument is `Widget` instance with a `value` attribute, that widget is used. Any widget with a `value` attribute can be used, even custom ones.\n",
+    "1. If the keyword argument is a `Widget` instance with a `value` attribute, that widget is used. Any widget with a `value` attribute can be used, even custom ones.\n",
     "2. Otherwise, the value is treated as a *widget abbreviation* that is converted to a widget before it is used.\n",
     "\n",
     "The following table gives an overview of different widget abbreviations:\n",
@@ -248,7 +248,7 @@
    "source": [
     "You have seen how the checkbox and textarea widgets work above. Here, more details about the different abbreviations for sliders and dropdowns are given.\n",
     "\n",
-    "If a 2-tuple of integers is passed `(min,max)` a integer valued slider is produced with those minimum and maximum (inclusive) values. In this case, the default step size of `1` is used."
+    "If a 2-tuple of integers is passed `(min,max)`, an integer-valued slider is produced with those minimum and maximum values (inclusively). In this case, the default step size of `1` is used."
    ]
   },
   {
@@ -266,7 +266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If a 3-tuple of integers is passed `(min,max,step)` the step size can also be set."
+    "If a 3-tuple of integers is passed `(min,max,step)`, the step size can also be set."
    ]
   },
   {
@@ -284,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A float valued slider is produced if the elements of the tuples are floats. Here the minimum is `0.0`, the maximum is `10.0` and step size is `0.1` (the default)."
+    "A float-valued slider is produced if the elements of the tuples are floats. Here the minimum is `0.0`, the maximum is `10.0` and step size is `0.1` (the default)."
    ]
   },
   {
@@ -302,7 +302,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The step size can be changed by passing a 3rd element in the tuple."
+    "The step size can be changed by passing a third element in the tuple."
    ]
   },
   {
@@ -320,7 +320,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For both integer and float valued sliders, you can pick the initial value of the widget by passing a default keyword argument to the underlying Python function. Here we set the initial value of a float slider to `5.5`."
+    "For both integer and float-valued sliders, you can pick the initial value of the widget by passing a default keyword argument to the underlying Python function. Here we set the initial value of a float slider to `5.5`."
    ]
   },
   {
@@ -340,7 +340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dropdown menus can be produced by passing a tuple of strings. In this case, the strings are both used as the names in the dropdown menu UI and passed to the underlying Python function."
+    "Dropdown menus are constructed by passing a tuple of strings. In this case, the strings are both used as the names in the dropdown menu UI and passed to the underlying Python function."
    ]
   },
   {
@@ -383,9 +383,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you are using Python 3, you can also specify widget abbreviations using [function annotations](https://docs.python.org/3/tutorial/controlflow.html#function-annotations). This is a convenient approach allows the widget abbreviations to be defined with a function.\n",
+    "If you are using Python 3, you can also specify widget abbreviations using [function annotations](https://docs.python.org/3/tutorial/controlflow.html#function-annotations).\n",
     "\n",
-    "Define a function with an checkbox widget abbreviation for the argument `x`."
+    "Define a function with a checkbox widget abbreviation for the argument `x`."
    ]
   },
   {
@@ -396,7 +396,7 @@
    },
    "outputs": [],
    "source": [
-    "def f(x:True):\n",
+    "def f(x:True): # python 3 only\n",
     "    return x"
    ]
   },
@@ -471,7 +471,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to `interact` IPython provides another function, `interactive`, that is useful when you want to reuse the widget that are produced or access the data that is bound to the UI controls."
+    "In addition to `interact`, IPython provides another function, `interactive`, that is useful when you want to reuse the widgets that are produced or access the data that is bound to the UI controls."
    ]
   },
   {
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The children of the `Box` are two integer valued sliders produced by the widget abbreviations above."
+    "The children of the `Box` are two integer-valued sliders produced by the widget abbreviations above."
    ]
   },
   {
@@ -603,25 +603,34 @@
    "source": [
     "w.result"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Using Interact.ipynb
+++ b/examples/Using Interact.ipynb
@@ -616,21 +616,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Using Interact.ipynb
+++ b/examples/Using Interact.ipynb
@@ -603,15 +603,6 @@
    "source": [
     "w.result"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Using Interact.ipynb
+++ b/examples/Using Interact.ipynb
@@ -78,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "interact(f, x=-1);"
+    "interact(f, x=10);"
    ]
   },
   {

--- a/examples/Using Interact.ipynb
+++ b/examples/Using Interact.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-success\">\n",
-    "As of IPython 3.0, the widgets in this notebook won't show up on http://nbviewer.ipython.org. To view the widgets and interact with them, you will need to download this notebook and run it with an IPython or Jupyter Notebook server.\n",
+    "As of Jupyter 4.0, the widgets in this notebook won't show up on http://nbviewer.ipython.org. To view the widgets and interact with them, you will need to download this notebook and run it with a Jupyter Notebook server.\n",
     "\n",
     "</div>"
    ]

--- a/examples/Variable Inspector.ipynb
+++ b/examples/Variable Inspector.ipynb
@@ -214,15 +214,6 @@
    "source": [
     "inspector.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Variable Inspector.ipynb
+++ b/examples/Variable Inspector.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates how one can use the widgets already built-in to IPython to create a working variable inspector much like the ones seen in popular commercial scientific computing environments."
+    "This notebook demonstrates how one can use the widgets already built in to IPython to create a working variable inspector much like the ones seen in popular commercial scientific computing environments."
    ]
   },
   {
@@ -214,25 +214,34 @@
    "source": [
     "inspector.close()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Variable Inspector.ipynb
+++ b/examples/Variable Inspector.ipynb
@@ -227,21 +227,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Widget Basics.ipynb
+++ b/examples/Widget Basics.ipynb
@@ -29,7 +29,7 @@
     }
    },
    "source": [
-    "Widgets are elements that exists in both the front-end and the back-end."
+    "Widgets are eventful python objects that have a representation in the browser, often as a control like a slider, textbox, etc."
    ]
   },
   {
@@ -66,7 +66,7 @@
     }
    },
    "source": [
-    "To use the widget framework, you need to **import `ipywidgets`**."
+    "To use the widget framework, you need to import `ipywidgets`."
    ]
   },
   {
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Widgets have their own display `repr` which allows them to be displayed using IPython's display framework.  Constructing and returning an `IntSlider` automatically displays the widget (as seen below).  Widgets are **displayed inside the `widget area`**, which sits between the code cell and output.  **You can hide all of the widgets** in the `widget area` by clicking the grey *x* in the margin."
+    "Widgets have their own display `repr` which allows them to be displayed using IPython's display framework.  Constructing and returning an `IntSlider` automatically displays the widget (as seen below).  Widgets are displayed inside the widget area, which sits between the code cell and output.  You can hide all of the widgets in the widget area by clicking the grey *x* in the margin."
    ]
   },
   {
@@ -155,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you display the same widget twice, the displayed instances in the front-end **will remain in sync** with each other."
+    "If you display the same widget twice, the displayed instances in the front-end will remain in sync with each other.  Try dragging the slider below and watch the slider above."
    ]
   },
   {
@@ -184,7 +184,7 @@
     }
    },
    "source": [
-    "Widgets are **represented in the back-end by a single object**.  Each time a widget is displayed, **a new representation** of that same object is created in the front-end.  These representations are called **views**.\n",
+    "Widgets are represented in the back-end by a single object.  Each time a widget is displayed, a new representation of that same object is created in the front-end.  These representations are called views.\n",
     "\n",
     "![Kernel & front-end diagram](images/WidgetModelView.png)"
    ]
@@ -244,7 +244,7 @@
     }
    },
    "source": [
-    "All of the IPython widgets **share a similar naming scheme**.  To read the value of a widget, you can query its `value` property."
+    "All of the IPython widgets share a similar naming scheme.  To read the value of a widget, you can query its `value` property."
    ]
   },
   {
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to `value`, most widgets share `keys`, `description`, `disabled`, and `visible`.  To see the entire list of synchronized, stateful properties, of any specific widget, you can **query the `keys` property**."
+    "In addition to `value`, most widgets share `keys`, `description`, `disabled`, and `visible`.  To see the entire list of synchronized, stateful properties of any specific widget, you can query the `keys` property."
    ]
   },
   {
@@ -332,7 +332,7 @@
     }
    },
    "source": [
-    "While creating a widget, you can set some or all of the initial values of that widget by **defining them as keyword arguments in the widget's constructor** (as seen below)."
+    "While creating a widget, you can set some or all of the initial values of that widget by defining them as keyword arguments in the widget's constructor (as seen below)."
    ]
   },
   {
@@ -361,7 +361,7 @@
     }
    },
    "source": [
-    "If you need to display the same value two different ways, you'll have to use two different widgets.  Instead of **attempting to manually synchronize the values** of the two widgets, you can use the `traitlet` `link` function **to link two properties together**.  Below, the values of three widgets are linked together."
+    "If you need to display the same value two different ways, you'll have to use two different widgets.  Instead of attempting to manually synchronize the values of the two widgets, you can use the `traitlet` `link` function to link two properties together.  Below, the values of two widgets are linked together."
    ]
   },
   {
@@ -395,7 +395,7 @@
     }
    },
    "source": [
-    "Unlinking the widgets is simple.  All you have to do is call `.unlink` on the link object."
+    "Unlinking the widgets is simple.  All you have to do is call `.unlink` on the link object.  Try changing one of the widgets above after unlinking to see that they can be independently changed."
    ]
   },
   {
@@ -419,21 +419,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Widget Basics.ipynb
+++ b/examples/Widget Basics.ipynb
@@ -419,21 +419,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Widget Events.ipynb
+++ b/examples/Widget Events.ipynb
@@ -359,21 +359,21 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Widget Events.ipynb
+++ b/examples/Widget Events.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Button` is not used to represent a data type.  Instead the button widget is used to **handle mouse clicks**.  The **`on_click` method** of the `Button` can be used to register function to be called when the button is clicked.  The doc string of the `on_click` can be seen below."
+    "The `Button` is not used to represent a data type.  Instead the button widget is used to handle mouse clicks.  The `on_click` method of the `Button` can be used to register function to be called when the button is clicked.  The doc string of the `on_click` can be seen below."
    ]
   },
   {
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since button clicks are **stateless**, they are **transmitted from the front-end to the back-end using custom messages**.  By using the `on_click` method, a button that prints a message when it has been clicked is shown below."
+    "Since button clicks are stateless, they are transmitted from the front-end to the back-end using custom messages.  By using the `on_click` method, a button that prints a message when it has been clicked is shown below."
    ]
   },
   {
@@ -106,7 +106,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The **`Text`** also has a special **`on_submit` event**.  The `on_submit` event **fires when the user hits return**."
+    "The `Text` widget also has a special `on_submit` event.  The `on_submit` event fires when the user hits return."
    ]
   },
   {
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Widget properties are IPython traitlets** and **traitlets are eventful**.  To handle  changes, the **`on_trait_change` method** of the widget can be used to **register a callback**.  The doc string for `on_trait_change` can be seen below."
+    "Widget properties are IPython traitlets and traitlets are eventful.  To handle  changes, the `on_trait_change` method of the widget can be used to register a callback.  The doc string for `on_trait_change` can be seen below."
    ]
   },
   {
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mentioned in the doc string, the callback registered can have **4 possible signatures**:\n",
+    "Mentioned in the doc string, the callback registered can have 4 possible signatures:\n",
     "\n",
     "- callback()\n",
     "- callback(trait_name)\n",
@@ -208,16 +208,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Often, you may want to simply link widget attributes together. Synchronization of attributes can be done in a simpler way than by using bare traitlets events. \n",
-    "\n",
-    "The first method is to use the `link` and `directional_link` functions from the `traitlets` module. "
+    "Often, you may want to simply link widget attributes together. Synchronization of attributes can be done in a simpler way than by using bare traitlets events. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Linking traitlets attributes from the server side"
+    "## Linking traitlets attributes from the server side\n",
+    "\n",
+    "The first method is to use the `link` and `dlink` functions from the `traitlets` module. "
    ]
   },
   {
@@ -265,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Function `traitlets.link` returns a `Link` object. The link can be broken by calling the `unlink` method."
+    "Function `traitlets.link` and `traitlets.dlink` return a `Link` or `DLink` object. The link can be broken by calling the `unlink` method."
    ]
   },
   {
@@ -291,7 +291,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When synchronizing traitlets attributes, you may experience a lag because of the latency dues to the rountrip to the server side. You can also directly link widgets attributes, either in a unidirectional or a bidirectional fashion using the link widgets. "
+    "When synchronizing traitlets attributes, you may experience a lag because of the latency due to the roundtrip to the server side. You can also directly link widget attributes in the browser using the link widgets, in either a unidirectional or a bidirectional fashion."
    ]
   },
   {
@@ -359,21 +359,21 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Widget List.ipynb
+++ b/examples/Widget List.ipynb
@@ -29,7 +29,7 @@
     }
    },
    "source": [
-    "For a complete list of the widgets available to you, you can list the classes in the widget namespace (as seen below).  `Widget` and `DOMWidget`, not listed below, are base classes."
+    "For a complete list of the GUI widgets available to you, you can list the registered widget types.  `Widget` and `DOMWidget`, not listed below, are base classes."
    ]
   },
   {
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "import ipywidgets as widgets\n",
-    "[n for n in dir(widgets) if not n.endswith('Widget') and n[0] == n[0].upper() and not n[0] == '_']"
+    "widgets.Widget.widget_types.values()"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are two widgets that are designed to display a boolean value."
+    "There are three widgets that are designed to display a boolean value."
    ]
   },
   {
@@ -255,6 +255,28 @@
    "source": [
     "widgets.Checkbox(\n",
     "    description='Check me',\n",
+    "    value=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Valid\n",
+    "\n",
+    "The valid widget provides a read-only indicator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "widgets.Valid(\n",
     "    value=True,\n",
     ")"
    ]
@@ -430,7 +452,7 @@
    "metadata": {},
    "source": [
     "### SelectMultiple\n",
-    "Multiple values can be selected with <kbd>shift</kbd> and <kbd>ctrl</kbd> pressed and mouse clicks or arrow keys."
+    "Multiple values can be selected with <kbd>shift</kbd> and/or <kbd>ctrl</kbd> (or <kbd>command</kbd>) pressed and mouse clicks or arrow keys."
    ]
   },
   {
@@ -474,7 +496,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 4 widgets that can be used to display a string value.  Of those, the **`Text` and `Textarea` widgets accept input**.  The **`Latex` and `HTML` widgets display the string** as either Latex or HTML respectively, but **do not accept input**."
+    "There are 4 widgets that can be used to display a string value.  Of those, the `Text` and `Textarea` widgets accept input.  The `Latex` and `HTML` widgets display the string as either Latex or HTML respectively, but do not accept input."
    ]
   },
   {
@@ -599,21 +621,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Widget List.ipynb
+++ b/examples/Widget List.ipynb
@@ -621,21 +621,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/examples/Widget Styling.ipynb
+++ b/examples/Widget Styling.ipynb
@@ -63,8 +63,7 @@
     "\n",
     "- width  \n",
     "- height  \n",
-    "- fore_color  \n",
-    "- back_color  \n",
+    "- background_color  \n",
     "- border_color  \n",
     "- border_width  \n",
     "- border_style  \n",
@@ -109,7 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To display widget A inside widget B, widget A must be a child of widget B.  Widgets that can contain other widgets have a **`children` attribute**.  This attribute can be **set via a keyword argument** in the widget's constructor **or after construction**.  Calling display on an **object with children automatically displays those children**, too."
+    "To display widget A inside widget B, widget A must be a child of widget B.  Widgets that can contain other widgets have a `children` attribute.  This attribute can be set via a keyword argument in the widget's constructor or after construction.  Calling display on an object with children automatically displays the children."
    ]
   },
   {
@@ -147,7 +146,7 @@
     }
    },
    "source": [
-    "Children **can be added to parents** after the parent has been displayed.  The **parent is responsible for rendering its children**."
+    "Children can be added to parents after the parent has been displayed.  The parent is responsible for rendering its children."
    ]
   },
   {
@@ -183,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you need to display a more complicated set of widgets, there are **specialized containers** that you can use.  To display **multiple sets of widgets**, you can use an **`Accordion` or a `Tab` in combination with one `Box` per set of widgets** (as seen below).  The \"pages\" of these widgets are their children.  To set the titles of the pages, one can **call `set_title`**."
+    "If you need to display a more complicated set of widgets, there are specialized containers that you can use.  To display multiple sets of widgets, you can use an `Accordion` or a `Tab` in combination with one `Box` per set of widgets (as seen below).  The \"pages\" of these widgets are their children.  To set the titles of the pages, use `set_title`."
    ]
   },
   {
@@ -265,9 +264,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most widgets have a **`description` attribute**, which allows a label for the widget to be defined.\n",
-    "The label of the widget **has a fixed minimum width**.\n",
-    "The text of the label is **always right aligned and the widget is left aligned**:"
+    "Most widgets have a `description` attribute, which allows a label for the widget to be defined.\n",
+    "The label of the widget has a fixed minimum width.\n",
+    "The text of the label is always right aligned and the widget is left aligned:"
    ]
   },
   {
@@ -291,7 +290,7 @@
     }
    },
    "source": [
-    "If a **label is longer** than the minimum width, the **widget is shifted to the right**:"
+    "If a label is longer than the minimum width, the widget is shifted to the right:"
    ]
   },
   {
@@ -316,7 +315,7 @@
     }
    },
    "source": [
-    "If a `description` is **not set** for the widget, the **label is not displayed**:"
+    "If a `description` is not set for the widget, the label is not displayed:"
    ]
   },
   {
@@ -396,7 +395,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To make widgets display horizontally, you need to **child them to a `HBox` widget**."
+    "To make widgets display horizontally, they can be children of an `HBox` widget."
    ]
   },
   {
@@ -445,8 +444,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sometimes it is necessary to **hide or show widgets** in place, **without having to re-display** the widget.\n",
-    "The `visible` property of widgets can be used to hide or show **widgets that have already been displayed** (as seen below).  The `visible` property can be:\n",
+    "The `visible` property of widgets can be used to hide or show widgets that have already been displayed (as seen below).  The `visible` property can be:\n",
     "* `True` - the widget is displayed\n",
     "* `False` - the widget is hidden, and the empty space where the widget would be is collapsed\n",
     "* `None` - the widget is hidden, and the empty space where the widget would be is shown"
@@ -563,21 +561,21 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/Widget Styling.ipynb
+++ b/examples/Widget Styling.ipynb
@@ -561,21 +561,21 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is some light editing of the notebooks, correcting grammar, making the narrative flow better, checking examples, etc.

I'm not done yet!

- [ ] In the Custom Widget notebook, the very last cell, clicking on the spinner up/down arrows updates the spinner, but not the slider, until the spinner loses focus (in Chrome, for me).  When the spinner loses focus (i.e., the change event fires?), then the slider is updated...
- [ ] In the Widget Styling notebook, the container.pack example does not center the buttons like it says it will.