### PR TITLE
Make _css stateful!

### DIFF
--- a/examples/development/web/manager.js
+++ b/examples/development/web/manager.js
@@ -5,6 +5,12 @@ var WidgetManager = exports.WidgetManager = function(el) {
     //  Call the base class.
     ipywidgets.ManagerBase.call(this);
     this.el = el;
+
+    // Create a style tag that will be used to apply stateful styling to the
+    // widgets.  Using a style tag allows us to clear/undo the styling.
+    this.styleTag = document.createElement('style');
+    this.styleTag.type = 'text/css';
+    document.querySelectorAll('body')[0].appendChild(this.styleTag);
 };
 WidgetManager.prototype = Object.create(ipywidgets.ManagerBase.prototype);
 
@@ -30,4 +36,12 @@ WidgetManager.prototype._create_comm = function(comm_target_name, model_id, meta
 
 WidgetManager.prototype._get_comm_info = function() {
     return Promise.resolve({});
+};
+
+WidgetManager.prototype.setCSS = function(css) {
+    if (this.styleTag.styleSheet) {
+        this.styleTag.styleSheet.cssText = css;
+    } else {
+        this.styleTag.appendChild(document.createTextNode(css));
+    }
 };

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -375,6 +375,16 @@ define([
         }).catch(utils.reject('Could not set widget manager state.', true));
     };
 
+    /**
+     * Create a style tag element in the current context.
+     * @return {HTMLElement}
+     */
+    ManagerBase.prototype.createStyleTag = function() {
+        var style = document.createElement('style');
+        document.querySelectorAll('body')[0].appendChild(style);
+        return style;
+    };
+
     ManagerBase.prototype._create_comm = function(comm_target_name, model_id, metadata) {
         throw new Error("Manager._create_comm not implemented");
     };

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -17,7 +17,7 @@ define([
         managerBase.ManagerBase.apply(this);
         WidgetManager._managers.push(this);
 
-        // Attach a comm manager to the
+        // Attach a comm manager
         this.notebook = notebook;
         this.keyboard_manager = notebook.keyboard_manager;
         this.comm_manager = comm_manager;

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -558,6 +558,22 @@ define(["nbextensions/widgets/widgets/js/utils",
              * Public constructor
              */
             WidgetViewMixin.initialize.apply(this, [parameters]);
+            this.id = utils.uuid();
+            
+            // Create and apply a unique style class name that can be used to
+            // style this view directly.
+            this.styleClassName = 'widget' + '-' + this.model.id + '-' + this.id;
+            this.el.className += ' ' + this.styleClassName;
+            
+            // Find or create a style tag for this widget view
+            this.styleNode = document.querySelectorAll('style.' + this.styleClassName);
+            if (this.styleNode && this.styleNode.length > 0) {
+                this.styleNode = this.styleNode[0];
+            } else {
+                this.styleNode = this.model.widget_manager.createStyleTag();
+                this.styleNode.className = this.styleClassName;
+            }
+            
             this.listenTo(this.model, 'change:visible', this.update_visible, this);
             this.listenTo(this.model, 'change:_css', this.update_css, this);
 
@@ -637,6 +653,17 @@ define(["nbextensions/widgets/widgets/js/utils",
                 this.setStyle(this.model.get('style'));
             }, this));
         },
+
+        remove: function () {
+            // Raise a remove event when the view is removed.
+            WidgetViewMixin.remove.apply(this, arguments);
+            
+            // Remove the style tag from the DOM so the GC can collect it
+            if (this.styleNode) {                
+                this.styleNode.remove();
+                delete this.styleNode;
+            }
+        },
         
         setStyle: function(style, oldStyle) {
             var that = this;
@@ -700,19 +727,41 @@ define(["nbextensions/widgets/widgets/js/utils",
             /**
              * Update the css styling of this view.
              */
-            if (css === undefined) {return;}
-            for (var i = 0; i < css.length; i++) {
-                // Apply the css traits to all elements that match the selector.
-                var selector = css[i][0];
-                var parent = this.el.parentElement;
-                var elements = parent.querySelectorAll(selector) || [this.el];
-                if (elements.length > 0) {
-                    var trait_key = css[i][1];
-                    var trait_value = css[i][2];
-                    _.each(elements, function(e) {
-                        e.style[trait_key] = trait_value;
-                    });
+            
+            // Convert the list of tuples into individual strings, which together
+            // form the complete CSS to apply to the view.
+            var styleStrings = [];
+            css.forEach(function(tuple) {
+                var selector = String(tuple[0]).trim();
+                var key = String(tuple[1]);
+                var value = String(tuple[2]);
+                
+                // If the selector starts with an ampersand, remove the ampersand
+                // and concatenate the selector to the styleClassName.
+                if (selector.length > 0 && selector[0] === ':') {
+                    selector = '.' + this.styleClassName + selector;
+                } else {
+                    selector = '.' + this.styleClassName + ' ' + selector;
                 }
+                
+                styleStrings.push(selector + ' { ' + key + ': ' + value + '; }');
+            }, this);
+            
+            // Set the style string on the style element.
+            var styleString = styleStrings.join('\n');
+            if (this.styleNode.styleSheet) {
+                
+                // Change styling
+                this.styleNode.styleSheet.cssText = styleString;
+            } else {
+                
+                // Remove existing styling
+                while (this.styleNode.firstChild) {
+                    this.styleNode.removeChild(this.styleNode.firstChild);
+                }
+                
+                // Add new styling
+                this.styleNode.appendChild(document.createTextNode(styleString));
             }
         },
 


### PR DESCRIPTION
@ellisonbg @SylvainCorlay @jasongrout @minrk I'm very excited about the functionality introduced by this PR!  This PR does two things:

1. It solves the problem of `_css` not being stateful by making it stateful!  This means we can once again have nice helper methods for allowing users to use all of CSS.
2. It allows you to use pseudo selectors with css

Note, this PR makes no changes to the Python API.  I figured we could iterate on that in another PR.  I'm just excited that this may end the "I need to be able to style X, but I don't want to subclass widgets" issue.

This is marked as backwards incompatible because the fixed behavior is not the same as the broken behavior, and may change people's layouts who are dependent on the broken behavior.

## Action shot!!
(LICEcap is broken on my machine right now, probably because of my OReilly screen casting setup)

## Demo notebook
https://gist.github.com/jdfreder/d0ec16a8f699b86895f1