### PR TITLE
Some changes to be able to run examples

### DIFF
--- a/examples/development/web3/README.md
+++ b/examples/development/web3/README.md
@@ -5,8 +5,10 @@ a context other than the notebook.
 
 ## Try it
 1. Open a command line in the `ipywidgets/ipywidgets` subdirectory and run `npm install`.
-2. Cd into this directory and run `npm install`.
-3. Now open the `index.html` file.
+2. Do `npm link`
+3. Cd into this directory and run `npm link jupyter-js-widgets`.
+4. Run `npm install`
+5. Now open the `index.html` file.
 
 ## Details
 If you plan to reproduce this in your own project, pay careful attention to the 

--- a/examples/development/web3/package.json
+++ b/examples/development/web3/package.json
@@ -16,7 +16,6 @@
     "browserify": "^11.2.0",
     "codemirror": "^5.9.0",
     "font-awesome": "^4.5.0",
-    "jupyter-js-widgets": "file:../../../ipywidgets",
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
     "jupyter-js-services": "^0.2.2",


### PR DESCRIPTION
Basically using `npm link`

The only bad thing is that the dependency to ipywidgets is not explicit  in the examples json. I only did web3.