### PR TITLE
WIP: Update first_state switch logic

### DIFF
--- a/ipywidgets/static/widgets/js/widget_controller.js
+++ b/ipywidgets/static/widgets/js/widget_controller.js
@@ -126,17 +126,15 @@ define([
                 // user-provided attribute, the gamepad index.
                 this.readout = 'Connect gamepad and press any button.';
                 // Wait for the state to be provided by the backend.
-                this.on('ready', function() {
-                    if (this.get('connected')) {
-                        // No need to re-create Button and Axis widgets, re-use
-                        // the models provided by the backend which may already
-                        // be wired to other things.
-                        this.update_loop();
-                    } else {
-                        // Wait for a gamepad to be connected.
-                        this.wait_loop();
-                    }
-                }, this);
+                if (this.get('connected')) {
+                    // No need to re-create Button and Axis widgets, re-use
+                    // the models provided by the backend which may already
+                    // be wired to other things.
+                    this.update_loop();
+                } else {
+                    // Wait for a gamepad to be connected.
+                    this.wait_loop();
+                }
             }
         },
 


### PR DESCRIPTION
The problem with the old logic is that since were setting `_first_state` to true *after* the first call to set, any other call to set that was synchronously triggered by the first call to `_first_state` would still not be buffered to be sent to the backend. We now change the value of `_first_state` prior to calling `set`.

*I still have to test this in a couple of other scenarios, please do not merge.*