### PR TITLE
Stricter LESS and Bower versions,

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "bower": "^1.5.3",
-    "clean-css": "*",
+    "clean-css": "^3.4.6",
     "less": "^2.5.3",
     "rimraf": "^2.4.1",
     "spawn-sync": "*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "npm run css && npm run buildtests",
-    "bower": "bower install",
+    "bower": "bower install --config.interactive=false",
     "precss": "rimraf ./ipywidgets/static/widgets/css/",
     "css": "node build_css.js",
     "prebuildtests": "rimraf ./ipywidgets/tests/bin/tests",
@@ -18,9 +18,9 @@
     "prepublish": "npm run bower && npm run build"
   },
   "devDependencies": {
-    "bower": "*",
+    "bower": "^1.5.3",
     "clean-css": "*",
-    "less": "~2",
+    "less": "^2.5.3",
     "rimraf": "^2.4.1",
     "spawn-sync": "*",
     "typescript": "~1.5.0-beta"


### PR DESCRIPTION
and make sure bower is ran silently

closes #143 

@SylvainCorlay @minrk I think this may fix some install problems that people were having.  Bower now prompts for anonymous data collection, which will halt automated build scripts, and halted my `npm install`.  The ` --config.interactive=false` skips this.