### PR TITLE
Persist widgets as screenshots to the notebook json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__
 .#*
 .coverage
 .xunit.xml
+.tern-project
 
 index.built.js
 **/es5/

--- a/ipywidgets/bower.json
+++ b/ipywidgets/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "bootstrap": "components/bootstrap#~3.3",
     "font-awesome": "components/font-awesome#~4.2.0",
-    "require-css": "0.1.8"
+    "require-css": "0.1.8",
+    "html2canvas": "~0.4.1"
   }
 }

--- a/ipywidgets/bower.json
+++ b/ipywidgets/bower.json
@@ -5,6 +5,6 @@
     "bootstrap": "components/bootstrap#~3.3",
     "font-awesome": "components/font-awesome#~4.2.0",
     "require-css": "0.1.8",
-    "html2canvas": "~0.4.1"
+    "html2canvas": "0.5.0-beta3"
   }
 }

--- a/ipywidgets/static/notebook/js/manager.js
+++ b/ipywidgets/static/notebook/js/manager.js
@@ -6,7 +6,7 @@ define([
     "backbone",
     "services/kernels/comm",
     "jupyter-js-widgets",
-    "../../components/html2canvas/dist/html2canvas",
+    "../../components/html2canvas/dist/html2canvas", // TODO: NPM package
     "./progress-modal",
     "./save_state"
 ], function (_, Backbone, comm, widgets, html2canvas, progressModal, saveState) {
@@ -126,7 +126,7 @@ define([
         // loaded from disk, and when the widget manager is constructed.
         this.notebook.events.on('notebook_saved.Notebook', this.deleteSnapshots.bind(this));
         this.notebook.events.on('notebook_save_failed.Notebook', this.deleteSnapshots.bind(this));
-        this.notebook.events.on('notebook_loaaded.Notebook', this.deleteSnapshots.bind(this));
+        this.notebook.events.on('notebook_loaded.Notebook', this.deleteSnapshots.bind(this));
         this.deleteSnapshots();
         
         // Create the actions and menu

--- a/ipywidgets/static/notebook/js/manager.js
+++ b/ipywidgets/static/notebook/js/manager.js
@@ -6,13 +6,12 @@ define([
     "backbone",
     "services/kernels/comm",
     "jupyter-js-widgets",
-    "../../components/html2canvas/build/html2canvas"
+    "../../components/html2canvas/dist/html2canvas"
 ], function (_, Backbone, comm, widgets, html2canvas) {
     "use strict";
     
-    // html2canvas cannot be loaded by AMD and pollutes the global namespace.
-    // Grab it from the global namespace.
-    html2canvas = window.html2canvas;
+    // Work around for a logging bug, reported in https://github.com/niklasvh/html2canvas/issues/543
+    window.html2canvas = html2canvas;
     
     //--------------------------------------------------------------------
     // WidgetManager class
@@ -204,7 +203,7 @@ define([
          * Note, this is only done on the outer most widgets.
          */
         view.trigger('displayed');
-
+         
         if (this.keyboard_manager) {
             this.keyboard_manager.register_events(view.el);
 
@@ -340,6 +339,7 @@ define([
      * @return {Promise<void>} success
      */
     WidgetManager.prototype.updateSnapshots = function() {
+        document.querySelector('#site').style.overflow = 'visible';
         var cells = Jupyter.notebook.get_cells();
         return Promise.all(cells.map((function(cell) {
             var widgetSubarea = cell.element[0].querySelector(".widget-subarea");
@@ -363,7 +363,9 @@ define([
                     delete widgetSubarea.widgetSnapshot;
                 }
             }
-        }).bind(this)));
+        }).bind(this))).then((function() {
+            document.querySelector('#site').style.overflow = '';
+        }).bind(this));
     };
     
     /**

--- a/ipywidgets/static/notebook/js/manager.js
+++ b/ipywidgets/static/notebook/js/manager.js
@@ -362,13 +362,18 @@ define([
      */
     WidgetManager.prototype.updateSnapshots = function() {
         var that = this;
+        var site = document.querySelector('#site');
         
         // Wait for the progress modal to show before continuing
         return this.progressModal.show().then(function() {
-            
+        
             // Disable overflow to prevent the document from having elements
             // that are scrolled out of visibility.
-            document.querySelector('#site').style.overflow = 'visible';
+            var siteScrollTop = site.scrollTop;
+            site.style.overflow = 'visible';
+            site.style.position = 'relative';
+            site.style.top = '-' + siteScrollTop + 'px';
+            document.body.style.overflow = 'hidden';    
             
             // Render the widgets of each cell.
             var progress = 0;
@@ -413,7 +418,10 @@ define([
             // When all of the rendering is complete, re-enable scrolling in the
             // notebook.
             return renderPromise.then(function() {
-                document.querySelector('#site').style.overflow = '';
+                site.style.overflow = '';
+                site.style.position = '';
+                site.style.top = '';
+                document.body.style.overflow = '';
             });    
         
         // When the entire process has completed, hide the progress modal.

--- a/ipywidgets/static/notebook/js/manager.js
+++ b/ipywidgets/static/notebook/js/manager.js
@@ -210,7 +210,7 @@ define([
         }
     
         // Update the widget area snapshots.
-        this.updateSnapshots();
+        setTimeout(this.updateSnapshots.bind(this), 1);
     };
 
     WidgetManager.prototype.display_model = function(msg, model, options) {

--- a/ipywidgets/static/notebook/js/progress-modal.js
+++ b/ipywidgets/static/notebook/js/progress-modal.js
@@ -33,7 +33,7 @@ define([], function() {
     }
     
     ProgressModal.prototype.show = function() {
-        return new Promise((function(resolve) {
+        return new Promise((function(resolve, reject) {
             this._backdrop.classList.remove('widget-modal-hidden');
             this._backdrop.classList.add('widget-modal-show');
             
@@ -42,7 +42,13 @@ define([], function() {
                 this._backdrop.removeEventListener('animationend', shown);
                 resolve();
             }).bind(this);
-            this._backdrop.addEventListener('animationend', shown);    
+            this._backdrop.addEventListener('animationend', shown);
+            
+            // Timeout if the dialog doesn't show in 2 seconds.  Something must
+            // be wrong.
+            setTimeout(function() {
+                reject('Could not show the save dialog, your css may be out of date.');
+            }, 2000);
         }).bind(this));
     };
     

--- a/ipywidgets/static/notebook/js/save_state.js
+++ b/ipywidgets/static/notebook/js/save_state.js
@@ -15,15 +15,15 @@ define(["base/js/namespace"], function(Jupyter) {
     };
 
     var action = {
-        help: 'Download Widget State',
+        help: 'Download the widget state as a JSON file',
         icon: 'fa-sliders',
         help_index : 'zz',
         handler : save_state
     };
 
     var action_name = 'save-widget-state';
-    var prefix = '';
+    var prefix = 'widgets';
     Jupyter.notebook.keyboard_manager.actions.register(action, action_name, prefix);
 
-    return {};
+    return {action: action};
 });

--- a/ipywidgets/static/widgets/js/progress-modal.js
+++ b/ipywidgets/static/widgets/js/progress-modal.js
@@ -1,0 +1,83 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([], function() {
+    "use strict";
+    
+    function ProgressModal() {
+        this._backdrop = document.createElement('div');
+        this._backdrop.classList.add('widget-modal-backdrop');
+        this._backdrop.classList.add('widget-modal-hidden');
+        var textContainer = document.createElement('div');
+        textContainer.classList.add('widget-modal-text');
+        var spinner = document.createElement('i');
+        spinner.className = "fa fa-cog fa-spin";
+        textContainer.appendChild(spinner);
+        this._text = document.createElement('div');
+        this._text.innerText = 'Rendering widgets...';
+        textContainer.appendChild(this._text);
+        this._backdrop.appendChild(textContainer);
+        var progressBar = document.createElement('div');
+        progressBar.classList.add('progress');
+        progressBar.classList.add('widget-modal-progress');
+        this._backdrop.appendChild(progressBar);
+        this._progressbar = document.createElement('div');
+        this._progressbar.classList.add('progress-bar');
+        this._progressbar.setAttribute('role', 'progressbar');
+        this._progressbar.setAttribute('aria-valuenow', '0');
+        this._progressbar.setAttribute('aria-valuemin', '0');
+        this._progressbar.setAttribute('aria-valuemax', '100');
+        this._progressbar.style.width = '0%';
+        progressBar.appendChild(this._progressbar);
+        document.body.appendChild(this._backdrop);
+    }
+    
+    ProgressModal.prototype.show = function() {
+        return new Promise((function(resolve) {
+            this._backdrop.classList.remove('widget-modal-hidden');
+            this._backdrop.classList.add('widget-modal-show');
+            
+            var shown = (function() {
+                this._backdrop.classList.remove('widget-modal-show');
+                this._backdrop.removeEventListener('animationend', shown);
+                resolve();
+            }).bind(this);
+            this._backdrop.addEventListener('animationend', shown);    
+        }).bind(this));
+    };
+    
+    ProgressModal.prototype.hide = function() {
+        return new Promise((function(resolve) {
+            this._backdrop.classList.add('widget-modal-hide');
+            
+            var hidden = (function() {
+                this._backdrop.classList.add('widget-modal-hidden');
+                this._backdrop.classList.remove('widget-modal-hide');
+                this._backdrop.removeEventListener('animationend', hidden);
+                resolve();
+            }).bind(this);
+            this._backdrop.addEventListener('animationend', hidden);
+        }).bind(this));
+    };
+    
+    ProgressModal.prototype.setText = function(text) {
+        this._text.innerText = text;
+        return this._waitForUpdate();
+    };
+    
+    ProgressModal.prototype.setValue = function(x) {
+        this._progressbar.setAttribute('aria-valuenow', String(x));
+        this._progressbar.style.width = String(x * 100.0) + '%';
+        return this._waitForUpdate();
+    };
+    
+    ProgressModal.prototype._waitForUpdate = function() {
+        return new Promise(function(resolve) {
+            setTimeout(resolve, 0);
+        });
+    };
+    
+    return {
+        ProgressModal: ProgressModal
+    };
+});

--- a/ipywidgets/static/widgets/less/mixins.less
+++ b/ipywidgets/static/widgets/less/mixins.less
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 // Mixin CSS classes
 
 .border-box-sizing() {

--- a/ipywidgets/static/widgets/less/progress-modal.less
+++ b/ipywidgets/static/widgets/less/progress-modal.less
@@ -1,0 +1,59 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+@modal-opacity: 0.5;
+
+.widget-modal-backdrop {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    width: 100%;
+    height: 100%;
+    background: black;
+    z-index: 999;
+    opacity: @modal-opacity;
+    
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    
+    &.widget-modal-hidden {
+        display: none;
+    }
+    
+    &.widget-modal-hide {
+        animation: fadeout 0.25s;
+    }
+    
+    &.widget-modal-show {
+        animation: fadein 0.25s;
+    }
+}
+
+@keyframes fadein {
+    from { opacity: 0.0; }
+    to   { opacity: @modal-opacity; }
+}
+
+@keyframes fadeout {
+    from { opacity: @modal-opacity; }
+    to   { opacity: 0.0; }
+}
+
+.widget-modal-text {
+    color: white;
+    font-size: x-large;
+    font-weight: bold;
+    
+    i, div {
+        display: inline;
+    }
+    
+    div {
+        padding-left: 1ex;
+    }
+}
+
+.widget-modal-progress {
+    width: 300px;
+}

--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 // minimal imports from bootstrap - only variables and mixins
 @import "../../components/bootstrap/less/variables.less";
 @import "../../components/bootstrap/less/mixins.less";
@@ -9,6 +12,7 @@
 // layout mixins
 @import "./flexbox.less";
 @import "./mixins.less";
+@import "./progress-modal.less";
 
 @widget-width: 300px;
 @widget-width-short: 148px;


### PR DESCRIPTION
Finally!  This PR introduces a work around for the inability to render widgets on GitHub, nbviewer, through nbconvert, etc...  A save hook is used to persist canvas renderings of the widget DOM elements to the notebook JSON prior to save.

Ping @SylvainCorlay , @ellisonbg, @captainsafia, @willingc (we can use this for docs), @blink1073 (similar to your export button in the matplotlib widget renderer)