### PR TITLE
Better handling of nested widgets

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -14,7 +14,7 @@ from inspect import getcallargs
 from IPython.core.getipython import get_ipython
 from . import (Widget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
-    Box, Button, DOMWidget, widget_box)
+    Box, Button, DOMWidget)
 from IPython.display import display, clear_output
 from ipython_genutils.py3compat import string_types, unicode_type
 from traitlets import HasTraits, Any, Unicode
@@ -218,7 +218,7 @@ def interactive(__interact_f, **kwargs):
             manual_button.disabled = True
         try:
             def close_result_widgets(w):
-                if type(w.result) is widget_box.Box:
+                if type(w.result) is Box:
                     close_result_widgets(w.result)
                     w.result.close()
             close_result_widgets(container)

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -14,7 +14,7 @@ from inspect import getcallargs
 from IPython.core.getipython import get_ipython
 from . import (Widget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
-    Box, Button, DOMWidget)
+    Box, Button, DOMWidget, widget_box)
 from IPython.display import display, clear_output
 from ipython_genutils.py3compat import string_types, unicode_type
 from traitlets import HasTraits, Any, Unicode
@@ -217,6 +217,11 @@ def interactive(__interact_f, **kwargs):
         if manual:
             manual_button.disabled = True
         try:
+            def close_result_widgets(w):
+                if type(w.result) is widget_box.Box:
+                    close_result_widgets(w.result)
+                    w.result.close()
+            close_result_widgets(container)
             container.result = f(**container.kwargs)
             if container.result is not None:
                 display(container.result)


### PR DESCRIPTION
I've run into situations where it'd be nice to start with one widget, and use the value of that widget to dynamically generate another widget. Unfortunately, when the outer widget changes, it leaves all of the previous widgets it created, which quickly becomes unmanageable.  Basically I'd like something similar to the `clear_output` keyword, but which also clears any widgets within the result of a widget.

(For a basic example of what I mean, check out: https://gist.github.com/egentry/f3f28130162d60c97b59)

In the past I got around this in hackish ways, but others might appreciate a clean fix.

Some thoughts / questions:
- Should this be triggered by a keyword (in the same way `interactive` uses `clear_output`)?
- Would this be better fixed in `clear_output()` (although it'd need to know which widgets to save and which to clear)
- This results in flickering, since it doesn't wait for a new widget to be created. I could look into that, but no promises that I'll find a good solution
- Does this break anyone's own use cases? Are there behaviors I'm not thinking about?
  - Will linked widgets (e.g. via `traitlets.jslink`) be a problem if one of the linked widgets disappears and is replaced by a new widget?  (If this PR seems useful, I can test some of those situations)