### PR TITLE
Create loadClass method in widget manager to allow overloading

### DIFF
--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -63,6 +63,10 @@ define([
         throw new Error("Manager.display_view not implemented");
     };
 
+    ManagerBase.prototype.loadClass = function(class_name, module_name, registry) {
+        return utils.loadClass(class_name, module_name, registry);
+    };
+
     ManagerBase.prototype.create_view = function(model, options) {
         /**
          * Creates a promise for a view of a given model
@@ -70,9 +74,10 @@ define([
          * Make sure the view creation is not out of order with
          * any state updates.
          */
+        var that = this;
         model.state_change = model.state_change.then(function() {
 
-            return utils.loadClass(model.get('_view_name'), model.get('_view_module'),
+            return that.loadClass(model.get('_view_name'), model.get('_view_module'),
             ManagerBase._view_types).then(function(ViewType) {
 
                 // If a view is passed into the method, use that view's cell as
@@ -233,9 +238,9 @@ define([
         } else {
             throw new Error('Neither comm nor model_id provided in options object.  Atleast one must exist.');
         }
-        var model_promise = utils.loadClass(options.model_name,
-                                             options.model_module,
-                                             ManagerBase._model_types)
+        var model_promise = this.loadClass(options.model_name,
+                                           options.model_module,
+                                           ManagerBase._model_types)
             .then(function(ModelType) {
                 var widget_model = new ModelType(that, model_id, options.comm);
                 widget_model.once('comm:close', function () {


### PR DESCRIPTION
Since using custom widgets in static pages will require more shims, this allows overloading loadClass in specific implementations of the widget manager. 

All these should probably disappear when we switch to stealjs for everything, but for now, this allows me to transform module path strings...