### PR TITLE
Use Jupyter namespace for widget registry

### DIFF
--- a/ipywidgets/widgets/widget_bool.py
+++ b/ipywidgets/widgets/widget_bool.py
@@ -22,7 +22,8 @@ class _Bool(DOMWidget):
             kwargs['value'] = value
         super(_Bool, self).__init__(**kwargs)
 
-@register('IPython.Checkbox')
+
+@register('Jupyter.Checkbox')
 class Checkbox(_Bool):
     """Displays a boolean `value` in the form of a checkbox.
 
@@ -36,7 +37,7 @@ class Checkbox(_Bool):
     _view_name = Unicode('CheckboxView', sync=True)
 
 
-@register('IPython.ToggleButton')
+@register('Jupyter.ToggleButton')
 class ToggleButton(_Bool):
     """Displays a boolean `value` in the form of a toggle button.
 
@@ -61,7 +62,7 @@ class ToggleButton(_Bool):
         predefined styling for the button.""")
 
 
-@register('IPython.Valid')
+@register('Jupyter.Valid')
 class Valid(_Bool):
 
     """Displays a boolean `value` in the form of a green check (True / valid)

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -12,7 +12,7 @@ from traitlets import Unicode, Tuple, Int, CaselessStrEnum, Instance
 from warnings import warn
 
 
-@register('IPython.Box')
+@register('Jupyter.Box')
 class Box(DOMWidget):
     """Displays multiple widgets in a group."""
     _model_name = Unicode('BoxModel', sync=True)
@@ -48,7 +48,7 @@ class Box(DOMWidget):
             child._handle_displayed()
 
 
-@register('IPython.Proxy')
+@register('Jupyter.Proxy')
 class Proxy(Widget):
     """A DOMWidget that holds another DOMWidget or nothing."""
     _model_name = Unicode('ProxyModel', sync=True)
@@ -68,7 +68,7 @@ class Proxy(Widget):
             self.child._handle_displayed()
 
 
-@register('IPython.PlaceProxy')
+@register('Jupyter.PlaceProxy')
 class PlaceProxy(Proxy):
     """Renders the child widget at the specified selector."""
     _view_name = Unicode('PlaceProxyView', sync=True)
@@ -90,7 +90,7 @@ def HBox(*pargs, **kwargs):
     return box
 
 
-@register('IPython.FlexBox')
+@register('Jupyter.FlexBox')
 class FlexBox(Box): # TODO: Deprecated in 5.0 (entire class)
     """Displays multiple widgets using the flexible box model."""
     _view_name = Unicode('FlexBoxView', sync=True)

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -12,10 +12,10 @@ from .widget import CallbackDispatcher, register
 from traitlets import Unicode, Bool, CaselessStrEnum
 
 
-@register('IPython.Button')
+@register('Jupyter.Button')
 class Button(DOMWidget):
     """Button widget.
-       This widget has an `on_click` method that allows you to listen for the 
+       This widget has an `on_click` method that allows you to listen for the
        user clicking on the button.  The click event itself is stateless.
 
        Parameters
@@ -36,10 +36,10 @@ class Button(DOMWidget):
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
 
     button_style = CaselessStrEnum(
-        values=['primary', 'success', 'info', 'warning', 'danger', ''], 
+        values=['primary', 'success', 'info', 'warning', 'danger', ''],
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the button.""")
-    
+
     def __init__(self, **kwargs):
         """Constructor"""
         super(Button, self).__init__(**kwargs)

--- a/ipywidgets/widgets/widget_color.py
+++ b/ipywidgets/widgets/widget_color.py
@@ -12,10 +12,10 @@ from .trait_types import Color
 from traitlets import Unicode, Bool
 
 
-@register('IPython.ColorPicker')
+@register('Jupyter.ColorPicker')
 class ColorPicker(DOMWidget):
     value = Color('black', sync=True)
     short = Bool(sync=True)
     description = Unicode(sync=True)
-    
+
     _view_name = Unicode('ColorPicker', sync=True)

--- a/ipywidgets/widgets/widget_controller.py
+++ b/ipywidgets/widgets/widget_controller.py
@@ -11,7 +11,7 @@ from .domwidget import DOMWidget
 from traitlets import Bool, Int, Float, Unicode, List, Instance
 
 
-@register('IPython.ControllerButton')
+@register('Jupyter.ControllerButton')
 class Button(Widget):
     """Represents a gamepad or joystick button"""
     value = Float(min=0.0, max=1.0, read_only=True, sync=True)
@@ -20,7 +20,7 @@ class Button(Widget):
     _view_name = Unicode('ControllerButton', sync=True)
 
 
-@register('IPython.ControllerAxis')
+@register('Jupyter.ControllerAxis')
 class Axis(Widget):
     """Represents a gamepad or joystick axis"""
     value = Float(min=-1.0, max=1.0, read_only=True, sync=True)
@@ -28,7 +28,7 @@ class Axis(Widget):
     _view_name = Unicode('ControllerAxis', sync=True)
 
 
