### PR TITLE
Cleaning up the padding/margin on the widget-subarea

### DIFF
--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -43,8 +43,7 @@
     .hbox();
 
     .widget-subarea {
-        padding     : 0.44em 0.4em 0.4em 1px;
-        margin-left : 6px;
+        padding     : 0.4em 0 0.4em 0;
 
         .border-box-sizing();
         .box-flex2();


### PR DESCRIPTION
Widgets are now left aligned with cells:

<img width="981" alt="screen shot 2015-10-29 at 2 53 53 pm" src="https://cloud.githubusercontent.com/assets/27600/10828831/1a49ba70-7e4d-11e5-96c9-0af5c7bb7ee8.png">
