### PR TITLE
Base css class for Jupyter widgets should not have 'ipy'

### DIFF
--- a/ipywidgets/static/widgets/js/widget_bool.js
+++ b/ipywidgets/static/widgets/js/widget_bool.js
@@ -30,7 +30,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-checkbox');
+                .addClass('jupyter-widgets widget-hbox widget-checkbox');
             this.$checkbox = $('<input />')
                 .attr('type', 'checkbox')
                 .appendTo(this.$el)
@@ -107,7 +107,7 @@ define([
              */
             var that = this;
             this.setElement($('<button />')
-                .addClass('ipy-widget widget-toggle-button btn btn-default')
+                .addClass('jupyter-widgets widget-toggle-button btn btn-default')
                 .attr('type', 'button')
                 .on('click', function (e) {
                     e.preventDefault();
@@ -186,7 +186,7 @@ define([
             /**
              * Called when view is rendered.
              */
-            this.$el.addClass("ipy-widget widget-valid");
+            this.$el.addClass("jupyter-widgets widget-valid");
             this.listenTo(this.model, "change", this.update, this);
             this.update();
         },
@@ -207,7 +207,7 @@ define([
                 icon = "fa-close";
                 color = "red";
                 readout = this.model.get("readout");
-            } 
+            }
             this.$el.text(readout);
             $('<i class="fa"></i>').prependTo(this.$el).addClass(icon);
             var that = this;

--- a/ipywidgets/static/widgets/js/widget_box.js
+++ b/ipywidgets/static/widgets/js/widget_box.js
@@ -41,7 +41,7 @@ define([
         initialize: function() {
             // Public constructor
             ProxyView.__super__.initialize.apply(this, arguments);
-            this.$el.addClass("ipy-widget widget-container");
+            this.$el.addClass("jupyter-widgets widget-container");
             this.$box = this.$el;
             this.child_promise = Promise.resolve();
         },
@@ -147,7 +147,7 @@ define([
             /**
              * Called when view is rendered.
              */
-            this.$el.addClass("ipy-widget widget-container widget-box");
+            this.$el.addClass("jupyter-widgets widget-container widget-box");
             this.$box = this.$el;
             this.children_views.update(this.model.get('children'));
             this.update_overflow_x();

--- a/ipywidgets/static/widgets/js/widget_button.js
+++ b/ipywidgets/static/widgets/js/widget_button.js
@@ -26,7 +26,7 @@ define([
              * Called when view is rendered.
              */
             this.setElement($("<button />")
-                .addClass('ipy-widget widget-button btn btn-default'));
+                .addClass('jupyter-widgets widget-button btn btn-default'));
             this.$el.attr("data-toggle", "tooltip");
             this.listenTo(this.model, "change:button_style", this.update_button_style, this);
             this.update_button_style();

--- a/ipywidgets/static/widgets/js/widget_color.js
+++ b/ipywidgets/static/widgets/js/widget_color.js
@@ -18,7 +18,7 @@ define([
 
     var ColorPickerView = widget.DOMWidgetView.extend({
         render: function() {
-            this.$el.addClass("ipy-widget widget-hbox widget-colorpicker");
+            this.$el.addClass("jupyter-widgets widget-hbox widget-colorpicker");
 
             this.$label = $("<div />")
                 .addClass("widget-label")

--- a/ipywidgets/static/widgets/js/widget_controller.js
+++ b/ipywidgets/static/widgets/js/widget_controller.js
@@ -22,7 +22,7 @@ define([
         /* Very simple view for a gamepad button. */
 
         render: function() {
-            this.$el.addClass('ipy-widget widget-controller-button');
+            this.$el.addClass('jupyter-widgets widget-controller-button');
 
             this.$support = $('<div />').css({
                     'position': 'relative',
@@ -65,7 +65,7 @@ define([
     var ControllerAxisView = widget.DOMWidgetView.extend({
         /* Very simple view for a gamepad axis. */
         render: function() {
-            this.$el.addClass('ipy-widget widget-controller-axis');
+            this.$el.addClass('jupyter-widgets widget-controller-axis');
             
             this.$el.css({
                     'width': '16px',
@@ -288,7 +288,7 @@ define([
         },
 
         render: function(){
-            this.$el.addClass('ipy-widget widget-controller');
+            this.$el.addClass('jupyter-widgets widget-controller');
 
             this.$box = this.$el;
 

--- a/ipywidgets/static/widgets/js/widget_image.js
+++ b/ipywidgets/static/widgets/js/widget_image.js
@@ -24,7 +24,7 @@ define([
              * Called when view is rendered.
              */
             this.setElement($("<img />")
-                .addClass("ipy-widget widget-image"));
+                .addClass("jupyter-widgets widget-image"));
             this.update(); // Set defaults.
         },
 

--- a/ipywidgets/static/widgets/js/widget_int.js
+++ b/ipywidgets/static/widgets/js/widget_int.js
@@ -45,7 +45,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-hslider');
+                .addClass('jupyter-widgets widget-hbox widget-hslider');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -376,7 +376,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-numeric-text');
+                .addClass('jupyter-widgets widget-hbox widget-numeric-text');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -389,11 +389,11 @@ define([
             this.listenTo(this.model, 'change:description', function(sender, value) {
                 this.updateDescription();
             }, this);
-                
+
             this.update(); // Set defaults.
             this.updateDescription();
         },
-        
+
         updateDescription: function() {
             var description = this.model.get('description');
             if (description.length === 0) {
@@ -511,7 +511,7 @@ define([
             /**
              * Called when view is rendered.
              */
-            this.$el.addClass('ipy-widget widget-hprogress');
+            this.$el.addClass('jupyter-widgets widget-hprogress');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -532,7 +532,7 @@ define([
             // Set defaults.
             this.update();
             this.updateDescription();
-           
+
             this.listenTo(this.model, "change:bar_style", this.update_bar_style, this);
             this.listenTo(this.model, "change:description", function(sender, value) {
                 this.updateDescription();

--- a/ipywidgets/static/widgets/js/widget_selection.js
+++ b/ipywidgets/static/widgets/js/widget_selection.js
@@ -30,7 +30,7 @@ define([
     var DropdownView = widget.DOMWidgetView.extend({
         render : function() {
             this.$el
-                .addClass('ipy-widget widget-hbox widget-dropdown');
+                .addClass('jupyter-widgets widget-hbox widget-dropdown');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -177,7 +177,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-radio');
+                .addClass('jupyter-widgets widget-hbox widget-radio');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -295,7 +295,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-toggle-buttons');
+                .addClass('jupyter-widgets widget-hbox widget-toggle-buttons');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -451,7 +451,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-select');
+                .addClass('jupyter-widgets widget-hbox widget-select');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')

--- a/ipywidgets/static/widgets/js/widget_selectioncontainer.js
+++ b/ipywidgets/static/widgets/js/widget_selectioncontainer.js
@@ -44,7 +44,7 @@ define([
             var guid = 'panel-group' + utils.uuid();
             this.$el
                 .attr('id', guid)
-                .addClass('ipy-widget panel-group');
+                .addClass('jupyter-widgets panel-group');
             this.listenTo(this.model, 'change:selected_index', function(model, value, options) {
                 this.update_selected_index(options);
             }, this);

--- a/ipywidgets/static/widgets/js/widget_string.js
+++ b/ipywidgets/static/widgets/js/widget_string.js
@@ -31,7 +31,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-html');
+                .addClass('jupyter-widgets widget-html');
             this.update(); // Set defaults.
         },
 
@@ -60,7 +60,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-latex');
+                .addClass('jupyter-widgets widget-latex');
             this.update(); // Set defaults.
         },
 
@@ -89,7 +89,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-textarea');
+                .addClass('jupyter-widgets widget-hbox widget-textarea');
             this.$label = $('<div />')
                 .appendTo(this.$el)
                 .addClass('widget-label')
@@ -187,7 +187,7 @@ define([
              * Called when view is rendered.
              */
             this.$el
-                .addClass('ipy-widget widget-hbox widget-text');
+                .addClass('jupyter-widgets widget-hbox widget-text');
             this.$label = $('<div />')
                 .addClass('widget-label')
                 .appendTo(this.$el)
@@ -210,7 +210,7 @@ define([
             }
             this.$textbox.attr('placeholder', value);
         },
-        
+
         update: function(options) {
             /**
              * Update the contents of this view

--- a/ipywidgets/static/widgets/less/widgets.less
+++ b/ipywidgets/static/widgets/less/widgets.less
@@ -19,7 +19,7 @@
 @shadow-key-penumbra-opacity: 0.14;
 @shadow-ambient-shadow-opacity: 0.12;
 
-.ipy-widget {
+.jupyter-widgets {
     & {
         margin: 2px;
     }
@@ -30,7 +30,7 @@
 
 .widget-area {
     /*
-    LESS file that styles IPython notebook widgets and the area they sit in.
+    LESS file that styles Jupyter widgets and the area they sit in.
 
     The widget area typically looks something like this:
      +------------------------------------------+


### PR DESCRIPTION
Removing references to IPython in jupyter-js-widgets Javascript.