### PR TITLE
SelectionSlider

### DIFF
--- a/examples/notebooks/Widget List.ipynb
+++ b/examples/notebooks/Widget List.ipynb
@@ -496,6 +496,27 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SelectionSlider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "widgets.SelectionSlider(\n",
+    "    description='I like my eggs ...',\n",
+    "    options=['scrambled', 'sunny side up', 'poached', 'over easy'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -11,7 +11,7 @@ from .widget_image import Image
 from .widget_int import IntText, BoundedIntText, IntSlider, IntProgress, IntRangeSlider
 from .widget_color import ColorPicker
 from .widget_output import Output
-from .widget_selection import RadioButtons, ToggleButtons, Dropdown, Select, SelectMultiple
+from .widget_selection import RadioButtons, ToggleButtons, Dropdown, Select, SelectionSlider, SelectMultiple
 from .widget_selectioncontainer import Tab, Accordion
 from .widget_string import HTML, Latex, Text, Textarea
 from .widget_controller import Controller

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -232,6 +232,20 @@ class Select(_Selection):
     _model_name = Unicode('SelectModel', sync=True)
 
 
+@register('Jupyter.SelectionSlider')
+class SelectionSlider(_Selection):
+    """Slider to select a single item from a list or dictionary."""
+    _view_name = Unicode('SelectionSliderView', sync=True)
+    _modelname = Unicode('SelectionSliderModel', sync=True)
+
+    orientation = CaselessStrEnum(
+        values=['horizontal', 'vertical'],
+        default_value='horizontal', allow_none=False, sync=True,
+        help="""Vertical or horizontal.""")
+    readout = Bool(True, sync=True,
+        help="""Display the current selected label next to the slider""")
+
+
 @register('Jupyter.SelectMultiple')
 class SelectMultiple(_MultipleSelection):
     """Listbox that allows many items to be selected at any given time.


### PR DESCRIPTION
`SelectionSlider` is a selection widget (inherits from `_Selection`) that works just like a Dropdown / Toggle / Radio, but with a slider interface. 

Right now this duplicates a lot of the slider code (the `render`, `updateDescription` and `update_attr` functions) from `widget_int.js` into `widget_selection.js`, which is pretty bad. I was thinking moving the base slider code into a new file `widget_slider.js` and then having the `IntSlider` and `SelectionSlider` inherit from that. 
What do you guys think?
@SylvainCorlay @jdfreder 

I also added an example in the `Widget List` notebook.