### PR TITLE
Fix OutputWidget

### DIFF
--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -11,6 +11,7 @@ import sys
 from traitlets import Unicode, List
 from IPython.display import clear_output
 from jupyter_client.session import Message
+from IPython import get_ipython
 
 class Output(DOMWidget):
     """Widget used as a context manager to display output.


### PR DESCRIPTION
Import get_ipython() since it is no longer available globally.

closes #134