### PR TITLE
Interact API support for selection widgets

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -86,7 +86,7 @@ def _widget_abbrev(o):
         # of tuples to specify slider widget attributes. This will be removed
         # in ipywidgets 6.0.
         if len(o) in [2, 3] and all(isinstance(x, Real) for x in o):
-            warn("For Sliders, use a tuple", DeprecationWarning)
+            warn("For Sliders, use a tuple: %s" % (tuple(o),), DeprecationWarning)
             return _widget_abbrev(tuple(o))
         # --------------------------------------------------------------------
         return Dropdown(options=[unicode_type(k) for k in o])
@@ -96,7 +96,7 @@ def _widget_abbrev(o):
         # Handle deprecated behavior of using tuples for selection widget. This
         # will be removed in ipywidgets 6.0.
         if any(not isinstance(x, Real) for x in o):
-            warn("For Selection widgets, use a list", DeprecationWarning)
+            warn("For Selection widgets, use a list %s" %(list(o),), DeprecationWarning)
             return Dropdown(options=[unicode_type(k) for k in o])
         # --------------------------------------------------------------------
         if _matches(o, (Real, Real)):

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -20,6 +20,7 @@ from IPython.display import display, clear_output
 from ipython_genutils.py3compat import string_types, unicode_type
 from traitlets import HasTraits, Any, Unicode
 from numbers import Real, Integral
+from warnings import warn
 
 empty = Parameter.empty
 
@@ -79,10 +80,26 @@ def _widget_abbrev_single_value(o):
 
 def _widget_abbrev(o):
     """Make widgets from abbreviations: single values, lists or tuples."""
-    if isinstance(o, (list, tuple)):
-        if o and all(isinstance(x, string_types) for x in o):
+    if isinstance(o, list):
+        # --------------------------------------------------------------------
+        # Handle deprecated behavior of using lists of length 2 or 3 in place
+        # of tuples to specify slider widget attributes. This will be removed
+        # in ipywidgets 6.0.
+        if len(o) in [2, 3] and all(isinstance(x, Real) for x in o):
+            warn("For Sliders, use a tuple", DeprecationWarning)
+            return _widget_abbrev(tuple(o))
+        # --------------------------------------------------------------------
+        return Dropdown(options=[unicode_type(k) for k in o])
+
+    elif isinstance(o, tuple):
+        # --------------------------------------------------------------------
+        # Handle deprecated behavior of using tuples for selection widget. This
+        # will be removed in ipywidgets 6.0.
+        if any(not isinstance(x, Real) for x in o):
+            warn("For Selection widgets, use a list", DeprecationWarning)
             return Dropdown(options=[unicode_type(k) for k in o])
-        elif _matches(o, (Real, Real)):
+        # --------------------------------------------------------------------
+        if _matches(o, (Real, Real)):
             min, max, value = _get_min_max_value(o[0], o[1])
             if all(isinstance(_, Integral) for _ in o):
                 cls = IntSlider
@@ -99,6 +116,7 @@ def _widget_abbrev(o):
             else:
                 cls = FloatSlider
             return cls(value=value, min=min, max=max, step=step)
+
     else:
         return _widget_abbrev_single_value(o)
 

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -237,10 +237,6 @@ def test_list_tuple_str():
 def test_list_tuple_invalid():
     for bad in [
         (),
-        (5, 'hi'),
-        ('hi', 5),
-        ({},),
-        (None,),
     ]:
         with nt.assert_raises(ValueError):
             print(bad) # because there is no custom message in assert_raises


### PR DESCRIPTION
**Jupyter and Sage's flavors of `@interact`:**
Both Jupyter and Sage use "abbreviations", that is default values for parameters of the function passed to `@interact` to specify which widget should be used:

- With Sage: When passing a `list` of items, the generated widget is a selection widget. When passing a tuple of 2 or 3 numerical values, a slider is created and these values are interpreted as (min, max[, step])

- With Jupyter (before this PR), a selection widget is only used when passing any sequence of strings (and no other type). A slider is used when passing a sequence of 2 or 3 numerical values, and these values are interpreted as (min, max[, step]) like in Sage.

**In order to transition from the current API to the Sage API, this changes the `@interact` API in the following fashion:**

1. When the widget abbreviation is a `list`, the generated widget is a selection widget (Dropdown), 
   - but, for backward compatibility, in the case of a list of length 2 or 3 of numerical values only, we generate a slider using these values for (min, max) or (min, max, step). This special-case behavior is **deprecated**.

2. When the widget abbreviation is a tuple of 2 or 3 numerical values, a slider is generated.
    - however, if any item of the list is *not* numerical, then we use a selection widget (dropdown). This special-case behavior is **deprecated** and is meant for backward compatibility.

Hence, this is a **backward-compatible** change. We only enable new cases. We would remove the two special cases in 6.0 effectively adopting Sage's `list -> selection`, `tuple -> slider` convention.

Fixes #238