### PR TITLE
Remove skipStateRequest attribute and switch to comm-less models

### DIFF
--- a/examples/development/web/index.js
+++ b/examples/development/web/index.js
@@ -1,10 +1,11 @@
 
 // Create a widget manager instance.
 var WidgetManager = require('./manager').WidgetManager;
+var uuid = require("jupyter-js-widgets").uuid;
 
-document.addEventListener("DOMContentLoaded", function(event) { 
+document.addEventListener("DOMContentLoaded", function(event) {
     var manager = new WidgetManager(document.body);
-    
+
     /**
      * Helper function for creating and displaying widgets.
      * @return {Promise<WidgetView>}
@@ -15,19 +16,18 @@ document.addEventListener("DOMContentLoaded", function(event) {
         return manager.new_widget({
             model_name: 'WidgetModel',
             widget_class: 'ipywidgets.' + widgetType,
-            skipStateRequest: true
-            
+            model_id: uuid()
         // Create a view for the model.
-        }).then(function(model) { 
+        }).then(function(model) {
             console.log(widgetType + ' model created', model);
-            
+
             model.set({
                 _view_name: widgetType + 'View',
                 description: description || '',
                 value: value || null,
                 visible: true
             });
-            
+
             return  manager.create_view(model);
         }, console.error.bind(console)
 
@@ -38,21 +38,21 @@ document.addEventListener("DOMContentLoaded", function(event) {
             return view;
         }, console.error.bind(console));
     }
-    
+
     var defaultHTML = 'test <b>text</b>';
     var textArea = createWidget('Textarea', defaultHTML, 'HTML:');
     var html = createWidget('HTML', defaultHTML);
-    
+
     // Create a link model.
     manager.new_widget({
         model_name: 'LinkModel',
         widget_class: 'ipywidgets.JSLink',
-        skipStateRequest: true
-        
+        model_id: uuid()
+
     // Set the link model state.
     }).then(function(link) {
         console.log('link created');
-        
+
         Promise.all([textArea, html]).then(
             function(models) {
                 console.log('setting link');

--- a/examples/development/web/manager.js
+++ b/examples/development/web/manager.js
@@ -19,19 +19,14 @@ WidgetManager.prototype.display_view = function(msg, view, options) {
     return Promise.resolve(view).then(function(view) {
         that.el.appendChild(view.el);
         view.on('remove', function() {
-            console.log('view removed', view);
+            console.log('View removed', view);
         });
         return view;
     });
 };
 
 WidgetManager.prototype._create_comm = function(comm_target_name, model_id, metadata) {
-    function nullFunction() {}
-    return Promise.resolve({
-        on_close: nullFunction,
-        on_msg: nullFunction,
-        send: nullFunction
-    });
+    return Promise.reject("No backend");
 };
 
 WidgetManager.prototype._get_comm_info = function() {

--- a/examples/development/web/manager.js
+++ b/examples/development/web/manager.js
@@ -25,14 +25,6 @@ WidgetManager.prototype.display_view = function(msg, view, options) {
     });
 };
 
-WidgetManager.prototype._create_comm = function(comm_target_name, model_id, metadata) {
-    return Promise.reject("No backend");
-};
-
-WidgetManager.prototype._get_comm_info = function() {
-    return Promise.resolve({});
-};
-
 WidgetManager.prototype.setCSS = function(css) {
     if (this.styleTag.styleSheet) {
         this.styleTag.styleSheet.cssText = css;

--- a/examples/development/web/manager.js
+++ b/examples/development/web/manager.js
@@ -32,3 +32,7 @@ WidgetManager.prototype.setCSS = function(css) {
         this.styleTag.appendChild(document.createTextNode(css));
     }
 };
+
+WidgetManager.prototype._get_comm_info = function() {
+    return Promise.resolve({});
+};

--- a/examples/development/web2/manager.js
+++ b/examples/development/web2/manager.js
@@ -16,19 +16,14 @@ WidgetManager.prototype.display_view = function(msg, view, options) {
     return Promise.resolve(view).then(function(view) {
         that.el.appendChild(view.el);
         view.on('remove', function() {
-            console.log('view removed', view);
+            console.log('View removed', view);
         });
         return view;
     });
 };
 
 WidgetManager.prototype._create_comm = function(comm_target_name, model_id, metadata) {
-    function nullFunction() {}
-    return Promise.resolve({
-        on_close: nullFunction,
-        on_msg: nullFunction,
-        send: nullFunction
-    });
+    return Promise.reject("No backend");
 };
 
 WidgetManager.prototype._get_comm_info = function() {

--- a/examples/development/web2/manager.js
+++ b/examples/development/web2/manager.js
@@ -21,3 +21,7 @@ WidgetManager.prototype.display_view = function(msg, view, options) {
         return view;
     });
 };
+
+WidgetManager.prototype._get_comm_info = function() {
+    return Promise.resolve({});
+};

--- a/examples/development/web2/manager.js
+++ b/examples/development/web2/manager.js
@@ -21,11 +21,3 @@ WidgetManager.prototype.display_view = function(msg, view, options) {
         return view;
     });
 };
-
-WidgetManager.prototype._create_comm = function(comm_target_name, model_id, metadata) {
-    return Promise.reject("No backend");
-};
-
-WidgetManager.prototype._get_comm_info = function() {
-    return Promise.resolve({});
-};

--- a/ipywidgets/index.js
+++ b/ipywidgets/index.js
@@ -26,10 +26,11 @@ var register = require("./static/widgets/js/register");
     require("./static/widgets/js/widget_selection"),
     require("./static/widgets/js/widget_selectioncontainer"),
     require("./static/widgets/js/widget_string"),
-    require("./static/widgets/js/widget_controller")
+    require("./static/widgets/js/widget_controller"),
+    require("./static/widgets/js/utils")
 ].forEach(function(module) {
     register.registerWidgets(module);
-    
+
     Object.keys(module).forEach(function(name) {
         exports[name] = module[name];
     });

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -386,13 +386,13 @@ define([
     };
 
     ManagerBase.prototype._create_comm = function(comm_target_name, model_id, metadata) {
-        throw new Error("Manager._create_comm not implemented");
+        return Promise.reject("No backend.");
     };
 
     ManagerBase.prototype._get_comm_info = function() {
-        throw new Error("Manager._get_comm_info not implemented");
+        return Promise.resolve({});
     };
-    
+
     return {
         'ManagerBase': ManagerBase
     };

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -390,7 +390,7 @@ define([
     };
 
     ManagerBase.prototype._get_comm_info = function() {
-        return Promise.resolve({});
+        return Promise.reject("No backend.");
     };
 
     return {

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -188,7 +188,7 @@ define([
                 return model.request_state();
             });
         }, function() {
-            // Comme Promise Rejected.
+            // Comm Promise Rejected.
             if (!options_clone.model_id) {
                 options_clone.model_id = utils.uuid();
             }

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -152,8 +152,10 @@ define(["./utils",
             }
             this.stopListening();
             this.trigger('destroy', this);
-            delete this.comm.model; // Delete ref so GC will collect widget model.
-            delete this.comm;
+            if (this.comm) {
+                delete this.comm.model; // Delete ref so GC will collect widget model.
+                delete this.comm;
+            }
             delete this.model_id; // Delete id from model so widget manager cleans up.
             _.each(this.views, function(v, id, views) {
                 v.then(function(view) {
@@ -164,7 +166,7 @@ define(["./utils",
         },
 
         _handle_comm_closed: function (msg) {
-            /** 
+            /**
              * Handle when a widget is closed.
              */
             this.trigger('comm:close');


### PR DESCRIPTION
Besides, the default_implementation of `_create_comm` now simply returns a rejected promise, so that we can always expect a promise.