-@register('IPython.Controller')
+@register('Jupyter.Controller')
 class Controller(DOMWidget):
     """Represents a game controller"""
     index = Int(sync=True)
@@ -48,4 +48,4 @@ class Controller(DOMWidget):
 
     _view_name = Unicode('ControllerView', sync=True)
     _model_name = Unicode('Controller', sync=True)
- 
+

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -29,10 +29,6 @@ class _BoundedFloat(_Float):
     min = CFloat(0.0, help="Min value", sync=True)
     step = CFloat(0.1, help="Minimum step to increment the value (ignored by some views)", sync=True)
 
-    def __init__(self, *pargs, **kwargs):
-        """Constructor"""
-        super(_BoundedFloat, self).__init__(*pargs, **kwargs)
-
     def _value_validate(self, value, trait):
         """Cap and floor value"""
         if self.min > value or self.max < value:
@@ -56,7 +52,7 @@ class _BoundedFloat(_Float):
         return max
 
 
-@register('IPython.FloatText')
+@register('Jupyter.FloatText')
 class FloatText(_Float):
     """ Displays a float value within a textbox. For a textbox in
 	which the value must be within a specific range, use BoundedFloatText.
@@ -73,7 +69,7 @@ class FloatText(_Float):
     _view_name = Unicode('FloatTextView', sync=True)
 
 
-@register('IPython.BoundedFloatText')
+@register('Jupyter.BoundedFloatText')
 class BoundedFloatText(_BoundedFloat):
     """ Displays a float value within a textbox. Value must be within the range specified.
 	For a textbox in which the value doesn't need to be within a specific range, use FloatText.
@@ -87,14 +83,14 @@ class BoundedFloatText(_BoundedFloat):
 	max : float
 	    maximal value of the range of possible values displayed
 	description : str
-	    description displayed next to the textbox  
+	    description displayed next to the textbox
 	color : str Unicode color code (eg. '#C13535'), optional
-	    color of the value displayed   
+	    color of the value displayed
     """
     _view_name = Unicode('FloatTextView', sync=True)
 
 
-@register('IPython.FloatSlider')
+@register('Jupyter.FloatSlider')
 class FloatSlider(_BoundedFloat):
     """ Slider/trackbar of floating values with the specified range.
 
