### PR TITLE
Call base ctor

### DIFF
--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -93,9 +93,10 @@ class FlexBox(Box): # TODO: Deprecated in 5.0 (entire class)
     align = CaselessStrEnum(
         values=_locations,
         default_value='start', sync=True)
-        
+
     def __init__(self, *pargs, **kwargs):
         warn('FlexBox, VBox, and HBox deprecated in ipywidgets 5.0.  Use Box and Box.style instead.', DeprecationWarning)
+        super(FlexBox, self).__init__(*pargs, **kwargs)
 
 
 def VBox(*pargs, **kwargs): # TODO: Deprecated in 5.0 (entire class)


### PR DESCRIPTION
`Flexbox`, `VBox` and `HBox` did not work anymore because the new `__init__` including the deprecation warning did not call the base class' `__init__`.