### PR TITLE
Hyphen-separated css attribute names and flexbox

### DIFF
--- a/ipywidgets/static/widgets/js/layout.js
+++ b/ipywidgets/static/widgets/js/layout.js
@@ -11,23 +11,22 @@ define([
     "backbone",
     "jquery"
 ], function(widget, _, Backbone, $) {
-    
+
     /**
      * Represents a group of CSS style attributes
      */
     var LayoutView = widget.WidgetView.extend({
-        
+
         /**
          * Public constructor
          */
-        constructor: function() {
-            LayoutView.__super__.constructor.apply(this, arguments);
-            
+        initialize: function() {
+            LayoutView.__super__.initialize.apply(this, arguments);
             // Register the traits that live on the Python side
             this._traitNames = [];
             this.initTraits();
         },
-        
+
         /**
          * Initialize the traits for this layout object
          */
@@ -56,7 +55,7 @@ define([
                 'width'
             );
         },
-        
+
         /**
          * Register CSS traits that are known by the model
          * @param  {...string[]} traits
@@ -69,34 +68,35 @@ define([
                 // Call registerTrait on each trait
                 .forEach(_.bind(this.registerTrait, this));
         },
-        
+
         /**
          * Register a CSS trait that is known by the model
          * @param  {string} trait
          */
         registerTrait: function(trait) {
             this._traitNames.push(trait);
-            
+
             // Listen to changes, and set the value on change.
-            this.listenTo(this.model, 'change:' + this.modelize(trait), function (model, value) { 
+            this.listenTo(this.model, 'change:' + trait, function (model, value) {
                 this.handleChange(trait, value);
             }, this);
 
             // Set the initial value on display.
             this.displayed.then(_.bind(function() {
-                this.handleChange(trait, this.model.get(this.modelize(trait)));
+                this.handleChange(trait, this.model.get(trait));
             }, this));
         },
-        
+
         /**
-         * Get the the name of the trait as it appears in the model
-         * @param  {string} trait - CSS trait name
-         * @return {string} model key name
+         * Get the the name of the style attribute from the trait name
+         * @param  {string} model attribute name
+         * @return {string} css attribute name.
          */
-        modelize: function(trait) {
-            return trait.replace('-', '_');
+        css_name: function(trait) {
+            return trait.replace('_', '-');
         },
-        
+
+
         /**
          * Handles when a trait value changes
          * @param  {string} trait
@@ -104,14 +104,14 @@ define([
          */
         handleChange: function(trait, value) {
             this.displayed.then(_.bind(function(parent) {
-                if (parent) {
-                    parent.el.style[trait] = value;
+                if (parent && value) {
+                    parent.el.style[this.css_name(trait)] = value;
                 } else {
                     console.warn("Style not applied because a parent view doesn't exist");
                 }
             }, this));
         },
-        
+
         /**
          * Remove the styling from the parent view.
          */
@@ -119,7 +119,7 @@ define([
             this._traitNames.forEach(function(trait) {
                 this.displayed.then(_.bind(function(parent) {
                     if (parent) {
-                        parent.el.style[trait] = '';
+                        parent.el.style[this.css_name(trait)] = '';
                     } else {
                         console.warn("Style not removed because a parent view doesn't exist");
                     }
@@ -127,6 +127,6 @@ define([
             }, this);
         }
     });
-    
+
     return {LayoutView: LayoutView};
 });

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -75,6 +75,22 @@ class PlaceProxy(Proxy):
     selector = Unicode(sync=True)
 
 
+def VBox(*pargs, **kwargs):
+    """Displays multiple widgets vertically using the flexible box model."""
+    box = Box(*pargs, **kwargs)
+    box.layout.display = 'flex'
+    box.layout.flex_direction = 'column'
+    return box
+
+
+def HBox(*pargs, **kwargs):
+    """Displays multiple widgets horizontally using the flexible box model."""
+    box = Box(*pargs, **kwargs)
+    box.layout.display = 'flex'
+    box.layout.flex_direction = 'row'
+    return box
+
+
 @register('IPython.FlexBox')
 class FlexBox(Box): # TODO: Deprecated in 5.0 (entire class)
     """Displays multiple widgets using the flexible box model."""
@@ -95,17 +111,6 @@ class FlexBox(Box): # TODO: Deprecated in 5.0 (entire class)
         default_value='start', sync=True)
 
     def __init__(self, *pargs, **kwargs):
-        warn('FlexBox, VBox, and HBox deprecated in ipywidgets 5.0.  Use Box and Box.style instead.', DeprecationWarning)
+        warn('FlexBox is deprecated in ipywidgets 5.0.  Use Box and Box.layout instead.', DeprecationWarning)
         super(FlexBox, self).__init__(*pargs, **kwargs)
 
-
-def VBox(*pargs, **kwargs): # TODO: Deprecated in 5.0 (entire class)
-    """Displays multiple widgets vertically using the flexible box model."""
-    kwargs['orientation'] = 'vertical'
-    return FlexBox(*pargs, **kwargs)
-
-
-def HBox(*pargs, **kwargs): # TODO: Deprecated in 5.0 (entire class)
-    """Displays multiple widgets horizontally using the flexible box model."""
-    kwargs['orientation'] = 'horizontal'
-    return FlexBox(*pargs, **kwargs)


### PR DESCRIPTION
This contains two bug fixes: 
- currently, css attributes specified in layout were not taken into account if specified before the widget is displayed
- hyphen-separated css attribute names did not work

Besides, I re-add the `VBox` and `HBox` helper functions, but use the layout widget in their implementation. 