### PR TITLE
Fixes to Accordion widget

### DIFF
--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -77,9 +77,9 @@ define([
             if (options === undefined || options.updated_view != this) {
                 var old_index = this.model.previous('selected_index');
                 var new_index = this.model.get('selected_index');
-                this.containers[old_index].find('.panel-collapse').collapse('hide');
+                this.containers[old_index].children('.panel-collapse').collapse('hide');
                 if (0 <= new_index && new_index < this.containers.length) {
-                    this.containers[new_index].find('.panel-collapse').collapse('show');
+                    this.containers[new_index].children('.panel-collapse').collapse('show');
                 }
             }
         },

--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -77,7 +77,11 @@ define([
             if (options === undefined || options.updated_view != this) {
                 var old_index = this.model.previous('selected_index');
                 var new_index = this.model.get('selected_index');
-                this.containers[old_index].children('.panel-collapse').collapse('hide');
+                /* old_index can be out of bounds, this check avoids raising
+                   a (hrmless) javascript error. */
+                if (0 <= old_index && old_index < this.containers.length) {
+                    this.containers[old_index].children('.panel-collapse').collapse('hide');
+                }
                 if (0 <= new_index && new_index < this.containers.length) {
                     this.containers[new_index].children('.panel-collapse').collapse('show');
                 }

--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -62,7 +62,7 @@ define([
                 var accordian = that.containers[page_index];
                 if (accordian !== undefined) {
                     accordian
-                        .find('.panel-heading')
+                        .children('.panel-heading')
                         .find('.accordion-toggle')
                         .text(title);
                 }


### PR DESCRIPTION
There are a couple of issues that come up if you try nesting accordion widgets:

+ The title of an accordion widget panel containing an accordion widget gets applied to all panels of that sub-accordion widget.
+ When an accordion widget panel containing an accordion widget gets opened, all panels of the sub-accordion widget also get opened.

This PR fixes those issues and checks with an index is in range before trying to close it when the `selected_index` is updated. That silences a couple of javascript errors that otherwise occur if you set `selected_index=-1` when you create the widget start the widget with all panels closed.

I wasn't sure how to test this sort of thing so no tests are included....happy to add them if you want.

I'll add a couple screenshots in a moment and a link to a sample notebook that demonstrates the problem.
 