### PR TITLE
Remaining `require("ipywidget")`

### DIFF
--- a/examples/development/web3/src/manager.js
+++ b/examples/development/web3/src/manager.js
@@ -1,21 +1,21 @@
-require('../node_modules/ipywidgets/static/components/bootstrap/css/bootstrap.css');
+require('../node_modules/jupyter-js-widgets/static/components/bootstrap/css/bootstrap.css');
 require('../node_modules/jquery-ui/themes/smoothness/jquery-ui.min.css');
 
-const ipywidgets = require('ipywidgets');
+const jpywidgets = require('jupyter-js-widgets');
 
-export class WidgetManager extends ipywidgets.ManagerBase {
+export class WidgetManager extends jpywidgets.ManagerBase {
     constructor(kernel, el) {
         super();
         this.kernel = kernel;
         this.el = el;
-        
+
         // Create a comm manager shim
-        this.commManager = new ipywidgets.shims.services.CommManager(kernel);
-        
+        this.commManager = new jpywidgets.shims.services.CommManager(kernel);
+
         // Register the comm target
         this.commManager.register_target(this.comm_target_name, this.handle_comm_open.bind(this));
     }
-    
+
     display_view(msg, view, options) {
         var that = this;
         return Promise.resolve(view).then(function(view) {


### PR DESCRIPTION
As reported by @lbustelo, there was a remaining occurence of `require("ipywidgets")` which was causing the web3 example to fail.

cc @jdfreder 