### PR TITLE
Add __version__ to ipywidgets package

### DIFF
--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from IPython import get_ipython
+from ._version import version_info, __version__
 from .widgets import *
 
 


### PR DESCRIPTION
Just noticed that `ipywidgets__version__` does not work. Has this a particular reason?

So added it to `__init__.py` like this is also done in `ipykernel`