### PR TITLE
Fixes flickering on interact

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -218,7 +218,8 @@ def interactive(__interact_f, **kwargs):
             manual_button.disabled = True
         try:
             container.result = f(**container.kwargs)
-            display(container.result)
+            if container.result is not None:
+                display(container.result)
         except Exception as e:
             ip = get_ipython()
             if ip is None:
@@ -316,7 +317,8 @@ def interact(__interact_f=None, **kwargs):
             # so wrap in a lambda
             f = lambda *args, **kwargs: __interact_f(*args, **kwargs)
             f.widget = w
-        display(w)
+        if w is not None:
+            display(w)
         return f
     else:
         # This branch handles the case 3

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -411,6 +411,22 @@ def test_call_interact():
     )
 
 @nt.with_setup(clear_display)
+def test_call_interact_on_trait_changed_none_return():
+    def foo(a='default'):
+        pass
+    with patch.object(interaction, 'display', record_display):
+        ifoo = interact(foo)
+    nt.assert_equal(len(displayed), 1)
+    w = displayed[0].children[0]
+    check_widget(w,
+        cls=widgets.Text,
+        value='default',
+    )
+    with patch.object(interaction, 'display', record_display):
+        w.value = 'called'
+    nt.assert_equal(len(displayed), 1)
+
+@nt.with_setup(clear_display)
 def test_call_interact_kwargs():
     def foo(a='default'):
         pass
@@ -444,8 +460,11 @@ def test_call_decorated_on_trait_change():
     nt.assert_equal(d['a'], 'hello')
     
     # test that setting trait values calls the function
-    w.value = 'called'
+    with patch.object(interaction, 'display', record_display):
+        w.value = 'called'
     nt.assert_equal(d['a'], 'called')
+    nt.assert_equal(len(displayed), 2)
+    nt.assert_equal(w.value, displayed[-1])
 
 @nt.with_setup(clear_display)
 def test_call_decorated_kwargs_on_trait_change():
@@ -468,8 +487,13 @@ def test_call_decorated_kwargs_on_trait_change():
     nt.assert_equal(d['a'], 'hello')
     
     # test that setting trait values calls the function
-    w.value = 'called'
+    with patch.object(interaction, 'display', record_display):
+        w.value = 'called'
     nt.assert_equal(d['a'], 'called')
+    nt.assert_equal(len(displayed), 2)
+    nt.assert_equal(w.value, displayed[-1])
+
+
 
 def test_fixed():
     c = interactive(f, a=widgets.fixed(5), b='text')


### PR DESCRIPTION
This change makes it so that the return value of a callback function is only displayed if it is not None.  This solves the problem of flickering output due to the display of multiple items.  Closes #145 