### PR TITLE
Download widget manager state

### DIFF
--- a/ipywidgets/static/widgets/js/init.js
+++ b/ipywidgets/static/widgets/js/init.js
@@ -6,6 +6,7 @@ define([
     "nbextensions/widgets/widgets/js/manager",
     "nbextensions/widgets/widgets/js/widget",
     "nbextensions/widgets/widgets/js/register",
+    "nbextensions/widgets/widgets/js/widget_state",
     "nbextensions/widgets/widgets/js/widget_link",
     "nbextensions/widgets/widgets/js/widget_bool",
     "nbextensions/widgets/widgets/js/widget_button",
@@ -19,10 +20,10 @@ define([
     "nbextensions/widgets/widgets/js/widget_selectioncontainer",
     "nbextensions/widgets/widgets/js/widget_string",
     "nbextensions/widgets/widgets/js/widget_controller",
-], function(IPython, widgetmanager, widget, register) {
+], function(IPython, widgetmanager, widget, register, state) {
     
     // Register all of the loaded models and views with the widget manager.
-    for (var i = 4; i < arguments.length; i++) {
+    for (var i = 5; i < arguments.length; i++) {
         var module = arguments[i];
         register.registerWidgets(module);
     }

--- a/ipywidgets/static/widgets/js/widget_state.js
+++ b/ipywidgets/static/widgets/js/widget_state.js
@@ -1,0 +1,31 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// npm compatibility
+if (typeof define !== 'function') { var define = require('./requirejs-shim')(module); }
+
+define(["base/js/namespace"], function(Jupyter) {
+    "use strict";
+
+    var save_state = function() {
+        Jupyter.WidgetManager._managers[0].get_state().then(function(state) {
+            var data = "text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(state, null, "    "));
+            var a = document.createElement("a");
+            a.download = "state.json";
+            a.href = "data:" + data;
+            a.click();
+        });
+    };
+
+    var load_extension = function() {
+        Jupyter.toolbar.add_buttons_group([{
+            id : 'widget_manager_state',
+            label : 'Download Widget State',
+            icon : 'fa-sliders',
+            callback : save_state
+        }]);
+    };
+
+    load_extension();
+
+});

--- a/ipywidgets/static/widgets/js/widget_state.js
+++ b/ipywidgets/static/widgets/js/widget_state.js
@@ -1,9 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// npm compatibility
-if (typeof define !== 'function') { var define = require('./requirejs-shim')(module); }
-
 define(["base/js/namespace"], function(Jupyter) {
     "use strict";
 
@@ -17,15 +14,15 @@ define(["base/js/namespace"], function(Jupyter) {
         });
     };
 
-    var load_extension = function() {
-        Jupyter.toolbar.add_buttons_group([{
-            id : 'widget_manager_state',
-            label : 'Download Widget State',
-            icon : 'fa-sliders',
-            callback : save_state
-        }]);
+    var action = {
+        help: 'Download Widget State',
+        icon: 'fa-sliders',
+        help_index : 'zz',
+        handler : save_state
     };
 
-    load_extension();
+    var action_name = 'save-widget-state';
+    var prefix = '';
+    Jupyter.notebook.keyboard_manager.actions.register(action, action_name, prefix);
 
 });


### PR DESCRIPTION
For now, this simply adds a button to download the widget manager state, but this should probably be in a menu. 

Looking at it, I realize that the widget manager has redundant information

```json
    "f7f010b9ef5f4352857009e34122f6e4": {
        "model_name": "LinearScaleModel",
        "model_module": "nbextensions/bqplot/LinearScaleModel",
        "state": {
            "_view_name": "LinearScale",
            "reverse": false,
            "msg_throttle": 3,
            "_model_name": "LinearScaleModel",
            "max": 1,
            "_view_module": "nbextensions/bqplot/LinearScale",
            "version": 0,
            "allow_padding": true,
            "min": 0,
            "_model_module": "nbextensions/bqplot/LinearScaleModel"
        },
        "views": []
    },
```

- The `views` property probably does not need to be there. Especially since it only contains the top-level views in cell output areas. 
- The `model_name` and `model_module`are both at the top level and in the `state` property.