### PR TITLE
Use backbone 1.2.0 to avoid backward-incompatible change between 1.2.0 and 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amdefine": "^1.0.0",
-    "backbone": "^1.2.3",
+    "backbone": "1.2.0",
     "bootstrap": "^3.3.5",
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",


### PR DESCRIPTION
The problem with 1.2.3 is that it deletes model ids by replacing them with the model state's `idAttribute`. This seems to have been solved in the dev version of backbone but the fix was not released yet.