### PR TITLE
Remove workaround for comm_info message

### DIFF
--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -35,24 +35,3 @@ def _handle_ipython():
     load_ipython_extension(ip)
 
 _handle_ipython()
-
-
-# Workaround for the absence of a comm_info_[request/reply] shell message
-class CommInfo(Widget):
-    """CommInfo widgets are is typically instantiated by the front-end.
-
-    As soon as it is instantiated, it sends the collection of valid comms, and
-    kills itself. It is a workaround to the absence of comm_info shell
-    message.
-    """
-
-    def __init__(self, **kwargs):
-        super(CommInfo, self).__init__(**kwargs)
-        target_name = 'ipython.widget'
-        comms = {
-            k: dict(target_name=v.target_name)
-            for (k, v) in self.comm.kernel.comm_manager.comms.items()
-            if v is not self.comm and (v.target_name == target_name or target_name is None)
-        }
-        self.send(dict(comms=comms))
-        self.close()

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -266,30 +266,13 @@ define([
 
     WidgetManager.prototype._get_comm_info = function() {
         /**
-         * Gets a promise for the open comms in the backend
+         * Gets a promise for the valid widget models.
          */
-
-        // Version using the comm_list_[request/reply] shell message.
-        /*var that = this;
-        return new Promise(function(resolve, reject) {
-             kernel.comm_info(function(msg) {
-                 resolve(msg['content']['comms']);
-             });
-        });*/
-
-        // Workaround for absence of comm_list_[request/reply] shell message.
-        // Create a new widget that gives the comm list and commits suicide.
         var that = this;
         return this._get_connected_kernel().then(function(kernel) {
             return new Promise(function(resolve, reject) {
-                var comm = kernel.comm_manager.new_comm('ipython.widget',
-                                    {'widget_class': 'ipywidgets.CommInfo'},
-                                    'comm_info');
-                comm.on_msg(function(msg) {
-                    var data = msg.content.data;
-                    if (data.content && data.method === 'custom') {
-                        resolve(data.content.comms);
-                    }
+                kernel.comm_info('ipython.widget', function(msg) {
+                    resolve(msg['content']['comms']);
                 });
             });
         });

--- a/setup.py
+++ b/setup.py
@@ -279,10 +279,10 @@ if 'setuptools' in sys.modules:
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'ipython>=4.0.0dev0',
-    'ipykernel',
+    'ipython>=4.0.0',
+    'ipykernel>=4.2.0',
     'traitlets',
-    'notebook',
+    'notebook>=4.1.0b1',
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
This depends on versions of jupyter_client, ipykernel and notebook including the following changes

jupyter/jupyter_client#34 *merged*
ipython/ipykernel#25 *merged*
jupyter/notebook#166, *merged*

This now only requires the notebook 4.1 to be released.