### PR TITLE
Fix issues with shorthand css properties

### DIFF
--- a/examples/notebooks/Flexbox Layout.ipynb
+++ b/examples/notebooks/Flexbox Layout.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "words = (\"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed \" +\n",
+    "         \"do eiusmod tempor incididunt ut labore et dolore magna aliqua.\").split(' ')\n",
+    "\n",
+    "items = [HTML('''\n",
+    "<div style=\"background-color: steelblue; \n",
+    "            padding: 5px; \n",
+    "            color: white; \n",
+    "            font-size: large;\n",
+    "            min-height:22px; \n",
+    "            text-align: center;\">\n",
+    "%s\n",
+    "</div>\n",
+    "''' % w) for w in words]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Column layout\n",
+    "## Natural width for items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "layout = Layout(display='flex', flex_flow='column')\n",
+    "box = Box(children=items, layout=layout)\n",
+    "box"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Align items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# center\n",
+    "box.layout.align_items = 'center'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# flex-end\n",
+    "box.layout.align_items = 'flex-end'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# stretch\n",
+    "box.layout.align_items = 'stretch'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# back to default flex-start\n",
+    "box.layout.align_items = 'flex-start'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# back to stretch with smaller width\n",
+    "box.layout.width = '400px'\n",
+    "box.layout.align_items = 'stretch'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Row Layout\n",
+    "## No wrap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "layout = Layout(display='flex', flex_flow='row', width='50%', overflow='hidden')\n",
+    "box = Box(children=items, layout=layout)\n",
+    "box"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "box.layout.flex_flow = 'row wrap'"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/ipywidgets/static/widgets/js/layout.js
+++ b/ipywidgets/static/widgets/js/layout.js
@@ -38,16 +38,12 @@ define([
                 'bottom',
                 'display',
                 'flex',
-                'flex_basis',
-                'flex_direction',
                 'flex_flow',
-                'flex_grow',
-                'flex_shrink',
-                'flex_wrap',
                 'height',
                 'justify_content',
                 'left',
                 'margin',
+                'overflow',
                 'padding',
                 'right',
                 'top',
@@ -88,9 +84,9 @@ define([
         },
 
         /**
-         * Get the the name of the style attribute from the trait name
+         * Get the the name of the css property from the trait name
          * @param  {string} model attribute name
-         * @return {string} css attribute name.
+         * @return {string} css property name.
          */
         css_name: function(trait) {
             return trait.replace('_', '-');
@@ -104,7 +100,7 @@ define([
          */
         handleChange: function(trait, value) {
             this.displayed.then(_.bind(function(parent) {
-                if (parent && value) {
+                if (parent) {
                     parent.el.style[this.css_name(trait)] = value;
                 } else {
                     console.warn("Style not applied because a parent view doesn't exist");
@@ -128,5 +124,7 @@ define([
         }
     });
 
-    return {LayoutView: LayoutView};
+    return {
+        LayoutView: LayoutView
+    };
 });

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -79,7 +79,7 @@ def VBox(*pargs, **kwargs):
     """Displays multiple widgets vertically using the flexible box model."""
     box = Box(*pargs, **kwargs)
     box.layout.display = 'flex'
-    box.layout.flex_direction = 'column'
+    box.layout.flex_flow = 'column'
     return box
 
 
@@ -87,7 +87,6 @@ def HBox(*pargs, **kwargs):
     """Displays multiple widgets horizontally using the flexible box model."""
     box = Box(*pargs, **kwargs)
     box.layout.display = 'flex'
-    box.layout.flex_direction = 'row'
     return box
 
 

--- a/ipywidgets/widgets/widget_layout.py
+++ b/ipywidgets/widgets/widget_layout.py
@@ -6,14 +6,22 @@
 from .widget import Widget, register
 from traitlets import Unicode, CUnicode
 
-@register('IPython.Button')
+
 class Layout(Widget):
     """Layout specification
-    
+
     Defines a layout that can be expressed using CSS.  Supports a subset of
     https://developer.mozilla.org/en-US/docs/Web/CSS/Reference
+
+    When a property is also accessible via a shorthand property, we only
+    expose the shorthand.
+
+    For example:
+    - ``flex-grow``, ``flex-shrink`` and ``flex-basis`` are bound to ``flex``.
+    - ``flex-wrap`` and ``flex-direction`` are bound to ``flex-flow``.
+    - ``margin-[top/bottom/left/right]`` values are bound to ``margin``, etc.
     """
-    
+
     _view_name = Unicode('LayoutView', sync=True)
 
     # Keys
@@ -23,19 +31,15 @@ class Layout(Widget):
     bottom = CUnicode(sync=True, allow_none=True)
     display = CUnicode(sync=True, allow_none=True)
     flex = CUnicode(sync=True, allow_none=True)
-    flex_basis = CUnicode(sync=True, allow_none=True)
-    flex_direction = CUnicode(sync=True, allow_none=True)
     flex_flow = CUnicode(sync=True, allow_none=True)
-    flex_grow = CUnicode(sync=True, allow_none=True)
-    flex_shrink = CUnicode(sync=True, allow_none=True)
-    flex_wrap = CUnicode(sync=True, allow_none=True)
     height = CUnicode(sync=True, allow_none=True)
     justify_content = CUnicode(sync=True, allow_none=True)
     left = CUnicode(sync=True, allow_none=True)
     margin = CUnicode(sync=True, allow_none=True)
+    overflow = CUnicode(sync=True, allow_none=True)
     padding = CUnicode(sync=True, allow_none=True)
     right = CUnicode(sync=True, allow_none=True)
     top = CUnicode(sync=True, allow_none=True)
     visibility = CUnicode(sync=True, allow_none=True)
     width = CUnicode(sync=True, allow_none=True)
-    
+


### PR DESCRIPTION
The `flex-flow` attribute is a shortcut containing the `flex-direction` and `flex-wrap`. 

When setting `flex-flow` to an empty string, this resets `flex-direction` to its default, that is `row`, even if the trait attribute for `flex-direction` was `column` which is a bug.

We actually don't need `flex-flow` which is only a shortcut to the two other properties so I am removing it.