### PR TITLE
DOM widget controller

### DIFF
--- a/ipywidgets/static/widgets/js/widget_controller.js
+++ b/ipywidgets/static/widgets/js/widget_controller.js
@@ -90,7 +90,7 @@ define([
 
     });
 
-    var Controller = widget.WidgetModel.extend({
+    var Controller = widget.DOMWidgetModel.extend({
         /* The Controller model. */
 
         initialize: function() {
@@ -243,7 +243,7 @@ define([
         serializers: _.extend({
             buttons: {deserialize: widget.unpack_models},
             axes: {deserialize: widget.unpack_models},
-        }, widget.WidgetModel.prototype.serializers)
+        }, widget.DOMWidgetModel.prototype.serializers)
 
     });
 

--- a/ipywidgets/widgets/widget_controller.py
+++ b/ipywidgets/widgets/widget_controller.py
@@ -7,6 +7,7 @@ Represents a Gamepad or Joystick controller.
 # Distributed under the terms of the Modified BSD License.
 
 from .widget import Widget, register, widget_serialization
+from .domwidget import DOMWidget
 from traitlets import Bool, Int, Float, Unicode, List, Instance
 
 
@@ -28,7 +29,7 @@ class Axis(Widget):
 
 
 @register('IPython.Controller')
-class Controller(Widget):
+class Controller(DOMWidget):
     """Represents a game controller"""
     index = Int(sync=True)
 


### PR DESCRIPTION
Bug fix for controller widget.

Detail: The Controller widget's view is a `DOMWidgetView` but its model was only a `WidgetModel` instead of a `DOMWidgetModel`. With the recent changes with the `_css` attribute, the `DOMWidgetView` tried to access the unexistant `_css` attribute in its constructor, which caused JS errors.