### PR TITLE
Add `continuous_update` flag to the sliders,

### DIFF
--- a/ipywidgets/static/widgets/js/widget_int.js
+++ b/ipywidgets/static/widgets/js/widget_int.js
@@ -173,7 +173,8 @@ define([
         
         events: {
             // Dictionary of events and their handlers.
-            "slide" : "handleSliderChange",
+            "slide": "handleSliderChange",
+            "stop": "handleSliderChanged",
             "blur [contentEditable=true]": "handleTextChange",
             "keydown [contentEditable=true]": "handleKeyDown"
         }, 
@@ -253,13 +254,22 @@ define([
 
         _range_regex: /^\s*([+-]?\d+)\s*[-:]\s*([+-]?\d+)/,
 
+        /**
+         * Called when the slider value is changing.
+         */
         handleSliderChange: function(e, ui) { 
-            /**
-             * Called when the slider value is changed.
-             *
-             * Calling model.set will trigger all of the other views of the 
-             * model to update.
-             */
+            if (this.model.get('continuous_update')) {
+                this.handleSliderChanged(e, ui);
+            }            
+        },
+        
+        /**
+         * Called when the slider value has changed.
+         *
+         * Calling model.set will trigger all of the other views of the 
+         * model to update.
+         */
+        handleSliderChanged: function(e, ui) {
             var actual_value;
             if (this.model.get("_range")) {
                 actual_value = ui.values.map(this._validate_slide_value);

--- a/ipywidgets/static/widgets/js/widget_int.js
+++ b/ipywidgets/static/widgets/js/widget_int.js
@@ -174,7 +174,7 @@ define([
         events: {
             // Dictionary of events and their handlers.
             "slide": "handleSliderChange",
-            "stop": "handleSliderChanged",
+            "slidestop": "handleSliderChanged",
             "blur [contentEditable=true]": "handleTextChange",
             "keydown [contentEditable=true]": "handleKeyDown"
         }, 
@@ -258,6 +258,17 @@ define([
          * Called when the slider value is changing.
          */
         handleSliderChange: function(e, ui) { 
+            var actual_value;
+            if (this.model.get("_range")) {
+                actual_value = ui.values.map(this._validate_slide_value);
+                this.$readout.text(actual_value.join("-"));
+            } else {
+                actual_value = this._validate_slide_value(ui.value);
+                this.$readout.text(actual_value);
+            }
+            
+            // Only persist the value while sliding if the continuous_update
+            // trait is set to true.
             if (this.model.get('continuous_update')) {
                 this.handleSliderChanged(e, ui);
             }            
@@ -273,10 +284,8 @@ define([
             var actual_value;
             if (this.model.get("_range")) {
                 actual_value = ui.values.map(this._validate_slide_value);
-                this.$readout.text(actual_value.join("-"));
             } else {
                 actual_value = this._validate_slide_value(ui.value);
-                this.$readout.text(actual_value);
             }
             this.model.set('value', actual_value, {updated_view: this});
             this.touch();

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -124,6 +124,7 @@ class FloatSlider(_BoundedFloat):
     _range = Bool(False, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
     slider_color = Color(None, allow_none=True, sync=True)
+    continuous_update = Bool(True, sync=True, help="Update the value of the widget as the user is sliding the slider.")
 
 
 @register('IPython.FloatProgress')
@@ -280,3 +281,4 @@ class FloatRangeSlider(_BoundedFloatRange):
     _range = Bool(True, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
     slider_color = Color(None, allow_none=True, sync=True)
+    continuous_update = Bool(True, sync=True, help="Update the value of the widget as the user is sliding the slider.")

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -78,6 +78,7 @@ class IntSlider(_BoundedInt):
     _range = Bool(False, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
     slider_color = Color(None, allow_none=True, sync=True)
+    continuous_update = Bool(True, sync=True, help="Update the value of the widget as the user is sliding the slider.")
 
 
 @register('IPython.IntProgress')
@@ -192,3 +193,4 @@ class IntRangeSlider(_BoundedIntRange):
     _range = Bool(True, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
     slider_color = Color(None, allow_none=True, sync=True)
+    continuous_update = Bool(True, sync=True, help="Update the value of the widget as the user is sliding the slider.")


### PR DESCRIPTION
This adds a `continuous_update` flag to the int and float range/single sliders. The flag allows you to set whether or not the sliders update as they are being dragged.

Example:
```python
from ipywidgets import *
from IPython.display import display
i = IntSlider(continuous_update=False)
display(i)

def handle(key, value):
    print value
i.on_trait_change(handle, 'value')
```

Drag the slider, observe that the readout changes, but the value doesn't print until released.

closes #160 