### PR TITLE
Update custom widget example

### DIFF
--- a/examples/Custom Widget - Hello World.ipynb
+++ b/examples/Custom Widget - Hello World.ipynb
@@ -237,7 +237,7 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
     "    \n",
     "});"
    ]
@@ -269,7 +269,7 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
     "    \n",
     "    // Define the HelloView\n",
     "    var HelloView = widget.DOMWidgetView.extend({\n",
@@ -308,7 +308,7 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
     "    \n",
     "    var HelloView = widget.DOMWidgetView.extend({\n",
     "        \n",
@@ -427,7 +427,7 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
     "    \n",
     "    var HelloView = widget.DOMWidgetView.extend({\n",
     "        \n",
@@ -467,7 +467,7 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
     "    \n",
     "    var HelloView = widget.DOMWidgetView.extend({\n",
     "        \n",
@@ -603,7 +603,7 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
     "    \n",
     "    var SpinnerView = widget.DOMWidgetView.extend({\n",
     "        \n",
@@ -656,10 +656,9 @@
    "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"widgets/js/widget\", \"widgets/js/manager\"], function(widget, manager){\n",
-    "    \n",
+    "require([\"nbextensions/widgets/widgets/js/widget\", \"nbextensions/widgets/widgets/js/manager\"], function(widget, manager){\n",
+    "\n",
     "    var SpinnerView = widget.DOMWidgetView.extend({\n",
-    "        \n",
     "        render: function(){ \n",
     "\n",
     "            var that = this;\n",
@@ -667,10 +666,11 @@
     "            this.$el.append(this.$input);\n",
     "            this.$spinner = this.$input.spinner({\n",
     "                change: function( event, ui ) {\n",
-    "                    that.handle_spin();\n",
+    "                    that.handle_spin(that.$spinner.spinner('value'));\n",
     "                },\n",
     "                spin: function( event, ui ) {\n",
-    "                    that.handle_spin();\n",
+    "                    //ui.value is the new value of the spinner\n",
+    "                    that.handle_spin(ui.value);\n",
     "                }\n",
     "            });\n",
     "            \n",
@@ -682,8 +682,8 @@
     "            this.$spinner.spinner('value', this.model.get('value'));\n",
     "        },\n",
     "        \n",
-    "        handle_spin: function() {\n",
-    "            this.model.set('value', this.$spinner.spinner('value'));\n",
+    "        handle_spin: function(value) {\n",
+    "            this.model.set('value', value);\n",
     "            this.touch();\n",
     "        },\n",
     "    });\n",


### PR DESCRIPTION
1. Correct javascript paths to the non-deprecated paths
2. Fix a bug where the spinner spin handler did not use the new value of the spinner, but instead used the old (current) value.