### PR TITLE
WIP: Use flexible model everywhere

### DIFF
--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -608,6 +608,32 @@ define(["nbextensions/widgets/widgets/js/utils",
             this.listenTo(this.model, 'change:border_radius', function (model, value) { 
                 this.update_attr('border-radius', this._default_px(value)); }, this);
 
+            // New flexible box model state added in ipywidgets 5.0
+            this.listenTo(this.model, 'change:order', function(model, value) {
+                this.update_attr('order', value);
+            }, this);
+            
+            this.listenTo(this.model, 'change:grow', function(model, value) {
+                this.update_attr('flex-grow', value);
+            }, this);
+            
+            this.listenTo(this.model, 'change:shrink', function(model, value) {
+                this.update_attr('flex-shrink', value);
+            }, this);
+            
+            this.listenTo(this.model, 'change:basis', function(model, value) {
+                this.update_attr('flex-basis', value);
+            }, this);
+            
+            this.listenTo(this.model, 'change:flex', function(model, value) {
+                this.update_attr('flex', value);
+            }, this);
+            
+            this.listenTo(this.model, 'change:align_self', function(model, value) {
+                this.update_attr('align-self', value);
+            }, this);
+            
+
             this.displayed.then(_.bind(function() {
                 this.update_visible(this.model, this.model.get("visible"));
                 this.update_classes([], this.model.get('_dom_classes'));
@@ -626,6 +652,14 @@ define(["nbextensions/widgets/widgets/js/utils",
                 this.update_attr('padding', this._default_px(this.model.get('padding')));
                 this.update_attr('margin', this._default_px(this.model.get('margin')));
                 this.update_attr('border-radius', this._default_px(this.model.get('border_radius')));
+                
+                // New flexible box model state added in ipywidgets 5.0
+                this.update_attr('order', this.model.get('order'));
+                this.update_attr('flex-grow', this.model.get('grow'));
+                this.update_attr('flex-shrink', this.model.get('shrink'));
+                this.update_attr('flex-basis', this.model.get('basis'));
+                this.update_attr('flex', this.model.get('flex'));
+                this.update_attr('align-self', this.model.get('align_self'));
 
                 this.update_css(this.model, this.model.get("_css"));
             }, this));

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -36,7 +36,7 @@ define([
 
         render: function() {
             var that = this;
-            var child_view = this.set_child(this.model.get("child"))
+            var child_view = this.set_child(this.model.get("child"));
             this.listenTo(this.model, "change:child", function(model, value) {
                 this.set_child(value);
             });
@@ -105,6 +105,19 @@ define([
             this.listenTo(this.model, 'change:overflow_x', this.update_overflow_x, this);
             this.listenTo(this.model, 'change:overflow_y', this.update_overflow_y, this);
             this.listenTo(this.model, 'change:box_style', this.update_box_style, this);
+            
+            this.deprecationWarning();
+        },
+        
+        /**
+         * Warn when the user tries to use this view directly.
+         */
+        deprecationWarning: function() {
+            if (!BoxView.warned) {
+                BoxView.warned = true;
+                console.warn('BoxView will become FlexBoxView in ipywidgets 6.0 and ' +
+                    'FlexBoxView will be removed.');
+            }
         },
 
         update_attr: function(name, value) {
@@ -191,6 +204,24 @@ define([
             this._pack_changed();
             this._align_changed();
             this.update_orientation();
+            
+            // New properties for 5.0
+            this.listenTo(this.model, 'change:display', this.updateDisplay, this);
+            this.listenTo(this.model, 'change:wrap', this.updateWrap, this);
+            this.listenTo(this.model, 'change:justify', this.updateJustify, this);
+            this.updateDisplay();
+            this.updateWrap();
+            this.updateJustify();
+        },
+        
+        /**
+         * Warn that this view will be renamed.
+         */
+        deprecationWarning: function() {
+            if (!FlexBoxView.warned) {
+                FlexBoxView.warned = true;
+                console.warn('FlexBoxView will be renamed to BoxView in ipywidgets 6.0.');
+            }
         },
 
         update_orientation: function() {
@@ -222,6 +253,27 @@ define([
             }
             this.$box.addClass('align-' + this.model.get('align'));
         },
+
+        /**
+         * Called when the display state changes.
+         */
+        updateDisplay: function() {
+            this.$box.css('display', this.model.get('display'));
+        },
+
+        /**
+         * Called when the display state changes.
+         */
+        updateWrap: function() {
+            this.$box.css('flex-wrap', this.model.get('wrap'));
+        },
+
+        /**
+         * Called when the display state changes.
+         */
+        updateJustify: function() {
+            this.$box.css('justify-content', this.model.get('justify'));
+        }
     });
 
     return {

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -499,7 +499,23 @@ class DOMWidget(Widget):
         default_value='', sync=True)
     font_size = CUnicode(sync=True)
     font_family = Unicode(sync=True)
-
+    
+    # New flex properties added in 5.0
+    order = Int(sync=True, allow_none=True)
+    grow = Int(sync=True, allow_none=True)
+    shrink = Int(sync=True, allow_none=True)
+    basis = CUnicode(sync=True, allow_none=True)
+    flex = CUnicode(sync=True, allow_none=True)
+    align_self = CaselessStrEnum(values=[
+        'auto', 
+        'flex-start', 
+        'flex-end', 
+        'center', 
+        'baseline', 
+        'stretch'],
+        sync=True, allow_none=True)
+    
+    
     def __init__(self, *pargs, **kwargs):
         super(DOMWidget, self).__init__(*pargs, **kwargs)
 

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -14,7 +14,7 @@ from traitlets import Unicode, Tuple, Int, CaselessStrEnum, Instance
 class Box(DOMWidget):
     """Displays multiple widgets in a group."""
     _model_name = Unicode('BoxModel', sync=True)
-    _view_name = Unicode('BoxView', sync=True)
+    _view_name = Unicode('FlexBoxView', sync=True)
 
     # Child widgets in the container.
     # Using a tuple here to force reassignment to update the list.
@@ -35,6 +35,33 @@ class Box(DOMWidget):
         values=['success', 'info', 'warning', 'danger', ''],
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the box.""")
+        
+    orientation = CaselessStrEnum(values=['vertical', 'horizontal'], default_value='vertical', sync=True)
+    flex = Int(0, sync=True, help="""Specify the flexible-ness of the model.""")
+    def _flex_changed(self, name, old, new):
+        new = min(max(0, new), 2)
+        if self.flex != new:
+            self.flex = new
+
+    _locations = ['start', 'center', 'end', 'baseline', 'stretch']
+    pack = CaselessStrEnum(
+        values=_locations,
+        default_value='start', sync=True)
+    align = CaselessStrEnum(
+        values=_locations,
+        default_value='start', sync=True)
+        
+    display = CaselessStrEnum(
+        values=['flex', 'inline-flex'],
+        sync=True, allow_none=True)
+    
+    wrap = CaselessStrEnum(
+        values=['nowrap', 'wrap', 'wrap-reverse'],
+        sync=True, allow_none=True)
+        
+    justify = CaselessStrEnum(
+        values=['flex-start', 'flex-end', 'center', 'space-between', 'space-around'],
+        sync=True, allow_none=True)
 
     def __init__(self, children = (), **kwargs):
         kwargs['children'] = children
@@ -73,33 +100,13 @@ class PlaceProxy(Proxy):
     selector = Unicode(sync=True)
 
 
-@register('IPython.FlexBox')
-class FlexBox(Box):
-    """Displays multiple widgets using the flexible box model."""
-    _view_name = Unicode('FlexBoxView', sync=True)
-    orientation = CaselessStrEnum(values=['vertical', 'horizontal'], default_value='vertical', sync=True)
-    flex = Int(0, sync=True, help="""Specify the flexible-ness of the model.""")
-    def _flex_changed(self, name, old, new):
-        new = min(max(0, new), 2)
-        if self.flex != new:
-            self.flex = new
-
-    _locations = ['start', 'center', 'end', 'baseline', 'stretch']
-    pack = CaselessStrEnum(
-        values=_locations,
-        default_value='start', sync=True)
-    align = CaselessStrEnum(
-        values=_locations,
-        default_value='start', sync=True)
-
-
 def VBox(*pargs, **kwargs):
     """Displays multiple widgets vertically using the flexible box model."""
     kwargs['orientation'] = 'vertical'
-    return FlexBox(*pargs, **kwargs)
+    return Box(*pargs, **kwargs)
 
 
 def HBox(*pargs, **kwargs):
     """Displays multiple widgets horizontally using the flexible box model."""
     kwargs['orientation'] = 'horizontal'
-    return FlexBox(*pargs, **kwargs)
+    return Box(*pargs, **kwargs)


### PR DESCRIPTION
- Add flexible box model traits to DOMWidget
- Add more container traits to FlexBox
- Renamed FlexBox to Box, remove old Box
- Deprecate FlexBoxView and warn BoxView changes

More specifically:
New to DOMWidget:
- order
- grow
- shrink
- basis
- flex
- align_self

New to Box:
- display
- wrap
- justify
- all properties from FlexBox

Partially addresses #206