### PR TITLE
Revert prototype PR

### DIFF
--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -177,7 +177,7 @@ define(["./utils",
             /**
              * Deserialize fields that have a custom serializer.
              */
-            var serializers = this.constructor.prototype.serializers;
+            var serializers = this.constructor.serializers || this.constructor.prototype.serializers;
             var deserialized;
             if (serializers) {
                 deserialized = {};
@@ -400,7 +400,7 @@ define(["./utils",
             var that = this;
             // first, build a state dictionary with key=the attribute and the value
             // being the value or the promise of the serialized value
-            var serializers = this.constructor.prototype.serializers;
+            var serializers = this.constructor.serializers || this.constructor.prototype.serializers;
             if (serializers) {
                 for (var k in attrs) {
                     if (serializers[k] && serializers[k].serialize) {

--- a/ipywidgets/test/widget.js
+++ b/ipywidgets/test/widget.js
@@ -137,7 +137,7 @@ describe("Widget", function() {
         
         // Create some dummy deserializers.  One returns synchronously, and the
         // other asynchronously using a promise.
-        this.widget.constructor.prototype.serializers = {
+        this.widget.constructor.serializers = {
             a: {
                 deserialize: (value, widget) => {
                     return value*3.0;


### PR DESCRIPTION
It seems that `ModelClass.prototype.foo` and `model_instance.constructor.foo` are the same thing.