### PR TITLE
Cross validate frontend and backend widget versions at runtime

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 To release a new version of the widgets on PyPI and npm, first checkout
-master can cd into the ipywidgets subfolder of the repo root.  Then run the 
+master can cd into the ipywidgets subfolder of the repo root.  Make sure the
+`VersionWidget` in `widget.py` has the correct JS front-end version.  Also check 
+that the front-end version specified in `manager-base.js` (`version`) is correct.
+
+Then run the 
 following, replacing the square bracketed content with appropriate values:
 
 ```

--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -38,8 +38,9 @@ def load_ipython_extension(ip):
 def register_comm_target(kernel=None):
     """Register the jupyter.widget comm target"""
     if kernel is None:
-        ip = get_ipython().kernel
+        kernel = get_ipython().kernel
     kernel.comm_manager.register_target('jupyter.widget', Widget.handle_comm_opened)
+    kernel.comm_manager.register_target('jupyter.widget.version', handle_version_comm_opened)
 
 # deprecated alias
 handle_kernel = register_comm_target

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -224,13 +224,11 @@ define([
      * @return {Promise<Boolean>} Whether or not the versions are okay
      */
     ManagerBase.prototype.validateVersion = function() {
-        console.info('validateVersion');
         return this.new_widget({
             model_name: 'WidgetModel',
             widget_class: 'Jupyter.__version',
             model_id: utils.uuid()
         }).then((function(model) {
-            console.info('version widget created');
             var validated = true;
             var backendVersion = this._parseVersion(model.get('version', null));
             if (backendVersion) {
@@ -256,6 +254,7 @@ define([
             model.set('validated', validated);
             model.save();
             
+            if (validated) console.info('Widget backend and frontend versions are compatible');
             return validated;
         }).bind(this));
     };

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -96,10 +96,18 @@ define([
         });
         
         // Validate the version requested by the backend.
-        this.validateVersion().then(function(valid) {
-            if (!valid) {
-                console.warn('Widget frontend version does not match the backend.');
-            }
+        var validate = (function validate() {
+            this.validateVersion().then(function(valid) {
+                if (!valid) {
+                    console.warn('Widget frontend version does not match the backend.');
+                }
+            });
+        }).bind(this);
+        validate();
+        
+        // Revalidate the version when a new kernel connects.
+        this.notebook.events.on('kernel_connected.Kernel', function(event, data) {
+            validate();
         });
     };
     WidgetManager.prototype = Object.create(managerBase.ManagerBase.prototype);

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -101,6 +101,8 @@ define([
                 if (!valid) {
                     console.warn('Widget frontend version does not match the backend.');
                 }
+            }).catch(function(err) {
+                console.error('Could not cross validate the widget frontend and backend versions.', err);
             });
         }).bind(this);
         validate();

--- a/ipywidgets/static/widgets/js/manager.js
+++ b/ipywidgets/static/widgets/js/manager.js
@@ -94,6 +94,13 @@ define([
                 }).catch(utils.reject('Could not call widget save state callback.', true));
             }
         });
+        
+        // Validate the version requested by the backend.
+        this.validateVersion().then(function(valid) {
+            if (!valid) {
+                console.warn('Widget frontend version does not match the backend.');
+            }
+        });
     };
     WidgetManager.prototype = Object.create(managerBase.ManagerBase.prototype);
 

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -1,4 +1,4 @@
-from .widget import Widget, CallbackDispatcher, register, widget_serialization
+from .widget import Widget, CallbackDispatcher, register, widget_serialization, handle_version_comm_opened
 from .domwidget import DOMWidget
 
 from .trait_types import Color, EventfulDict, EventfulList

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -13,7 +13,7 @@ from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from traitlets.utils.importstring import import_item
-from traitlets import Unicode, Dict, Instance, List, Int, Set, Bytes, Bool
+from traitlets import Unicode, Dict, Instance, List, Int, Set, Bytes
 from ipython_genutils.py3compat import string_types, PY3
 
 

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -160,7 +160,6 @@ class Widget(LoggingConfigurable):
     msg_throttle = Int(3, sync=True, help="""Maximum number of msgs the
         front-end can send before receiving an idle msg from the back-end.""")
 
-    version = Int(0, sync=True, help="""Widget's version""")
     keys = List()
     def _keys_default(self):
         return [name for name in self.traits(sync=True)]


### PR DESCRIPTION
I expect this will save a lot of installation head scratching and come in handy for when we split the widgets repo into two pieces.

This also finishes implementing the backend widget registry.

closes #103
closes #148
closes #235