### PR TITLE
Fix button width issue

### DIFF
--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -11,12 +11,12 @@ define([
 ], function(widget, $){
 
     var ButtonView = widget.DOMWidgetView.extend({
-        render : function(){
+        render: function() {
             /**
              * Called when view is rendered.
              */
             this.setElement($("<button />")
-                .addClass('btn btn-default'));
+                .addClass('widget-button btn btn-default'));
             this.$el.attr("data-toggle", "tooltip");
             this.listenTo(this.model, 'change:button_style', function(model, value) {
                 this.update_button_style();
@@ -26,7 +26,7 @@ define([
             this.update(); // Set defaults.
         },
         
-        update : function(){
+        update: function() {
             /**
              * Update the contents of this view
              *
@@ -64,7 +64,7 @@ define([
             'click': '_handle_click',
         },
         
-        _handle_click: function(){
+        _handle_click: function() {
             /**
              * Handles when the button is clicked.
              */

--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -10,7 +10,7 @@
 @import "./flexbox.less";
 @import "./mixins.less";
 
-@widget-width: 350px;
+@widget-width: 300px;
 @widget-width-short: 150px;
 
 // Pad interact widgets by default.
@@ -176,6 +176,11 @@
             margin-left : -1px;
         }
     }
+}
+
+.widget-button {
+    /* Button */
+    width         : @widget-width-short;
 }
 
 .widget-text {


### PR DESCRIPTION
- add a semantic css class to the button
- style the button to use widget-width-short by default
- as suggested by Brian make widget-width 300px so that the short width is half the default width. (These two values will have to be adjusted when we add margin to non-container widgets.)