### PR TITLE
Search for css selectors using the parent element

### DIFF
--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -665,7 +665,8 @@ define(["nbextensions/widgets/widgets/js/manager",
             for (var i = 0; i < css.length; i++) {
                 // Apply the css traits to all elements that match the selector.
                 var selector = css[i][0];
-                var elements = this.el.querySelectorAll(selector) || [this.el];
+                var parent = this.el.parentElement
+                var elements = parent.querySelectorAll(selector) || [this.el];
                 if (elements.length > 0) {
                     var trait_key = css[i][1];
                     var trait_value = css[i][2];


### PR DESCRIPTION
Perhaps I was using the `_css` property incorrectly and this is unnecessary, but I think this is needed to allow setting of custom css via `_css`.

This notebook illustrates the issue: https://gist.github.com/5155b92539f0e9a6deeb

On the current master branch of ipywidgets, this outputs 'hello!' in black. With this PR, it outputs in red.