### PR TITLE
Update max-height on dropdown-menu

### DIFF
--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -298,7 +298,7 @@
     }
 
     .dropdown-menu {
-        max-height: 200px;
+        max-height: 120px;
         overflow: hidden;
         overflow-y: auto;
     }


### PR DESCRIPTION
Closes #94.

A better solution would be to increase the `min-height` on the `end_space` div at the end of the document to accommodate for longer dropdowns but I'm not sure if we just want to limit changes for this issue to ipywidgets.

![dropdown-end-of-notebook](https://cloud.githubusercontent.com/assets/1857993/12375984/7a930704-bca2-11e5-8242-026707307c88.gif)

cc: @jdfreder