### PR TITLE
Use 'here' rather than 'path' in find_static_assets

### DIFF
--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -7,7 +7,7 @@ from .widgets import *
 def find_static_assets():
     """Return the path to static assets for widgets (js, css)"""
     here = os.path.abspath(__file__)
-    return os.path.join(os.path.dirname(path), 'static')
+    return os.path.join(os.path.dirname(here), 'static')
 
 
 def load_ipython_extension(ip):
@@ -39,7 +39,7 @@ _handle_ipython()
 # Workaround for the absence of a comm_info_[request/reply] shell message
 class CommInfo(Widget):
     """CommInfo widgets are is typically instantiated by the front-end. As soon as it is instantiated, it sends the collection of valid comms, and kills itself. It is a workaround to the absence of comm_info shell message."""
-    
+
     def __init__(self, **kwargs):
         super(CommInfo, self).__init__(**kwargs)
         self.send(dict(comms={


### PR DESCRIPTION
I installed ipywidgets, but Jupyter notebook still said `ipywidgets package not installed.  Widgets are unavailable.` [This block of code][1] in `notebook/notebook/notebookapp.py` throws the error. I figured the path returned by `find_static_assets` might be messed up, so I ran it in a python terminal:

```python
>>> import ipywidgets
>>> ipywidgets.find_static_assets()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jkersulis/Documents/ipywidgets/ipywidgets/__init__.py", line 10, in find_static_assets
    return os.path.join(os.path.dirname(path), 'static')
NameError: global name 'path' is not defined
```

It looks like the problem is that [`find_static_assets`][2] stores part of the proper path in a variable called `here` but tries to reference `path` (which is undefined) in the next line instead. When I changed `path` to `here`, Jupyter notebook started recognizing that ipywidgets was installed, and I could make buttons and such.

I am not familiar with this repository, so please correct me if this proposed change is misguided.

[1]: https://github.com/jupyter/notebook/blob/master/notebook/notebookapp.py#L242
[2]: https://github.com/ipython/ipywidgets/blob/master/ipywidgets/__init__.py#L7