### PR TITLE
Rst version of the README linking to Index.ipynb for the examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,17 @@
+.. image:: https://img.shields.io/pypi/v/ipywidgets.svg
+   :target: https://pypi.python.org/pypi/ipywidgets/
+   :alt: Version Number
+
+.. image:: https://img.shields.io/pypi/dm/ipywidgets.svg
+   :target: https://pypi.python.org/pypi/ipywidgets/
+   :alt: Number of PyPI downloads
+
+Interactive HTML Widgets
+========================
+
+Interactive HTML widgets for Jupyter notebooks and the IPython kernel.
+
+Usage
+=====
+
+See the `example notebooks <https://github.com/ipython/ipywidgets/blob/v4.0.2/examples/Index.ipynb>`_.


### PR DESCRIPTION
pypipins seems to be [down](https://github.com/badges/pypipins/issues/37).

I am using shields.io instead. The link goes to the tag to be created.

I am leveraging github's ability to render ipynb by linking to the Index.ipynb notebook.