### PR TITLE
Updated docs on running tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ To run the Python tests:
 
 To run the Javascript tests:
 
-    npm run buildtests; python -m ipywidgets.jstest
+    npm run test
 
-To run the Javascript tests with all output printed:
-
-    npm run buildtests; python -m ipywidgets.jstest -- --logall
-
-Description of jstest additional arguments:
-logall - If there is atleast one failure in the notebook, log information for every cell.
-logsuccess - Log information for every cell in the notebook, regardless of failure.
+This will run the test suit using `karma` with 'debug' level logging.


### PR DESCRIPTION
Closes #280.

So an interesting problem I experienced whilst running the test suite was the following error.

```
03 01 2016 20:30:57.130:DEBUG [plugin]: Loading karma-* from /usr/local/lib/node_modules
03 01 2016 20:30:57.135:DEBUG [plugin]: Loading inlined plugin (defining launcher:Chrome_travis_ci).
03 01 2016 20:30:57.137:WARN [preprocess]: Can not load "browserify", it is not registered!
  Perhaps you are missing some plugin?
03 01 2016 20:30:57.141:WARN [reporter]: Can not load "mocha", it is not registered!
  Perhaps you are missing some plugin?
/usr/local/lib/node_modules/karma/node_modules/di/lib/injector.js:9
      throw error('No provider for "' + name + '"!');
      ^

Error: No provider for "framework:browserify"! (Resolving: framework:browserify)
```

After digging around some issues in the `karma-browserify` repo, the [solution](https://github.com/nikku/karma-browserify/issues/96) ended up being running the command as `$(npm bin)/karma`. Leaving this as a note to all who may experience similar issues.

cc: @jdfreder 