### PR TITLE
Defining border-radius-base

### DIFF
--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -12,6 +12,7 @@
 
 @widget-width: 300px;
 @widget-width-short: 150px;
+@border-radius-base: 2px;
 
 // Pad interact widgets by default.
 .widget-interact {


### PR DESCRIPTION
Wasn't defined so the border radii were picking up 4px rather than our current 2px. This was causing sliders to have roundy corners. This makes them sharp 2px again.