### PR TITLE
 WidgetModel.__super__.constructor should be called last

### DIFF
--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -52,7 +52,6 @@ define(["./utils",
              *      An ID unique to this model.
              * comm : Comm instance (optional)
              */
-            WidgetModel.__super__.constructor.apply(this);
             this.widget_manager = widget_manager;
             this.state_change = Promise.resolve();
             this._buffered_state_diff = {};
@@ -99,6 +98,7 @@ define(["./utils",
                 widget_manager.notebook.events.on('kernel_restarting.Kernel', died);
                 widget_manager.notebook.events.on('kernel_dead.Kernel', died);
             }
+            WidgetModel.__super__.constructor.apply(this);
         },
 
         send: function (content, callbacks, buffers) {


### PR DESCRIPTION
`__super__.constructor` is the function call `Model.initialize`. We need everything that is in constructor to be done before initialize otherwise, we cannot call model.set in initialize.

The reason is that we overload `Model.set` and our overloaded method uses attributes set in `constructor`.