### PR TITLE
Add `ready` event which fires when the widget receives its first state

### DIFF
--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -56,6 +56,7 @@ define(["nbextensions/widgets/widgets/js/manager",
             this.msg_buffer = null;
             this.state_lock = null;
             this.id = model_id;
+            this._first_state = true;
 
             // Force backbone to think that the model has already been
             // synced with the server.  As of backbone 1.1, backbone
@@ -223,6 +224,10 @@ define(["nbextensions/widgets/widgets/js/manager",
             // Handle when a widget is updated via the python side.
             this.state_lock = state;
             try {
+                if (this._first_state) {
+                    this.trigger('ready', this);
+                    this._first_state = false;
+                }
                 WidgetModel.__super__.set.call(this, state);
             } finally {
                 this.state_lock = null;

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -224,11 +224,11 @@ define(["nbextensions/widgets/widgets/js/manager",
             // Handle when a widget is updated via the python side.
             this.state_lock = state;
             try {
+                WidgetModel.__super__.set.call(this, state);
                 if (this._first_state) {
                     this.trigger('ready', this);
                     this._first_state = false;
                 }
-                WidgetModel.__super__.set.call(this, state);
             } finally {
                 this.state_lock = null;
             }


### PR DESCRIPTION
@SylvainCorlay can you verify that this is the event you want?  It should fire on all paths **exept**, and by-design, `new_model`.  The higher level `new_widget` function will fire it, once the state has been received.  Additionally, Python instantiated widgets will fire it.

closes #71 