@@ -113,14 +109,14 @@ class FloatSlider(_BoundedFloat):
 	orientation : {'vertical', 'horizontal}, optional
             default is horizontal
 	readout : {True, False}, optional
-	    default is True, display the current value of the slider next to it		
-	slider_color : str Unicode color code (eg. '#C13535'), optional 
-	    color of the slider 
+	    default is True, display the current value of the slider next to it
+	slider_color : str Unicode color code (eg. '#C13535'), optional
+	    color of the slider
 	color : str Unicode color code (eg. '#C13535'), optional
 	    color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView', sync=True)
-    orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
+    orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(False, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
@@ -128,7 +124,7 @@ class FloatSlider(_BoundedFloat):
     continuous_update = Bool(True, sync=True, help="Update the value of the widget as the user is sliding the slider.")
 
 
-@register('IPython.FloatProgress')
+@register('Jupyter.FloatProgress')
 class FloatProgress(_BoundedFloat):
     """ Displays a progress bar.
 
@@ -251,7 +247,7 @@ class _BoundedFloatRange(_FloatRange):
             self.lower = low
 
 
-@register('IPython.FloatRangeSlider')
+@register('Jupyter.FloatRangeSlider')
 class FloatRangeSlider(_BoundedFloatRange):
     """ Slider/trackbar for displaying a floating value range (within the specified range of values).
 
@@ -270,9 +266,9 @@ class FloatRangeSlider(_BoundedFloatRange):
 	orientation : {'vertical', 'horizontal}, optional
             default is horizontal
 	readout : {True, False}, optional
-	    default is True, display the current value of the slider next to it		
-	slider_color : str Unicode color code (eg. '#C13535'), optional 
-	    color of the slider 
+	    default is True, display the current value of the slider next to it
+	slider_color : str Unicode color code (eg. '#C13535'), optional
+	    color of the slider
 	color : str Unicode color code (eg. '#C13535'), optional
 	    color of the value displayed (if readout == True)
     """

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -13,7 +13,7 @@ from .widget import register
 from traitlets import Unicode, CUnicode, Bytes
 
 
-@register('IPython.Image')
+@register('Jupyter.Image')
 class Image(DOMWidget):
     """Displays an image as a widget.
 
@@ -22,13 +22,13 @@ class Image(DOMWidget):
     the format of the byte string using the `format` trait (which defaults to
     "png")."""
     _view_name = Unicode('ImageView', sync=True)
-    
+
     # Define the custom state properties to sync with the front-end
     format = Unicode('png', sync=True)
     width = CUnicode(sync=True)
     height = CUnicode(sync=True)
     _b64value = Unicode(sync=True)
-    
+
     value = Bytes()
     def _value_changed(self, name, old, new):
         self._b64value = base64.b64encode(new)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -119,21 +119,21 @@ class _BoundedInt(_Int):
             self.value = max
         return max
 
-@register('IPython.IntText')
+@register('Jupyter.IntText')
 @_int_doc
 class IntText(_Int):
     """Textbox widget that represents an integer."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
-@register('IPython.BoundedIntText')
+@register('Jupyter.BoundedIntText')
 @_bounded_int_doc
 class BoundedIntText(_BoundedInt):
     """Textbox widget that represents an integer bounded by a minimum and maximum value."""
     _view_name = Unicode('IntTextView', sync=True)
 
 
-@register('IPython.IntSlider')
+@register('Jupyter.IntSlider')
 @_bounded_int_doc
 class IntSlider(_BoundedInt):
     """Slider widget that represents an integer bounded by a minimum and maximum value."""
@@ -146,7 +146,7 @@ class IntSlider(_BoundedInt):
     continuous_update = Bool(True, sync=True, help="Update the value of the widget as the user is sliding the slider.")
 
 
-@register('IPython.IntProgress')
+@register('Jupyter.IntProgress')
 @_bounded_int_doc
 class IntProgress(_BoundedInt):
     """Progress bar that represents an integer bounded by a minimum and maximum value."""
@@ -250,7 +250,7 @@ class _BoundedIntRange(_IntRange):
             self.upper = high
             self.lower = low
 
-@register('IPython.IntRangeSlider')
+@register('Jupyter.IntRangeSlider')
 class IntRangeSlider(_BoundedIntRange):
     """Slider widget that represents a pair of ints between a minimum and maximum value.
     
@@ -267,7 +267,7 @@ class IntRangeSlider(_BoundedIntRange):
         The highest allowed value for `upper`
     """
     _view_name = Unicode('IntSliderView', sync=True)
-    orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
+    orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(True, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -185,7 +185,7 @@ class _MultipleSelection(_Selection):
                 self.value_lock.release()
 
 
-@register('IPython.ToggleButtons')
+@register('Jupyter.ToggleButtons')
 class ToggleButtons(_Selection):
     """Group of toggle buttons that represent an enumeration.  Only one toggle
     button can be toggled at any point in time."""
@@ -198,7 +198,8 @@ class ToggleButtons(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-@register('IPython.Dropdown')
+
+@register('Jupyter.Dropdown')
 class Dropdown(_Selection):
     """Allows you to select a single item from a dropdown."""
     _view_name = Unicode('DropdownView', sync=True)
@@ -208,21 +209,21 @@ class Dropdown(_Selection):
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the buttons.""")
 
-@register('IPython.RadioButtons')
+
+@register('Jupyter.RadioButtons')
 class RadioButtons(_Selection):
     """Group of radio buttons that represent an enumeration.  Only one radio
     button can be toggled at any point in time."""
     _view_name = Unicode('RadioButtonsView', sync=True)
 
 
-
-@register('IPython.Select')
+@register('Jupyter.Select')
 class Select(_Selection):
     """Listbox that only allows one item to be selected at any given time."""
     _view_name = Unicode('SelectView', sync=True)
 
 
-@register('IPython.SelectMultiple')
+@register('Jupyter.SelectMultiple')
 class SelectMultiple(_MultipleSelection):
     """Listbox that allows many items to be selected at any given time.
     Despite their names, inherited from ``_Selection``, the currently chosen

--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -42,13 +42,13 @@ class _SelectionContainer(Box):
             return None
 
 
-@register('IPython.Accordion')
+@register('Jupyter.Accordion')
 class Accordion(_SelectionContainer):
     """Displays children each on a separate accordion page."""
     _view_name = Unicode('AccordionView', sync=True)
 
 
-@register('IPython.Tab')
+@register('Jupyter.Tab')
 class Tab(_SelectionContainer):
     """Displays children each on a separate accordion tab."""
     _view_name = Unicode('TabView', sync=True)

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -23,20 +23,20 @@ class _String(DOMWidget):
             kwargs['value'] = value
         super(_String, self).__init__(**kwargs)
 
-@register('IPython.HTML')
+@register('Jupyter.HTML')
 class HTML(_String):
     """Renders the string `value` as HTML."""
     _view_name = Unicode('HTMLView', sync=True)
 
 
-@register('IPython.Latex')
+@register('Jupyter.Latex')
 class Latex(_String):
     """Renders math inside the string `value` as Latex (requires $ $ or $$ $$ 
     and similar latex tags)."""
     _view_name = Unicode('LatexView', sync=True)
 
 
-@register('IPython.Textarea')
+@register('Jupyter.Textarea')
 class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView', sync=True)
@@ -45,7 +45,7 @@ class Textarea(_String):
         self.send({"method": "scroll_to_bottom"})
 
 
-@register('IPython.Text')
+@register('Jupyter.Text')
 class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)


### PR DESCRIPTION
This registry was meant to replace the class name in the front-end `create_widget` function, in order to be language agnostic. Hence it makes sense for it to be name-spaced with Jupyter rather than IPython.