### PR TITLE
Adding MD style button shading

### DIFF
--- a/ipywidgets/static/widgets/js/widget_bool.js
+++ b/ipywidgets/static/widgets/js/widget_bool.js
@@ -84,7 +84,7 @@ define([
              */
             var that = this;
             this.setElement($('<button />')
-                .addClass('ipy-widget widget-button btn btn-default')
+                .addClass('ipy-widget widget-toggle-button btn btn-default')
                 .attr('type', 'button')
                 .on('click', function (e) {
                     e.preventDefault();

--- a/ipywidgets/static/widgets/less/mixins.less
+++ b/ipywidgets/static/widgets/less/mixins.less
@@ -10,3 +10,15 @@
     border-radius: @border-radius-base;
 }
 
+// From Material Design Lite
+.outside-shadow-2dp() {
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, @shadow-key-penumbra-opacity),
+                0 3px 1px -2px rgba(0, 0, 0, @shadow-key-umbra-opacity),
+                0 1px 5px 0 rgba(0, 0, 0, @shadow-ambient-shadow-opacity);
+}
+
+.outside-shadow-4dp() {
+    box-shadow: 0 4px 5px 0 rgba(0, 0, 0, @shadow-key-penumbra-opacity),
+                0 1px 10px 0 rgba(0, 0, 0, @shadow-ambient-shadow-opacity),
+                0 2px 4px -1px rgba(0, 0, 0, @shadow-key-umbra-opacity);
+}

--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -14,6 +14,11 @@
 @widget-width-short: 148px;
 @border-radius-base: 2px;
 
+// From Material Design Lite
+@shadow-key-umbra-opacity: 0.2;
+@shadow-key-penumbra-opacity: 0.14;
+@shadow-ambient-shadow-opacity: 0.12;
+
 .ipy-widget {
     & {
         margin: 2px;
@@ -188,6 +193,55 @@
 .widget-button {
     /* Button */
     width : @widget-width-short;
+    
+    .outside-shadow-2dp();
+
+    &.btn,
+    &.btn:active,
+    &.btn:focus,
+    &.btn.hover {
+        outline: none !important;
+    }
+    
+    &.btn:active {
+        .outside-shadow-4dp();
+    }
+}
+
+.widget-toggle-button {
+    /* Button */
+    width : @widget-width-short;
+    
+    .outside-shadow-2dp();
+
+    &.btn,
+    &.btn:active,
+    &.btn:focus,
+    &.btn.hover {
+        outline: none !important;
+    }
+    
+    // &.btn:active {
+    //     .outside-shadow-4dp();
+    // }
+}
+
+.widget-toggle-buttons {
+
+    .btn,
+    .btn:active,
+    .btn:focus,
+    .btn.hover {
+        outline: none !important;
+    }
+    
+    .btn.active {
+        box-shadow: none !important;
+    }
+    
+    .btn-group {
+        .outside-shadow-2dp();
+    }
 }
 
 .widget-text {


### PR DESCRIPTION
Closes #214 

This applies a Material Design exterior shading to button so they look like buttons. I am not entirely happy with how this interplays with Bootstrap and also not happy with certain aspects of MD buttons. But this is better than before.

<img width="393" alt="screen shot 2015-11-01 at 6 46 03 pm" src="https://cloud.githubusercontent.com/assets/27600/10872101/284e06a2-80c9-11e5-9ae4-33f733151603.png">
