### PR TITLE
Support later version of jupyter-js-services

### DIFF
--- a/examples/development/web3/README.md
+++ b/examples/development/web3/README.md
@@ -6,7 +6,9 @@ a context other than the notebook.
 ## Try it
 1. Open a command line in the `ipywidgets/ipywidgets` subdirectory and run `npm install`.
 2. Cd into this directory and run `npm install`.
-3. Now open the `index.html` file.
+3. Run `npm run host`
+4. In a new terminal run `python -m notebook --no-browser --NotebookApp.allow_origin="*"`
+5. In a web browser, navigate to `http://localhost:8080/` (or the address specified by the `npm run host` command)
 
 ## Details
 If you plan to reproduce this in your own project, pay careful attention to the 

--- a/examples/development/web3/package.json
+++ b/examples/development/web3/package.json
@@ -8,6 +8,7 @@
     "build": "npm run build:es5 && npm run build:bundle",
     "build:es5": "babel src --out-dir es5 --presets es2015",
     "build:bundle": "webpack ./es5/index.js index.built.js",
+    "host": "http-server",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "IPython",
@@ -15,10 +16,11 @@
   "dependencies": {
     "codemirror": "^5.9.0",
     "font-awesome": "^4.5.0",
+    "http-server": "^0.8.5",
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
-    "jupyter-js-widgets": "file:../../../ipywidgets",
-    "jupyter-js-services": "^0.3.3"
+    "jupyter-js-services": "^0.3.3",
+    "jupyter-js-widgets": "file:../../../ipywidgets"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",

--- a/examples/development/web3/package.json
+++ b/examples/development/web3/package.json
@@ -18,7 +18,7 @@
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
     "jupyter-js-widgets": "file:../../../ipywidgets",
-    "jupyter-js-services": "^0.2.2"
+    "jupyter-js-services": "^0.3.3"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",

--- a/examples/development/web3/src/index.js
+++ b/examples/development/web3/src/index.js
@@ -15,12 +15,13 @@ var WSURL = 'ws:' + BASEURL.split(':').slice(1).join(':');
 document.addEventListener("DOMContentLoaded", function(event) {
 
     // Connect to the notebook webserver.
-    getKernelSpecs(BASEURL).then(kernelSpecs => {
-        return startNewKernel({
-            baseUrl: BASEURL,
-            wsUrl: WSURL,
-            name: kernelSpecs.default,
-        });
+    let connectionInfo = {
+        baseUrl: BASEURL,
+        wsUrl: WSURL
+    };
+    getKernelSpecs(connectionInfo).then(kernelSpecs => {
+        connectionInfo.name = kernelSpecs.default;
+        return startNewKernel(connectionInfo);
     }).then(kernel => {
 
         // Create a codemirror instance


### PR DESCRIPTION
In particular, update to pass along full message object in shim.

Tested by running `npm run test` in `ipywidgets/ipywidgets`.