### PR TITLE
Delete container.pack example that doesn't work

### DIFF
--- a/examples/Widget Styling.ipynb
+++ b/examples/Widget Styling.ipynb
@@ -412,25 +412,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By setting the width of the container to 100% and its `pack` to `center`, you can center the buttons."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "container.width = '100%'\n",
-    "container.pack = 'center'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"


### PR DESCRIPTION
@jdfreder reports that it didn't work in IPython 3.x either.

"Fixes" #126 