### PR TITLE
Call correct superclass in AccordionView

### DIFF
--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -49,7 +49,7 @@ define([
         update: function(options) {
             this.update_titles();
             this.update_selected_index(options);
-            return TabView.__super__.update.apply(this);
+            return AccordionView.__super__.update.apply(this);
         },
 
         update_titles: function() {


### PR DESCRIPTION
I assume `AccordionView` is supposed to call its `__super__`, not that of `TabView`, on `update`.

I'm not sure this actually causes any issues, since `TabView` and `AccordionView` both subclass the same thing, but noticed it when I tried cutting out the `TabView` part of the code to backport accordion changes for reducer. 