### PR TITLE
Default values for widget model attributes

### DIFF
--- a/examples/development/web/index.js
+++ b/examples/development/web/index.js
@@ -14,15 +14,14 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
         // Create the widget model.
         return manager.new_widget({
-            model_name: 'WidgetModel',
-            widget_class: 'ipywidgets.' + widgetType,
+            model_name: widgetType + 'Model',
+            widget_class: 'jupyter.' + widgetType,
             model_id: uuid()
         // Create a view for the model.
         }).then(function(model) {
             console.log(widgetType + ' model created', model);
 
             model.set({
-                _view_name: widgetType + 'View',
                 description: description || '',
                 value: value || null,
                 visible: true

--- a/examples/notebooks/Widget Layout.ipynb
+++ b/examples/notebooks/Widget Layout.ipynb
@@ -130,7 +130,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**5.** Colorpicker alignment, short and long version"
+    "**5.** Colorpicker alignment, concise and long version"
    ]
   },
   {
@@ -152,7 +152,7 @@
    },
    "outputs": [],
    "source": [
-    "cp.short = True"
+    "cp.concise = True"
    ]
   },
   {
@@ -163,7 +163,7 @@
    },
    "outputs": [],
    "source": [
-    "cp.short = False"
+    "cp.concise = False"
    ]
   },
   {
@@ -196,7 +196,7 @@
    },
    "outputs": [],
    "source": [
-    "cp2.short = True"
+    "cp2.concise = True"
    ]
   },
   {
@@ -207,7 +207,7 @@
    },
    "outputs": [],
    "source": [
-    "cp2.short = False"
+    "cp2.concise = False"
    ]
   },
   {

--- a/ipywidgets/static/widgets/js/layout.js
+++ b/ipywidgets/static/widgets/js/layout.js
@@ -13,8 +13,39 @@ define([
 ], function(widget, _, Backbone, $) {
 
     /**
+     * css properties exposed by the layout widget with their default values.
+     */
+    var css_properties = {
+        align_content: "",
+        align_items: "",
+        align_self: "",
+        border: "",
+        bottom: "",
+        display: "",
+        flex: "",
+        flex_flow: "",
+        height: "",
+        justify_content: "",
+        left: "",
+        margin: "",
+        overflow: "",
+        padding: "",
+        right: "",
+        top: "",
+        visibility: "",
+        width: ""
+    };
+
+    /**
      * Represents a group of CSS style attributes
      */
+    var LayoutModel = widget.WidgetModel.extend({
+        defaults: _.extend({}, widget.WidgetModel.prototype.defaults, {
+            _model_name: "LayoutModel",
+            _view_name: "LayoutView"
+        }, css_properties),
+    });
+
     var LayoutView = widget.WidgetView.extend({
 
         /**
@@ -24,33 +55,7 @@ define([
             LayoutView.__super__.initialize.apply(this, arguments);
             // Register the traits that live on the Python side
             this._traitNames = [];
-            this.initTraits();
-        },
-
-        /**
-         * Initialize the traits for this layout object
-         */
-        initTraits: function() {
-            this.registerTraits(
-                'align_content',
-                'align_items',
-                'align_self',
-                'border',
-                'bottom',
-                'display',
-                'flex',
-                'flex_flow',
-                'height',
-                'justify_content',
-                'left',
-                'margin',
-                'overflow',
-                'padding',
-                'right',
-                'top',
-                'visibility',
-                'width'
-            );
+            this.registerTraits(Object.keys(css_properties));
         },
 
         /**
@@ -126,6 +131,7 @@ define([
     });
 
     return {
-        LayoutView: LayoutView
+        LayoutView: LayoutView,
+        LayoutModel: LayoutModel
     };
 });

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -156,7 +156,6 @@ define([
         }).then(function(model) {
             return model._deserialize_state(msg.content.data).then(function(state) {
                 model.set_state(state);
-                model._buffered_state_diff = {};
                 return model;
             });
         }).catch(utils.reject("Couldn't create a model.", true));

--- a/ipywidgets/static/widgets/js/manager-base.js
+++ b/ipywidgets/static/widgets/js/manager-base.js
@@ -156,6 +156,7 @@ define([
         }).then(function(model) {
             return model._deserialize_state(msg.content.data).then(function(state) {
                 model.set_state(state);
+                model._buffered_state_diff = {};
                 return model;
             });
         }).catch(utils.reject("Couldn't create a model.", true));

--- a/ipywidgets/static/widgets/js/requirejs-shim.js
+++ b/ipywidgets/static/widgets/js/requirejs-shim.js
@@ -11,13 +11,14 @@ function requireLocalFiles() {
     require('./utils');
     require('./widget');
     require('./widget_int');
+    require('./widget_box');
     require('./manager-base');
     require('../css/widgets.min.css');
 }
 
 module.exports = function createDefine(targetModule) {
     var amdefine = require('amdefine')(targetModule, require);
-    
+
     return function define() {
         var args = Array.prototype.slice.call(arguments);
         if (args.length > 1) {

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -249,7 +249,7 @@ define(["./utils",
             // Handle when a widget is updated via the python side.
             this.state_lock = state;
             try {
-                WidgetModel.__super__.set.call(this, state);
+                this.set(state);
                 if (this._first_state) {
                     this.trigger('ready', this);
                     this._first_state = false;
@@ -314,10 +314,16 @@ define(["./utils",
              */
             var return_value = WidgetModel.__super__.set.apply(this, arguments);
 
-            // Backbone only remembers the diff of the most recent set()
-            // operation.  Calling set multiple times in a row results in a
-            // loss of diff information.  Here we keep our own running diff.
-            this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
+            if (!this._first_state) {
+                // Backbone only remembers the diff of the most recent set()
+                // operation.  Calling set multiple times in a row results in a
+                // loss of diff information.  Here we keep our own running diff.
+                //
+                // However, we don't buffer the initial state comming from the
+                // backend or the default values specified in `defaults`.
+                // 
+                this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
+            }
             return return_value;
         },
 

--- a/ipywidgets/static/widgets/js/widget.js
+++ b/ipywidgets/static/widgets/js/widget.js
@@ -39,6 +39,15 @@ define(["./utils",
     };
 
     var WidgetModel = Backbone.Model.extend({
+
+        defaults: {
+            _model_module: null,
+            _model_name: "WidgetModel",
+            _view_module: "",
+            _view_name: null,
+            msg_throttle: 3
+        },
+
         constructor: function (widget_manager, model_id, comm) {
             /**
              * Constructor
@@ -548,7 +557,11 @@ define(["./utils",
         }
     };
 
-    var DOMWidgetModel = WidgetModel.extend({}, {
+    var DOMWidgetModel = WidgetModel.extend({
+        defaults: _.extend({}, WidgetModel.prototype.defaults, {
+            layout: undefined,
+        }),
+    }, {
         serializers: _.extend({
             layout: {deserialize: unpack_models},
         }, WidgetModel.serializers),
@@ -830,7 +843,7 @@ define(["./utils",
             });
         },
     });
-    
+
     managerBase.ManagerBase.register_widget_model('WidgetModel', WidgetModel);
 
     // For backwards compatibility.
@@ -838,16 +851,16 @@ define(["./utils",
     var DOMWidgetView = WidgetView.extend(DOMWidgetViewMixin);
 
     var widget = {
-        'unpack_models': unpack_models,
-        'WidgetModel': WidgetModel,
-        'WidgetViewMixin': WidgetViewMixin,
-        'DOMWidgetViewMixin': DOMWidgetViewMixin,
-        'ViewList': ViewList,
-        'DOMWidgetModel': DOMWidgetModel,
+        unpack_models: unpack_models,
+        WidgetModel: WidgetModel,
+        WidgetViewMixin: WidgetViewMixin,
+        DOMWidgetViewMixin: DOMWidgetViewMixin,
+        ViewList: ViewList,
+        DOMWidgetModel: DOMWidgetModel,
 
         // For backwards compatibility.
-        'WidgetView': WidgetView,
-        'DOMWidgetView': DOMWidgetView,
+        WidgetView: WidgetView,
+        DOMWidgetView: DOMWidgetView,
     };
 
     return widget;

--- a/ipywidgets/static/widgets/js/widget_bool.js
+++ b/ipywidgets/static/widgets/js/widget_bool.js
@@ -9,7 +9,7 @@ define([
     "jquery",
     "underscore",
     "bootstrap",
-], function(widget, $, _){
+], function(widget, $, _) {
 
     var BoolModel = widget.DOMWidgetModel.extend({
         defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {

--- a/ipywidgets/static/widgets/js/widget_bool.js
+++ b/ipywidgets/static/widgets/js/widget_bool.js
@@ -99,7 +99,7 @@ define([
             _model_name: "ToggleButtonModel",
             tooltip: "",
             icon: "",
-            button_style: "primary",
+            button_style: "",
         }),
     });
 

--- a/ipywidgets/static/widgets/js/widget_bool.js
+++ b/ipywidgets/static/widgets/js/widget_bool.js
@@ -7,11 +7,28 @@ if (typeof define !== 'function') { var define = require('./requirejs-shim')(mod
 define([
     "./widget",
     "jquery",
+    "underscore",
     "bootstrap",
-], function(widget, $){
+], function(widget, $, _){
+
+    var BoolModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            value: false,
+            description: "",
+            disabled: false,
+            _model_name: "BoolModel"
+        }),
+    });
+
+    var CheckboxModel = BoolModel.extend({
+        defaults: _.extend({}, BoolModel.prototype.defaults, {
+            _view_name: "CheckboxView",
+            _model_name: "CheckboxModel"
+        }),
+    });
 
     var CheckboxView = widget.DOMWidgetView.extend({
-        render : function(){
+        render: function(){
             /**
              * Called when view is rendered.
              */
@@ -52,7 +69,7 @@ define([
             this.touch();
         },
 
-        update : function(options){
+        update: function(options){
             /**
              * Update the contents of this view
              *
@@ -76,9 +93,18 @@ define([
         },
     });
 
+    var ToggleButtonModel = BoolModel.extend({
+        defaults: _.extend({}, BoolModel.prototype.defaults, {
+            _view_name: "ToggleButtonView",
+            _model_name: "ToggleButtonModel",
+            tooltip: "",
+            icon: "",
+            button_style: "primary",
+        }),
+    });
 
     var ToggleButtonView = widget.DOMWidgetView.extend({
-        render : function() {
+        render: function() {
             /**
              * Called when view is rendered.
              */
@@ -108,7 +134,7 @@ define([
             this.update_mapped_classes(class_map, 'button_style');
         },
 
-        update : function(options){
+        update: function(options){
             /**
              * Update the contents of this view
              *
@@ -150,6 +176,13 @@ define([
         },
     });
 
+    var ValidModel = BoolModel.extend({
+        defaults: _.extend({}, BoolModel.prototype.defaults, {
+            readout: "Invalid",
+            _view_name: "ValidView",
+            _model_name: "ValidModel"
+        }),
+    });
 
     var ValidView = widget.DOMWidgetView.extend({
         render: function() {
@@ -160,6 +193,7 @@ define([
             this.listenTo(this.model, "change", this.update, this);
             this.update();
         },
+
         update: function() {
             /**
              * Update the contents of this view
@@ -188,8 +222,12 @@ define([
 
 
     return {
-        'CheckboxView': CheckboxView,
-        'ToggleButtonView': ToggleButtonView,
-        'ValidView': ValidView,
+        BoolModel: BoolModel,
+        CheckboxModel: CheckboxModel,
+        CheckboxView: CheckboxView,
+        ToggleButtonModel: ToggleButtonModel,
+        ToggleButtonView: ToggleButtonView,
+        ValidModel: ValidModel,
+        ValidView: ValidView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -13,13 +13,28 @@ define([
 ], function(widget, utils, $, _) {
     "use strict";
 
-    var BoxModel = widget.DOMWidgetModel.extend({}, {
+    var BoxModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _view_name: "BoxView",
+            _model_name: "BoxModel",
+            children: [],
+            box_style: "",
+            overflow_x: "",
+            overflow_y: "",
+        }),
+    }, {
         serializers: _.extend({
             children: {deserialize: widget.unpack_models},
-        }, widget.DOMWidgetModel.serializers)
+        }, widget.DOMWidgetModel.serializers),
     });
 
-    var ProxyModel = widget.DOMWidgetModel.extend({}, {
+    var ProxyModel = widget.DOMWidgetModel.extend({
+        defaults: {
+            _view_name: "ProxyView",
+            _model_name: "ProxyModel",
+            child: null,
+        },
+    }, {
         serializers: _.extend({
             child: {deserialize: widget.unpack_models},
         }, widget.DOMWidgetModel.serializers),

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -29,11 +29,11 @@ define([
     });
 
     var ProxyModel = widget.DOMWidgetModel.extend({
-        defaults: {
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
             _view_name: "ProxyView",
             _model_name: "ProxyModel",
             child: null,
-        },
+        }),
     }, {
         serializers: _.extend({
             child: {deserialize: widget.unpack_models},
@@ -101,6 +101,14 @@ define([
         update_attr: function(name, value) { // TODO: Deprecated in 5.0
             this.$box.css(name, value);
         },
+    });
+
+    var PlaceProxyModel = ProxyModel.extend({
+        defaults: _.extend({}, ProxyModel.prototype.defaults, {
+            _view_name: "PlaceProxyView",
+            _model_name: "PlaceProxyModel",
+            selector: "",
+        }),
     });
 
     var PlaceProxyView = ProxyView.extend({
@@ -203,6 +211,15 @@ define([
         },
     });
 
+    var FlexBoxModel = BoxModel.extend({ // TODO: Deprecated in 5.0 (entire model)
+        defaults: _.extend({}, BoxModel.prototype.defaults, {
+            _view_name: "FlexBoxView",
+            _model_name: "FlexBoxModel",
+            orientation: "vertical",
+            pack: "start",
+            alignt: "start",
+        }),
+    });
 
     var FlexBoxView = BoxView.extend({ // TODO: Deprecated in 5.0 (entire view)
         render: function() {
@@ -250,10 +267,12 @@ define([
 
     return {
         BoxModel: BoxModel,
-        ProxyModel: ProxyModel,
         BoxView: BoxView,
+        FlexBoxModel: FlexBoxModel, // TODO: Deprecated in 5.0
         FlexBoxView: FlexBoxView, // TODO: Deprecated in 5.0
+        ProxyModel: ProxyModel,
         ProxyView: ProxyView,
+        PlaceProxyModel: PlaceProxyModel,
         PlaceProxyView: PlaceProxyView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -7,8 +7,21 @@ if (typeof define !== 'function') { var define = require('./requirejs-shim')(mod
 define([
     "./widget",
     "jquery",
+    "underscore",
     "bootstrap",
-], function(widget, $){
+], function(widget, $, _) {
+
+    var ButtonModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            description: "",
+            tooltip: "",
+            disabled: false,
+            icon: "",
+            button_style: "",
+            _view_name: "ButtonView",
+            _model_name: "ButtonModel"
+        }),
+    });
 
     var ButtonView = widget.DOMWidgetView.extend({
         render: function() {
@@ -23,12 +36,12 @@ define([
 
             this.update(); // Set defaults.
         },
-        
+
         update: function() {
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed. The model may have been 
+             * Called when the model is changed. The model may have been
              * changed by another view or by a state update from the back-end.
              */
             this.$el.prop("disabled", this.model.get("disabled"));
@@ -61,7 +74,7 @@ define([
             // Dictionary of events and their handlers.
             'click': '_handle_click',
         },
-        
+
         _handle_click: function() {
             /**
              * Handles when the button is clicked.
@@ -71,6 +84,7 @@ define([
     });
 
     return {
-        'ButtonView': ButtonView,
+        ButtonView: ButtonView,
+        ButtonModel: ButtonModel
     };
 });

--- a/ipywidgets/static/widgets/js/widget_color.js
+++ b/ipywidgets/static/widgets/js/widget_color.js
@@ -6,9 +6,20 @@ if (typeof define !== 'function') { var define = require('./requirejs-shim')(mod
 
 define([
     "./widget",
-], function(widget) {
+    "underscore",
+], function(widget, _) {
 
-    var ColorPicker = widget.DOMWidgetView.extend({
+    var ColorPickerModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            value: "black",
+            description: "",
+            "short": false,
+            _model_name: "ColorPickerModel",
+            _view_name: "ColorPickerView",
+        }),
+    });
+
+    var ColorPickerView = widget.DOMWidgetView.extend({
         render: function() {
             this.$el.addClass("ipy-widget widget-hbox widget-colorpicker");
 
@@ -103,6 +114,7 @@ define([
     };
 
     return {
-        ColorPicker: ColorPicker,
+        ColorPickerModel: ColorPickerModel,
+        ColorPickerView: ColorPickerView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_color.js
+++ b/ipywidgets/static/widgets/js/widget_color.js
@@ -13,7 +13,7 @@ define([
         defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
             value: "black",
             description: "",
-            "short": false,
+            concise: false,
             _model_name: "ColorPickerModel",
             _view_name: "ColorPickerView",
         }),
@@ -42,11 +42,11 @@ define([
 
             this.listenTo(this.model, "change:value", this._update_value, this);
             this.listenTo(this.model, "change:description", this._update_description, this);
-            this.listenTo(this.model, "change:short", this._update_short, this);
+            this.listenTo(this.model, "change:concise", this._update_concise, this);
             this.$colorpicker.on("change", this._picker_change.bind(this));
             this.$textbox.on("change", this._text_change.bind(this));
 
-            this._update_short();
+            this._update_concise();
             this._update_value();
             this._update_description();
         },
@@ -66,14 +66,14 @@ define([
                 this.$label.show();
             }
         },
-        _update_short: function() {
-            var short = this.model.get('short');
-            if (short) {
-                this.$el.addClass('short');
+        _update_concise: function() {
+            var concise = this.model.get("concise");
+            if (concise) {
+                this.$el.addClass("concise");
                 this.$colorpicker.removeClass("input-group-addon");
                 this.$textbox.hide();
             } else {
-                this.$el.removeClass('short');
+                this.$el.removeClass("concise");
                 this.$colorpicker.addClass("input-group-addon");
                 this.$textbox.show();
             }

--- a/ipywidgets/static/widgets/js/widget_controller.js
+++ b/ipywidgets/static/widgets/js/widget_controller.js
@@ -10,12 +10,21 @@ define([
     "jquery",
     "underscore"
 ], function(widget, utils, $, _) {
-    'use strict';
+    "use strict";
 
-    var Button = widget.DOMWidgetView.extend({
+    var ControllerButtonModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "ControllerButtonModel",
+            _view_name: "ControllerButtonView",
+            value: 0.0,
+            pressed: false,
+        }),
+    });
+
+    var ControllerButtonView = widget.DOMWidgetView.extend({
         /* Very simple view for a gamepad button. */
 
-        render : function() {
+        render: function() {
             this.$el.addClass('ipy-widget widget-controller-button');
 
             this.$support = $('<div />').css({
@@ -42,17 +51,23 @@ define([
             this.update();
         },
 
-        update : function() {
+        update: function() {
             this.$bar.css('height', 100 * this.model.get('value') + '%');
         },
 
     });
 
-    var Axis = widget.DOMWidgetView.extend({
+    var ControllerAxisModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "ControllerAxisModel",
+            _view_name: "ControllerAxisView",
+            value: 0.0,
+        }),
+    });
+
+    var ControllerAxisView = widget.DOMWidgetView.extend({
         /* Very simple view for a gamepad axis. */
-
-        render : function() {
-
+        render: function() {
             this.$el.addClass('ipy-widget widget-controller-axis');
             
             this.$el.css({
@@ -84,14 +99,25 @@ define([
             this.update();
         },
 
-        update : function() {
+        update: function() {
             this.$bullet.css('top', 50 * (this.model.get('value') + 1) + '%');
         },
 
     });
 
-    var Controller = widget.DOMWidgetModel.extend({
+    var ControllerModel = widget.DOMWidgetModel.extend({
         /* The Controller model. */
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "ControllerModel",
+            _view_name: "ControllerView",
+            index: 0,
+            name: "",
+            mapping: "",
+            connected: false,
+            timestamp: 0,
+            buttons: [],
+            axez: [],
+        }),
 
         initialize: function() {
             if (navigator.getGamepads === void 0) {
@@ -325,9 +351,11 @@ define([
     });
 
     return {
-        ControllerButton: Button,
-        ControllerAxis: Axis,
-        Controller: Controller,
+        ControllerButtonView: ControllerButtonView,
+        ControllerButtonModel: ControllerButtonModel,
+        ControllerAxisView: ControllerAxisView,
+        ControllerAxisModel: ControllerAxisModel,      
+        ControllerModel: ControllerModel,
         ControllerView: ControllerView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_float.js
+++ b/ipywidgets/static/widgets/js/widget_float.js
@@ -31,7 +31,7 @@ define([
     });
 
     return {
-        'FloatSliderView': FloatSliderView,
-        'FloatTextView': FloatTextView,
+        FloatSliderView: FloatSliderView,
+        FloatTextView: FloatTextView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_image.js
+++ b/ipywidgets/static/widgets/js/widget_image.js
@@ -7,9 +7,21 @@ if (typeof define !== 'function') { var define = require('./requirejs-shim')(mod
 define([
     "./widget",
     "jquery",
-], function(widget, $) {
-    
-    var ImageView = widget.DOMWidgetView.extend({  
+    "underscore",
+], function(widget, $, _) {
+
+    var ImageModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "ImageModel",
+            _view_name: "ImageView",
+            format: "png",
+            width: "",
+            height: "",
+            _b64value: ""
+        }),
+    });
+
+    var ImageView = widget.DOMWidgetView.extend({
         render : function() {
             /**
              * Called when view is rendered.
@@ -18,24 +30,24 @@ define([
                 .addClass("ipy-widget widget-image"));
             this.update(); // Set defaults.
         },
-        
+
         update : function() {
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed.  The model may have been 
+             * Called when the model is changed.  The model may have been
              * changed by another view or by a state update from the back-end.
              */
             var image_src = 'data:image/' + this.model.get('format') + ';base64,' + this.model.get('_b64value');
             this.$el.attr('src', image_src);
-            
+
             var width = this.model.get('width');
             if (width !== undefined && width.length > 0) {
                 this.$el.attr('width', width);
             } else {
                 this.$el.removeAttr('width');
             }
-            
+
             var height = this.model.get('height');
             if (height !== undefined && height.length > 0) {
                 this.$el.attr('height', height);
@@ -47,6 +59,7 @@ define([
     });
 
     return {
-        'ImageView': ImageView,
+        ImageView: ImageView,
+        ImageModel: ImageModel,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_int.js
+++ b/ipywidgets/static/widgets/js/widget_int.js
@@ -12,6 +12,36 @@ define([
     "jquery-ui"
 ], function(widget, _, $) {
 
+    var IntModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "IntModel",
+            value: 0,
+            disabled: false,
+            description: ""
+        }),
+    });
+
+    var BoundedIntModel = IntModel.extend({
+        defaults: _.extend({}, IntModel.prototype.defaults, {
+            _model_name: "BoundedIntModel",
+            step: 1,
+            max: 100,
+            min: 0
+        }),
+    });
+
+    var IntSliderModel = BoundedIntModel.extend({
+        defaults: _.extend({}, BoundedIntModel.prototype.defaults, {
+            _model_name: "IntSliderModel",
+            _view_name: "IntSliderView",
+            orientation: "horizontal",
+            _range: false,
+            readout: true,
+            slider_color: null,
+            continuous_update: true
+        }),
+    });
+
     var IntSliderView = widget.DOMWidgetView.extend({
         render : function() {
             /**
@@ -27,7 +57,7 @@ define([
             this.$slider = $('<div />')
                 .slider({})
                 .addClass('slider');
-            // Put the slider in a container 
+            // Put the slider in a container
             this.$slider_container = $('<div />')
                 .addClass('slider-container')
                 .append(this.$slider);
@@ -41,7 +71,7 @@ define([
                 
             this.listenTo(this.model, 'change:slider_handleTextChangecolor', function(sender, value) {
                 this.$slider.find('a').css('background', value);
-            }, this);            
+            }, this);
             this.listenTo(this.model, 'change:description', function(sender, value) {
                 this.updateDescription();
             }, this);
@@ -336,8 +366,14 @@ define([
         },
     });
 
+    var IntTextModel = IntModel.extend({
+        defaults: _.extend({}, IntModel.prototype.defaults, {
+            _model_name: "IntTextModel",
+            _view_name: "IntTextView"
+        }),
+    });
 
-    var IntTextView = widget.DOMWidgetView.extend({    
+    var IntTextView = widget.DOMWidgetView.extend({
         render : function() {
             /**
              * Called when view is rendered.
@@ -352,7 +388,7 @@ define([
                 .addClass('form-control')
                 .addClass('widget-numeric-text')
                 .appendTo(this.$el);
-                
+
             this.listenTo(this.model, 'change:description', function(sender, value) {
                 this.updateDescription();
             }, this);
@@ -412,9 +448,9 @@ define([
 
             // Fires only when control is validated or looses focus.
             "change input" : "handleChanged"
-        }, 
+        },
         
-        handleChanging: function(e) { 
+        handleChanging: function(e) {
             /**
              * Handles and validates user input.
              *
@@ -443,15 +479,15 @@ define([
                 
                 // Apply the value if it has changed.
                 if (numericalValue != this.model.get('value')) {
-            
-                    // Calling model.set will trigger all of the other views of the 
+
+                    // Calling model.set will trigger all of the other views of the
                     // model to update.
                     this.model.set('value', numericalValue, {updated_view: this});
                     this.touch();
                 }
             }
         },
-        
+
         handleChanged: function(e) {
             /**
              * Applies validated input.
@@ -464,6 +500,14 @@ define([
         _parse_value: parseInt
     });
 
+    var ProgressModel = BoundedIntModel.extend({
+        defaults: _.extend({}, BoundedIntModel.prototype.defaults, {
+            _model_name: "ProgressModel",
+            _view_name: "ProgressView",
+            orientation: "horisontal",
+            bar_style: ""
+        }),
+    });
 
     var ProgressView = widget.DOMWidgetView.extend({
         render : function() {
@@ -487,9 +531,9 @@ define([
                     'bottom': 0, 'left': 0,
                 })
                 .appendTo(this.$progress);
-            
+
             // Set defaults.
-            this.update(); 
+            this.update();
             this.updateDescription();
            
             this.listenTo(this.model, "change:bar_style", this.update_bar_style, this);
@@ -507,14 +551,14 @@ define([
             } else {
                 this.typeset(this.$label, description);
                 this.$label.show();
-            }    
+            }
         },
         
         update : function() {
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed.  The model may have been 
+             * Called when the model is changed.  The model may have been
              * changed by another view or by a state update from the back-end.
              */
             var value = this.model.get('value');
@@ -544,7 +588,7 @@ define([
                 });
             }
             return ProgressView.__super__.update.apply(this);
-        }, 
+        },
 
         update_bar_style: function() {
             var class_map = {
@@ -560,7 +604,7 @@ define([
             /**
              * Set a css attr of the widget view.
              */
-            if (name == 'color') {                
+            if (name == "color") {
                 this.$bar.css('background', value);
             } else if (name.substring(0, 6) == 'border' || name == 'background') {
                 this.$progress.css(name, value);
@@ -571,8 +615,13 @@ define([
     });
 
     return {
-        'IntSliderView': IntSliderView, 
-        'IntTextView': IntTextView,
-        'ProgressView': ProgressView,
+        IntModel: IntModel,
+        BoundedIntModel: BoundedIntModel,
+        IntSliderModel: IntSliderModel,
+        IntSliderView: IntSliderView,
+        IntTextModel: IntTextModel,
+        IntTextView: IntTextView,
+        ProgressModel: ProgressModel,
+        ProgressView: ProgressView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_link.js
+++ b/ipywidgets/static/widgets/js/widget_link.js
@@ -12,6 +12,11 @@ define([
 
     var BaseLinkModel = widget.WidgetModel.extend({
 
+        defaults: _.extend({}, widget.WidgetModel.prototype.defaults, {
+            target: undefined,
+            source: undefined,
+        }),
+
         update_value: function(source, target) {
             if (this.updating) {
                 return;
@@ -50,6 +55,10 @@ define([
 
     var LinkModel = BaseLinkModel.extend({
 
+        defaults: _.extend({}, BaseLinkModel.prototype.defaults, {
+            _model_name: "LinkModel"
+        }),
+
         initialize: function() {
             this.on("change", this.update_bindings, this);
         },
@@ -72,10 +81,13 @@ define([
                 this.listenToOnce(this.target[0], "destroy", this.cleanup, this);
             }
         },
-
     });
 
     var DirectionalLinkModel = BaseLinkModel.extend({
+
+        defaults: _.extend({}, BaseLinkModel.prototype.defaults, {
+            _model_name: "DirectionalLinkModel"
+        }),
 
         initialize: function() {
             this.on("change", this.update_bindings, this);
@@ -100,7 +112,7 @@ define([
     });
 
     return {
-        "LinkModel": LinkModel,
-        "DirectionalLinkModel": DirectionalLinkModel,
+        LinkModel: LinkModel,
+        DirectionalLinkModel: DirectionalLinkModel,
     }
 });

--- a/ipywidgets/static/widgets/js/widget_output.js
+++ b/ipywidgets/static/widgets/js/widget_output.js
@@ -7,27 +7,29 @@
 define([
     "./widget",
     "jquery",
-    'notebook/js/outputarea',
-], function(widget, $, outputarea) {
-    'use strict';
+    "notebook/js/outputarea",
+    "underscore",
+], function(widget, $, outputarea, _) {
+    "use strict";
+
+    var OutputModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "OutputModel",
+            _view_name: "OutputView"
+        }),
+    });
 
     var OutputView = widget.DOMWidgetView.extend({
-        /**
-         * Public constructor
-         */
         initialize: function (parameters) {
             OutputView.__super__.initialize.apply(this, [parameters]);
             this.listenTo(this.model, 'msg:custom', this._handle_route_msg, this);
         },
 
-        /**
-         * Called when view is rendered.
-         */
         render: function(){
             this.output_area = new outputarea.OutputArea({
-                selector: this.$el, 
-                prompt_area: false, 
-                events: this.model.widget_manager.notebook.events, 
+                selector: this.$el,
+                prompt_area: false,
+                events: this.model.widget_manager.notebook.events,
                 keyboard_manager: this.model.widget_manager.keyboard_manager });
 
             // Make output area reactive.
@@ -45,7 +47,7 @@ define([
             // Set initial contents.
             this.output_area.element.html(this.model.get('contents'));
         },
-        
+
         /**
          * Handles re-routed iopub messages.
          */
@@ -62,6 +64,7 @@ define([
     });
 
     return {
-        'OutputView': OutputView,
+        OutputView: OutputView,
+        OutputModel: OutputModel,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_selection.js
+++ b/ipywidgets/static/widgets/js/widget_selection.js
@@ -12,11 +12,26 @@ define([
     "bootstrap",
 ], function(widget, utils, $, _) {
 
+    var SelectionModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            _model_name: "SelectionModel",
+            selected_label: "",
+            _options_labels: [],
+            disabled: false,
+            description: "",
+        }),
+    });
+
+    var DropdownModel = SelectionModel.extend({
+        defaults: _.extend({}, SelectionModel.prototype.defaults, {
+            _model_name: "DropdownModel",
+            _view_name: "DropdownView",
+            button_style: ""
+        }),
+    });
+
     var DropdownView = widget.DOMWidgetView.extend({
         render : function() {
-            /**
-             * Called when view is rendered.
-             */
             this.$el
                 .addClass('ipy-widget widget-hbox widget-dropdown');
             this.$label = $('<div />')
@@ -149,6 +164,16 @@ define([
 
     });
 
+    var RadioButtonsModel = SelectionModel.extend({
+        defaults: _.extend({}, SelectionModel.prototype.defaults, {
+            _model_name: "RadioButtonsModel",
+            _view_name: "RadioButtonsView",
+            tooltips: [],
+            icons: [],
+            button_style: ""
+        }),
+    });
+
     var RadioButtonsView = widget.DOMWidgetView.extend({
         render : function() {
             /**
@@ -255,6 +280,12 @@ define([
         },
     });
 
+    var ToggleButtonsModel = SelectionModel.extend({
+        defaults: _.extend({}, SelectionModel.prototype.defaults, {
+            _model_name: "ToggleButtonsModel",
+            _view_name: "ToggleButtonsView",
+        }),
+    });
 
     var ToggleButtonsView = widget.DOMWidgetView.extend({
         initialize: function() {
@@ -410,6 +441,12 @@ define([
         },
     });
 
+    var SelectModel = SelectionModel.extend({
+        defaults: _.extend({}, SelectionModel.prototype.defaults, {
+            _model_name: "SelectModel",
+            _view_name: "SelectView",
+        }),
+    });
 
     var SelectView = widget.DOMWidgetView.extend({
         render: function() {
@@ -517,6 +554,19 @@ define([
         },
     });
 
+    var MultipleSelectionModel = SelectionModel.extend({
+        defaults: _.extend({}, SelectionModel.prototype.defaults, {
+            _model_name: "MultipleSelectionModel",
+            selected_labels: [],
+        }),
+    });
+
+    var SelectMultipleModel = MultipleSelectionModel.extend({
+        defaults: _.extend({}, MultipleSelectionModel.prototype.defaults, {
+            _model_name: "SelectMultipleModel",
+            _view_name: "SelectMultipleView",
+        }),
+    });
 
     var SelectMultipleView = SelectView.extend({
         render: function() {
@@ -577,12 +627,18 @@ define([
         },
     });
 
-
     return {
-        'DropdownView': DropdownView,
-        'RadioButtonsView': RadioButtonsView,
-        'ToggleButtonsView': ToggleButtonsView,
-        'SelectView': SelectView,
-        'SelectMultipleView': SelectMultipleView,
+        SelectionModel: SelectionModel,
+        DropdownView: DropdownView,
+        DropdownModel: DropdownModel,
+        RadioButtonsView: RadioButtonsView,
+        RadioButtonsModel: RadioButtonsModel,
+        ToggleButtonsView: ToggleButtonsView,
+        ToggleButtonsModel: ToggleButtonsModel,
+        SelectView: SelectView,
+        SelectModel: SelectModel,
+        MultipleSelectionModel: MultipleSelectionModel,
+        SelectMultipleView: SelectMultipleView,
+        SelectMultipleModel: SelectMultipleModel,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -7,9 +7,26 @@ if (typeof define !== 'function') { var define = require('./requirejs-shim')(mod
 define([
     "./widget",
     "./utils",
+    "./widget_box",
     "jquery",
+    "underscore",
     "bootstrap",
-], function(widget, utils, $) {
+], function(widget, utils, box, $, _) {
+
+    var SelectionContainerModel = box.BoxModel.extend({
+        defaults: _.extend({}, box.BoxModel.prototype.defaults, {
+            _model_name: "SelectionContainerModel",
+            selected_index: 0,
+            _titles: {},
+        }),
+    });
+
+    var AccordionModel = SelectionContainerModel.extend({
+        defaults: _.extend({}, SelectionContainerModel.prototype.defaults, {
+            _model_name: "AccordionModel",
+            _view_name: "AccordionView"
+        }),
+    });
 
     var AccordionView = widget.DOMWidgetView.extend({
         initialize: function(){
@@ -74,7 +91,7 @@ define([
                 this.expandTab(new_index);
             }
         },
-        
+
         /**
          * Collapses an accordion tab.
          * @param  {number} index
@@ -82,26 +99,26 @@ define([
         collapseTab: function(index) {
             // .children('.panel-collapse')
             var page = this.containers[index].children('.collapse');
-            
+
             if (page.hasClass('in')) {
                 page.removeClass('in');
                 page.collapse('hide');
             }
         },
-        
+
         /**
          * Expands an accordion tab.
          * @param  {number} index
          */
         expandTab: function(index) {
             var page = this.containers[index].children('.collapse');
-            
+
             if (!page.hasClass('in')) {
                 page.addClass('in');
                 page.collapse('show');
             }
         },
-        
+
         remove_child_view: function(view) {
             /**
              * Called when a child is removed from children list.
@@ -132,10 +149,9 @@ define([
                 .attr('data-toggle', 'collapse')
                 .attr('data-parent', '#' + this.$el.attr('id'))
                 .attr('href', '#' + uuid)
-                .click(function(evt) { 
-            
-                    // Calling model.set will trigger all of the other views of the 
-                    // model to update.
+                .click(function(evt) {
+                    // Calling model.set will trigger all of the other views of
+                    // the model to update.
                     that.model.set("selected_index", index, {updated_view: that});
                     that.touch();
                  })
@@ -150,7 +166,7 @@ define([
             var container_index = this.containers.push(accordion_group) - 1;
             accordion_group.container_index = container_index;
             this.model_containers[model.id] = accordion_group;
-            
+
             var dummy = $('<div/>');
             accordion_inner.append(dummy);
             return this.create_child_view(model).then(function(view) {
@@ -165,7 +181,7 @@ define([
                 return view;
             }).catch(utils.reject("Couldn't add child view to box", true));
         },
-        
+
         remove: function() {
             /**
              * We remove this widget before removing the children as an optimization
@@ -176,15 +192,20 @@ define([
             this.children_views.remove();
         },
     });
-    
 
-    var TabView = widget.DOMWidgetView.extend({    
+    var TabModel = SelectionContainerModel.extend({
+        defaults: _.extend({}, SelectionContainerModel.prototype.defaults, {
+            _model_name: "TabModel",
+            _view_name: "TabView"
+        }),
+    });
+
+    var TabView = widget.DOMWidgetView.extend({
         initialize: function() {
             /**
              * Public constructor.
              */
             TabView.__super__.initialize.apply(this, arguments);
-            
             this.containers = [];
             this.children_views = new widget.ViewList(this.add_child_view, this.remove_child_view, this);
             this.listenTo(this.model, 'change:children', function(model, value) {
@@ -242,13 +263,12 @@ define([
 
             var tab_text = $('<a />')
                 .attr('href', '#' + uuid)
-                .attr('data-toggle', 'tab') 
+                .attr('data-toggle', 'tab')
                 .text('Page ' + index)
                 .appendTo(tab)
                 .click(function (e) {
-            
-                    // Calling model.set will trigger all of the other views of the 
-                    // model to update.
+                    // Calling model.set will trigger all of the other views of
+                    // the model to update.
                     that.model.set("selected_index", index, {updated_view: that});
                     that.touch();
                     that.select_page(index);
@@ -281,7 +301,7 @@ define([
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed.  The model may have been 
+             * Called when the model is changed.  The model may have been
              * changed by another view or by a state update from the back-end.
              */
             this.update_titles();
@@ -299,7 +319,7 @@ define([
                var tab_text = that.containers[page_index];
                 if (tab_text !== undefined) {
                     tab_text.text(title);
-                } 
+                }
             });
         },
 
@@ -323,7 +343,7 @@ define([
                 .removeClass('active');
             this.containers[index].tab('show');
         },
-        
+
         remove: function() {
             /**
              * We remove this widget before removing the children as an optimization
@@ -336,7 +356,10 @@ define([
     });
 
     return {
-        'AccordionView': AccordionView,
-        'TabView': TabView,
+        SelectionContainerModel: SelectionContainerModel,
+        AccordionModel: AccordionModel,
+        AccordionView: AccordionView,
+        TabModel: TabModel,
+        TabView: TabView,
     };
 });

--- a/ipywidgets/static/widgets/js/widget_string.js
+++ b/ipywidgets/static/widgets/js/widget_string.js
@@ -7,10 +7,28 @@ if (typeof define !== 'function') { var define = require('./requirejs-shim')(mod
 define([
     "./widget",
     "jquery",
+    "underscore",
     "bootstrap",
-], function(widget, $) {
+], function(widget, $, _) {
 
-    var HTMLView = widget.DOMWidgetView.extend({  
+    var StringModel = widget.DOMWidgetModel.extend({
+        defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+            value: "",
+            disabled: false,
+            description: "",
+            placeholder: "",
+            _model_name: "StringModel"
+        }),
+    });
+
+    var HTMLModel = StringModel.extend({
+        defaults: _.extend({}, StringModel.prototype.defaults, {
+            _view_name: "HTMLView",
+            _model_name: "HTMLModel"
+        }),
+    });
+
+    var HTMLView = widget.DOMWidgetView.extend({
         render : function() {
             /**
              * Called when view is rendered.
@@ -19,12 +37,12 @@ define([
                 .addClass('ipy-widget widget-html');
             this.update(); // Set defaults.
         },
-        
+
         update : function() {
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed.  The model may have been 
+             * Called when the model is changed.  The model may have been
              * changed by another view or by a state update from the back-end.
              */
             this.$el.html(this.model.get('value')); // CAUTION! .html(...) CALL MANDATORY!!!
@@ -32,8 +50,14 @@ define([
         },
     });
 
+    var LatexModel = StringModel.extend({
+        defaults: _.extend({}, StringModel.prototype.defaults, {
+            _view_name: "LatexView",
+            _model_name: "LatexModel"
+        }),
+    });
 
-    var LatexView = widget.DOMWidgetView.extend({  
+    var LatexView = widget.DOMWidgetView.extend({
         render : function() {
             /**
              * Called when view is rendered.
@@ -42,21 +66,27 @@ define([
                 .addClass('ipy-widget widget-latex');
             this.update(); // Set defaults.
         },
-        
+
         update : function() {
             /**
              * Update the contents of this view
              *
-             * Called when the model is changed.  The model may have been 
+             * Called when the model is changed.  The model may have been
              * changed by another view or by a state update from the back-end.
              */
             this.typeset(this.$el, this.model.get('value'));
             return LatexView.__super__.update.apply(this);
-        }, 
+        },
     });
 
+    var TextareaModel = StringModel.extend({
+        defaults: _.extend({}, StringModel.prototype.defaults, {
+            _view_name: "TextareaView",
+            _model_name: "TextareaModel"
+        }),
+    });
 
-    var TextareaView = widget.DOMWidgetView.extend({  
+    var TextareaView = widget.DOMWidgetView.extend({
         render: function() {
             /**
              * Called when view is rendered.
@@ -134,12 +164,12 @@ define([
             "paste textarea" : "handleChanging",
             "cut textarea"   : "handleChanging"
         },
-        
-        handleChanging: function(e) { 
+
+        handleChanging: function(e) {
             /**
              * Handles and validates user input.
              *
-             * Calling model.set will trigger all of the other views of the 
+             * Calling model.set will trigger all of the other views of the
              * model to update.
              */
             this.model.set('value', e.target.value, {updated_view: this});
@@ -147,8 +177,14 @@ define([
         },
     });
 
+    var TextModel = StringModel.extend({
+        defaults: _.extend({}, StringModel.prototype.defaults, {
+            _view_name: "TextView",
+            _model_name: "TextModel"
+        }),
+    });
 
-    var TextView = widget.DOMWidgetView.extend({  
+    var TextView = widget.DOMWidgetView.extend({
         render: function() {
             /**
              * Called when view is rendered.
@@ -225,7 +261,7 @@ define([
             this.touch();
         },
         
-        handleKeypress: function(e) { 
+        handleKeypress: function(e) {
             /**
              * Handles text submition
              */
@@ -237,7 +273,7 @@ define([
             }
         },
 
-        handleBlur: function(e) { 
+        handleBlur: function(e) {
             /**
              * Prevent a blur from firing if the blur was not user intended.
              * This is a workaround for the return-key focus loss bug.
@@ -251,7 +287,7 @@ define([
             }
         },
 
-        handleFocusOut: function(e) { 
+        handleFocusOut: function(e) {
             /**
              * Prevent a blur from firing if the blur was not user intended.
              * This is a workaround for the return-key focus loss bug.
@@ -265,9 +301,14 @@ define([
     });
 
     return {
-        'HTMLView': HTMLView,
-        'LatexView': LatexView,
-        'TextareaView': TextareaView,
-        'TextView': TextView,
+        StringModel: StringModel,
+        HTMLView: HTMLView,
+        HTMLModel: HTMLModel,
+        LatexView: LatexView,
+        LatexModel: LatexModel,
+        TextareaView: TextareaView,
+        TextareaModel: TextareaModel,
+        TextView: TextView,
+        TextModel: TextModel,
     };
 });

--- a/ipywidgets/widgets/widget_bool.py
+++ b/ipywidgets/widgets/widget_bool.py
@@ -22,37 +22,42 @@ class _Bool(DOMWidget):
             kwargs['value'] = value
         super(_Bool, self).__init__(**kwargs)
 
+    _model_name = Unicode('BoolModel', sync=True)
+
 
 @register('Jupyter.Checkbox')
 class Checkbox(_Bool):
     """Displays a boolean `value` in the form of a checkbox.
 
-       Parameters
-       ----------
-       value : {True,False}
-           value of the checkbox: True-checked, False-unchecked
-       description : str
-	   description displayed next to the checkbox
-"""
+    Parameters
+    ----------
+    value : {True,False}
+       value of the checkbox: True-checked, False-unchecked
+    description : str
+	     description displayed next to the checkbox
+    """
     _view_name = Unicode('CheckboxView', sync=True)
+    _model_name = Unicode('CheckboxModel', sync=True)
 
 
 @register('Jupyter.ToggleButton')
 class ToggleButton(_Bool):
     """Displays a boolean `value` in the form of a toggle button.
 
-       Parameters
-       ----------
-       value : {True,False}
-           value of the toggle button: True-pressed, False-unpressed
-       description : str
-	   description displayed next to the button
-       tooltip: str
-           tooltip caption of the toggle button
-       icon: str
-           font-awesome icon name
-"""
+    Parameters
+    ----------
+    value : {True,False}
+        value of the toggle button: True-pressed, False-unpressed
+    description : str
+	      description displayed next to the button
+    tooltip: str
+        tooltip caption of the toggle button
+    icon: str
+        font-awesome icon name
+    """
     _view_name = Unicode('ToggleButtonView', sync=True)
+    _model_name = Unicode('ToggleButtonModel', sync=True)
+
     tooltip = Unicode(help="Tooltip caption of the toggle button.", sync=True)
     icon = Unicode('', help= "Font-awesome icon.", sync=True)
 
@@ -63,7 +68,6 @@ class ToggleButton(_Bool):
 
 @register('Jupyter.Valid')
 class Valid(_Bool):
-
     """Displays a boolean `value` in the form of a green check (True / valid)
     or a red cross (False / invalid).
 
@@ -71,6 +75,8 @@ class Valid(_Bool):
     ----------
     value: {True,False}
         value of the Valid widget
-"""
-    readout = Unicode(help="Message displayed when the value is False", sync=True)
+    """
+    readout = Unicode('Invalid', help="Message displayed when the value is False", sync=True)
     _view_name = Unicode('ValidView', sync=True)
+    _model_name = Unicode('ValidModel', sync=True)
+

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -71,6 +71,7 @@ class Proxy(Widget):
 class PlaceProxy(Proxy):
     """Renders the child widget at the specified selector."""
     _view_name = Unicode('PlaceProxyView', sync=True)
+    _model_name = Unicode('PlaceProxyModel', sync=True)
     selector = Unicode(sync=True)
 
 
@@ -93,6 +94,7 @@ def HBox(*pargs, **kwargs):
 class FlexBox(Box): # TODO: Deprecated in 5.0 (entire class)
     """Displays multiple widgets using the flexible box model."""
     _view_name = Unicode('FlexBoxView', sync=True)
+    _model_name = Unicode('FlexBoxModel', sync=True)
     orientation = CaselessStrEnum(values=['vertical', 'horizontal'], default_value='vertical', sync=True)
     flex = Int(0, sync=True, help="""Specify the flexible-ness of the model.""")
     def _flex_changed(self, name, old, new):

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -29,8 +29,8 @@ class Button(DOMWidget):
        font-awesome icon name
     """
     _view_name = Unicode('ButtonView', sync=True)
+    _model_name = Unicode('ButtonModel', sync=True)
 
-    # Keys
     description = Unicode('', help="Button label.", sync=True)
     tooltip = Unicode(help="Tooltip caption of the button.", sync=True)
     disabled = Bool(False, help="Enable or disable user changes.", sync=True)
@@ -41,7 +41,6 @@ class Button(DOMWidget):
         sync=True, help="""Use a predefined styling for the button.""")
 
     def __init__(self, **kwargs):
-        """Constructor"""
         super(Button, self).__init__(**kwargs)
         self._click_handlers = CallbackDispatcher()
         self.on_msg(self._handle_button_msg)

--- a/ipywidgets/widgets/widget_color.py
+++ b/ipywidgets/widgets/widget_color.py
@@ -18,4 +18,5 @@ class ColorPicker(DOMWidget):
     short = Bool(sync=True)
     description = Unicode(sync=True)
 
-    _view_name = Unicode('ColorPicker', sync=True)
+    _view_name = Unicode('ColorPickerView', sync=True)
+    _model_name = Unicode('ColorPickerModel', sync=True)

--- a/ipywidgets/widgets/widget_color.py
+++ b/ipywidgets/widgets/widget_color.py
@@ -15,7 +15,7 @@ from traitlets import Unicode, Bool
 @register('Jupyter.ColorPicker')
 class ColorPicker(DOMWidget):
     value = Color('black', sync=True)
-    short = Bool(sync=True)
+    concise = Bool(sync=True)
     description = Unicode(sync=True)
 
     _view_name = Unicode('ColorPickerView', sync=True)

--- a/ipywidgets/widgets/widget_controller.py
+++ b/ipywidgets/widgets/widget_controller.py
@@ -17,7 +17,8 @@ class Button(Widget):
     value = Float(min=0.0, max=1.0, read_only=True, sync=True)
     pressed = Bool(read_only=True, sync=True)
 
-    _view_name = Unicode('ControllerButton', sync=True)
+    _view_name = Unicode('ControllerButtonView', sync=True)
+    _model_name = Unicode('ControllerButtonModel', sync=True)
 
 
 @register('Jupyter.ControllerAxis')
@@ -25,7 +26,8 @@ class Axis(Widget):
     """Represents a gamepad or joystick axis"""
     value = Float(min=-1.0, max=1.0, read_only=True, sync=True)
 
-    _view_name = Unicode('ControllerAxis', sync=True)
+    _view_name = Unicode('ControllerAxisView', sync=True)
+    _model_name = Unicode('ControllerAxisModel', sync=True)
 
 
 @register('Jupyter.Controller')
@@ -47,5 +49,5 @@ class Controller(DOMWidget):
                 **widget_serialization)
 
     _view_name = Unicode('ControllerView', sync=True)
-    _model_name = Unicode('Controller', sync=True)
+    _model_name = Unicode('ControllerModel', sync=True)
 

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -67,6 +67,7 @@ class FloatText(_Float):
 	    color of the value displayed
     """
     _view_name = Unicode('FloatTextView', sync=True)
+    _model_name = Unicode('IntTextModel', sync=True)
 
 
 @register('Jupyter.BoundedFloatText')
@@ -88,6 +89,7 @@ class BoundedFloatText(_BoundedFloat):
 	    color of the value displayed
     """
     _view_name = Unicode('FloatTextView', sync=True)
+    _model_name = Unicode('IntTextModel', sync=True)
 
 
 @register('Jupyter.FloatSlider')
@@ -107,7 +109,7 @@ class FloatSlider(_BoundedFloat):
 	description : str
 	    name of the slider
 	orientation : {'vertical', 'horizontal}, optional
-            default is horizontal
+        default is horizontal
 	readout : {True, False}, optional
 	    default is True, display the current value of the slider next to it
 	slider_color : str Unicode color code (eg. '#C13535'), optional
@@ -116,6 +118,7 @@ class FloatSlider(_BoundedFloat):
 	    color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView', sync=True)
+    _model_name = Unicode('IntSliderModel', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(False, help="Display a range selector", sync=True)
@@ -145,20 +148,22 @@ class FloatProgress(_BoundedFloat):
 	colors are: 'success'-green, 'info'-light blue, 'warning'-orange, 'danger'-red
 """
     _view_name = Unicode('ProgressView', sync=True)
-    orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
+    _model_name = Unicode('ProgressModel', sync=True)
+    orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
 
     bar_style = CaselessStrEnum(
-        values=['success', 'info', 'warning', 'danger', ''], 
+        values=['success', 'info', 'warning', 'danger', ''],
         default_value='', allow_none=True, sync=True, help="""Use a
         predefined styling for the progess bar.""")
 
 
 class _FloatRange(_Float):
-    value = Tuple(CFloat(), CFloat(), default_value=(0.0, 1.0), help="Tuple of (lower, upper) bounds", sync=True)
+    value = Tuple(CFloat(), CFloat(), default_value=(0.0, 1.0),
+                  help="Tuple of (lower, upper) bounds", sync=True)
     lower = CFloat(0.0, help="Lower bound", sync=False)
     upper = CFloat(1.0, help="Upper bound", sync=False)
-    
+
     def __init__(self, *pargs, **kwargs):
         value_given = 'value' in kwargs
         lower_given = 'lower' in kwargs
@@ -167,17 +172,17 @@ class _FloatRange(_Float):
             raise ValueError("Cannot specify both 'value' and 'lower'/'upper' for range widget")
         if lower_given != upper_given:
             raise ValueError("Must specify both 'lower' and 'upper' for range widget")
-        
+
         DOMWidget.__init__(self, *pargs, **kwargs)
-        
+
         # ensure the traits match, preferring whichever (if any) was given in kwargs
         if value_given:
             self.lower, self.upper = self.value
         else:
             self.value = (self.lower, self.upper)
-        
+
         self.on_trait_change(self._validate, ['value', 'upper', 'lower'])
-    
+
     def _validate(self, name, old, new):
         if name == 'value':
             self.lower, self.upper = min(new), max(new)
@@ -273,7 +278,8 @@ class FloatRangeSlider(_BoundedFloatRange):
 	    color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView', sync=True)
-    orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
+    _model_name = Unicode('IntSliderModel', sync=True)
+    orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(True, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -134,19 +134,19 @@ class FloatProgress(_BoundedFloat):
     Parameters
     -----------
     value : float
-	position within the range of the progress bar
+	    position within the range of the progress bar
     min : float
-	minimal position of the slider
+	    minimal position of the slider
     max : float
-	maximal position of the slider
+	    maximal position of the slider
     step : float
-	step of the progress bar
+	    step of the progress bar
     description : str
-	name of the progress bar
+	    name of the progress bar
     bar_style: {'success', 'info', 'warning', 'danger', ''}, optional
-	color of the progress bar, default is '' (blue)
-	colors are: 'success'-green, 'info'-light blue, 'warning'-orange, 'danger'-red
-"""
+	    color of the progress bar, default is '' (blue)
+	    colors are: 'success'-green, 'info'-light blue, 'warning'-orange, 'danger'-red
+    """
     _view_name = Unicode('ProgressView', sync=True)
     _model_name = Unicode('ProgressModel', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
@@ -195,15 +195,15 @@ class _BoundedFloatRange(_FloatRange):
     step = CFloat(1.0, help="Minimum step that the value can take (ignored by some views)", sync=True)
     max = CFloat(100.0, help="Max value", sync=True)
     min = CFloat(0.0, help="Min value", sync=True)
-    
+
     def __init__(self, *pargs, **kwargs):
         any_value_given = 'value' in kwargs or 'upper' in kwargs or 'lower' in kwargs
         _FloatRange.__init__(self, *pargs, **kwargs)
-        
+
         # ensure a minimal amount of sanity
         if self.min > self.max:
             raise ValueError("min must be <= max")
-        
+
         if any_value_given:
             # if a value was given, clamp it within (min, max)
             self._validate("value", None, self.value)

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -17,11 +17,13 @@ from traitlets import Unicode, CUnicode, Bytes
 class Image(DOMWidget):
     """Displays an image as a widget.
 
-    The `value` of this widget accepts a byte string.  The byte string is the raw
-    image data that you want the browser to display.  You can explicitly define
-    the format of the byte string using the `format` trait (which defaults to
-    "png")."""
+    The `value` of this widget accepts a byte string.  The byte string is the
+    raw image data that you want the browser to display.  You can explicitly
+    define the format of the byte string using the `format` trait (which
+    defaults to "png").
+    """
     _view_name = Unicode('ImageView', sync=True)
+    _model_name = Unicode('ImageModel', sync=True)
 
     # Define the custom state properties to sync with the front-end
     format = Unicode('png', sync=True)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -35,7 +35,7 @@ step: integer
 """
 
 def _int_doc(cls):
-    """Add int docstring template to class init"""
+    """Add int docstring template to class init."""
     def __init__(self, value=None, **kwargs):
         if value is not None:
             kwargs['value'] = value

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -9,8 +9,7 @@ Represents an unbounded int using a widget.
 from .domwidget import DOMWidget
 from .widget import register
 from .trait_types import Color
-from traitlets import (Unicode, CInt, Bool, CaselessStrEnum,
-                                     Tuple, TraitError)
+from traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError
 
 
 _int_doc_t = """
@@ -41,13 +40,13 @@ def _int_doc(cls):
         if value is not None:
             kwargs['value'] = value
         super(cls, self).__init__(**kwargs)
-    
+
     __init__.__doc__ = _int_doc_t
     cls.__init__ = __init__
     return cls
 
 def _bounded_int_doc(cls):
-    """Add bounded int docstring template to class init"""
+    """Add bounded int docstring template to class init."""
     def __init__(self, value=None, min=None, max=None, step=None, **kwargs):
         if value is not None:
             kwargs['value'] = value
@@ -57,16 +56,15 @@ def _bounded_int_doc(cls):
             kwargs['max'] = max
         if step is not None:
             kwargs['step'] = step
-        
         super(cls, self).__init__(**kwargs)
-    
+
     __init__.__doc__ = _bounded_int_doc_t
     cls.__init__ = __init__
     return cls
 
 
 class _Int(DOMWidget):
-    """Base class used to create widgets that represent an int."""
+    """Base class for widgets that represent an integer."""
     value = CInt(0, help="Int value", sync=True)
     disabled = Bool(False, help="Enable or disable user changes", sync=True)
     description = Unicode(help="Description of the value this widget represents", sync=True)
@@ -78,8 +76,7 @@ class _Int(DOMWidget):
 
 
 class _BoundedInt(_Int):
-    """Base class used to create widgets that represent an integer that is bounded
-    by a minium and maximum.
+    """Base class for widgets that represent an integer bounded from above and below.
     """
     step = CInt(1, help="Minimum step to increment the value (ignored by some views)", sync=True)
     max = CInt(100, help="Max value", sync=True)
@@ -94,7 +91,6 @@ class _BoundedInt(_Int):
             kwargs['max'] = max
         if step is not None:
             kwargs['step'] = step
-        
         super(_BoundedInt, self).__init__(**kwargs)
 
     def _value_validate(self, value, trait):
@@ -124,21 +120,26 @@ class _BoundedInt(_Int):
 class IntText(_Int):
     """Textbox widget that represents an integer."""
     _view_name = Unicode('IntTextView', sync=True)
+    _model_name = Unicode('IntTextModel', sync=True)
 
 
 @register('Jupyter.BoundedIntText')
 @_bounded_int_doc
 class BoundedIntText(_BoundedInt):
-    """Textbox widget that represents an integer bounded by a minimum and maximum value."""
+    """Textbox widget that represents an integer bounded from above and below.
+    """
     _view_name = Unicode('IntTextView', sync=True)
+    _model_name = Unicode('IntTextModel', sync=True)
 
 
 @register('Jupyter.IntSlider')
 @_bounded_int_doc
 class IntSlider(_BoundedInt):
-    """Slider widget that represents an integer bounded by a minimum and maximum value."""
+    """Slider widget that represents an integer bounded from above and below.
+    """
     _view_name = Unicode('IntSliderView', sync=True)
-    orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
+    _model_name = Unicode('IntSliderModel', sync=True)
+    orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(False, help="Display a range selector", sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.", sync=True)
@@ -149,22 +150,24 @@ class IntSlider(_BoundedInt):
 @register('Jupyter.IntProgress')
 @_bounded_int_doc
 class IntProgress(_BoundedInt):
-    """Progress bar that represents an integer bounded by a minimum and maximum value."""
+    """Progress bar that represents an integer bounded from above and below.
+    """
     _view_name = Unicode('ProgressView', sync=True)
-    orientation = CaselessStrEnum(values=['horizontal', 'vertical'], 
+    _model_name = Unicode('ProgressModel', sync=True)
+
+    orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
 
     bar_style = CaselessStrEnum(
-        values=['success', 'info', 'warning', 'danger', ''], 
-        default_value='', allow_none=True, sync=True, help="""Use a
-        predefined styling for the progess bar.""")
+        values=['success', 'info', 'warning', 'danger', ''], default_value='',
+        sync=True, help="""Use a predefined styling for the progess bar.""")
 
 
 class _IntRange(_Int):
     value = Tuple(CInt(), CInt(), default_value=(0, 1), help="Tuple of (lower, upper) bounds", sync=True)
     lower = CInt(0, help="Lower bound", sync=False)
     upper = CInt(1, help="Upper bound", sync=False)
-    
+
     def __init__(self, *pargs, **kwargs):
         value_given = 'value' in kwargs
         lower_given = 'lower' in kwargs
@@ -234,14 +237,14 @@ class _BoundedIntRange(_IntRange):
             if new > self.upper:
                 raise ValueError("setting lower > upper")
             low = new
-        
+
         low = max(self.min, min(low, self.max))
         high = min(self.max, max(high, self.min))
-        
+
         # determine the order in which we should update the
         # lower, upper traits to avoid a temporary inverted overlap
         lower_first = high < self.lower
-        
+
         self.value = (low, high)
         if lower_first:
             self.lower = low
@@ -252,11 +255,10 @@ class _BoundedIntRange(_IntRange):
 
 @register('Jupyter.IntRangeSlider')
 class IntRangeSlider(_BoundedIntRange):
-    """Slider widget that represents a pair of ints between a minimum and maximum value.
-    
+    """Slider widget that represents a pair of ints bounded by minimum and maximum value.
+
     Parameters
     ----------
-    
     lower: int
         The lower bound of the range
     upper: int
@@ -267,6 +269,7 @@ class IntRangeSlider(_BoundedIntRange):
         The highest allowed value for `upper`
     """
     _view_name = Unicode('IntSliderView', sync=True)
+    _model_name = Unicode('IntSliderModel', sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.", sync=True)
     _range = Bool(True, help="Display a range selector", sync=True)

--- a/ipywidgets/widgets/widget_layout.py
+++ b/ipywidgets/widgets/widget_layout.py
@@ -23,6 +23,7 @@ class Layout(Widget):
     """
 
     _view_name = Unicode('LayoutView', sync=True)
+    _model_name = Unicode('LayoutModel', sync=True)
 
     # Keys
     align_content = CUnicode(sync=True)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -13,6 +13,7 @@ from IPython.display import clear_output
 from jupyter_client.session import Message
 from IPython import get_ipython
 
+
 class Output(DOMWidget):
     """Widget used as a context manager to display output.
 

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -1,4 +1,4 @@
-"""Output class.  
+"""Output class.
 
 Represents a widget that can be used to display output within the widget area.
 """
@@ -21,17 +21,19 @@ class Output(DOMWidget):
     manager.  Any output produced while in it's context will be captured and
     displayed in it instead of the standard output area.
 
-    Example
+    Example::
         import ipywidgets as widgets
         from IPython.display import display
         out = widgets.Output()
         display(out)
-        
+
         print('prints to output area')
 
         with out:
-            print('prints to output widget')"""
+            print('prints to output widget')
+    """
     _view_name = Unicode('OutputView', sync=True)
+    _model_name = Unicode('OutputModel', sync=True)
 
     def clear_output(self, *pargs, **kwargs):
         with self:
@@ -47,7 +49,7 @@ class Output(DOMWidget):
         self._session = session
 
         def send_hook(stream, msg_or_type, content=None, parent=None, ident=None,
-             buffers=None, track=False, header=None, metadata=None): 
+             buffers=None, track=False, header=None, metadata=None):
 
             # Handle both prebuild messages and unbuilt messages.
             if isinstance(msg_or_type, (Message, dict)):
@@ -55,13 +57,13 @@ class Output(DOMWidget):
                 msg = dict(msg_or_type)
             else:
                 msg_type = msg_or_type
-                msg = session.msg(msg_type, content=content, parent=parent, 
+                msg = session.msg(msg_type, content=content, parent=parent,
                     header=header, metadata=metadata)
 
             # If this is a message type that we want to forward, forward it.
             if stream is kernel.iopub_socket and msg_type in ['clear_output', 'stream', 'display_data']:
                 self.send(msg)
-            else: 
+            else:
                 send(stream, msg, ident=ident, buffers=buffers, track=track)
 
         session.send = send_hook

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -187,9 +187,13 @@ class _MultipleSelection(_Selection):
 
 @register('Jupyter.ToggleButtons')
 class ToggleButtons(_Selection):
-    """Group of toggle buttons that represent an enumeration.  Only one toggle
-    button can be toggled at any point in time."""
+    """Group of toggle buttons that represent an enumeration.
+
+    Only one toggle button can be toggled at any point in time.
+    """
     _view_name = Unicode('ToggleButtonsView', sync=True)
+    _model_name = Unicode('ToggleButtonsModel', sync=True)
+
     tooltips = List(Unicode(), sync=True)
     icons = List(Unicode(), sync=True)
 
@@ -203,6 +207,7 @@ class ToggleButtons(_Selection):
 class Dropdown(_Selection):
     """Allows you to select a single item from a dropdown."""
     _view_name = Unicode('DropdownView', sync=True)
+    _model_name = Unicode('DropdownModel', sync=True)
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''],
@@ -212,21 +217,28 @@ class Dropdown(_Selection):
 
 @register('Jupyter.RadioButtons')
 class RadioButtons(_Selection):
-    """Group of radio buttons that represent an enumeration.  Only one radio
-    button can be toggled at any point in time."""
+    """Group of radio buttons that represent an enumeration.
+
+    Only one radio button can be toggled at any point in time.
+    """
     _view_name = Unicode('RadioButtonsView', sync=True)
+    _modelname = Unicode('RadioButtonsModel', sync=True)
 
 
 @register('Jupyter.Select')
 class Select(_Selection):
     """Listbox that only allows one item to be selected at any given time."""
     _view_name = Unicode('SelectView', sync=True)
+    _model_name = Unicode('SelectModel', sync=True)
 
 
 @register('Jupyter.SelectMultiple')
 class SelectMultiple(_MultipleSelection):
     """Listbox that allows many items to be selected at any given time.
+
     Despite their names, inherited from ``_Selection``, the currently chosen
     option values, ``value``, or their labels, ``selected_labels`` must both be
-    updated with a list-like object."""
+    updated with a list-like object.
+    """
     _view_name = Unicode('SelectMultipleView', sync=True)
+    _model_name = Unicode('SelectMultipleModel', sync=True)

--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -1,4 +1,4 @@
-"""SelectionContainer class.  
+"""SelectionContainer class.
 
 Represents a multipage container that can be used to group other widgets into
 pages.
@@ -46,9 +46,11 @@ class _SelectionContainer(Box):
 class Accordion(_SelectionContainer):
     """Displays children each on a separate accordion page."""
     _view_name = Unicode('AccordionView', sync=True)
+    _model_name = Unicode('AccordionModel', sync=True)
 
 
 @register('Jupyter.Tab')
 class Tab(_SelectionContainer):
     """Displays children each on a separate accordion tab."""
     _view_name = Unicode('TabView', sync=True)
+    _model_name = Unicode('TabModel', sync=True)

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -23,23 +23,32 @@ class _String(DOMWidget):
             kwargs['value'] = value
         super(_String, self).__init__(**kwargs)
 
+    _model_name = Unicode('StringModel', sync=True)
+
+
 @register('Jupyter.HTML')
 class HTML(_String):
     """Renders the string `value` as HTML."""
     _view_name = Unicode('HTMLView', sync=True)
+    _model_name = Unicode('HTMLModel', sync=True)
 
 
 @register('Jupyter.Latex')
 class Latex(_String):
-    """Renders math inside the string `value` as Latex (requires $ $ or $$ $$ 
-    and similar latex tags)."""
+    """Label widget.
+
+    It also renders math inside the string `value` as Latex (requires $ $ or
+    $$ $$ and similar latex tags).
+    """
     _view_name = Unicode('LatexView', sync=True)
+    _model_name = Unicode('LatexModel', sync=True)
 
 
 @register('Jupyter.Textarea')
 class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView', sync=True)
+    _model_name = Unicode('TextareaModel', sync=True)
 
     def scroll_to_bottom(self):
         self.send({"method": "scroll_to_bottom"})
@@ -49,6 +58,7 @@ class Textarea(_String):
 class Text(_String):
     """Single line textbox widget."""
     _view_name = Unicode('TextView', sync=True)
+    _model_name = Unicode('TextModel', sync=True)
 
     def __init__(self, *args, **kwargs):
         super(Text, self).__init__(*args, **kwargs)


### PR DESCRIPTION
@jdfreder @parente here is the approach I am proposing for specifying default values for widget attributes on the javascript side.

I started with the base widget classes and the `_Bool` widgets.

TODO:
- [x] figure out what to do with the instance of layout widget.
- [x] check commit regarding buffered state diff.
- [ ] some widgets have the same models and view types, but *different default values*. Is it worth inheriting and specifying a custom model for these cases (range sliders vs sliders)

This is an API change from the perspective of custom widget authors who need custom models.