### PR TITLE
Fix iopub callback invocation

### DIFF
--- a/jupyter-js-widgets/src/services-shim.js
+++ b/jupyter-js-widgets/src/services-shim.js
@@ -203,8 +203,13 @@ Comm.prototype._hookupCallbacks = function(future, callbacks) {
                     callbacks.iopub.status(msg);
                 } else if (callbacks.iopub.clear_output && msg.msg_type === 'clear_output') {
                     callbacks.iopub.clear_output(msg);
-                } else if (callbacks.iopub.output && msg.msg_type === 'display_data') {
-                    callbacks.iopub.output(msg);
+                } else if (callbacks.iopub.output) {
+                    switch(msg.msg_type) {
+                        case 'display_data':
+                        case 'execute_result':
+                            callbacks.iopub.output(msg);
+                            break;
+                    };
                 }
             }
         };

--- a/jupyter-js-widgets/src/services-shim.js
+++ b/jupyter-js-widgets/src/services-shim.js
@@ -198,9 +198,15 @@ Comm.prototype._hookupCallbacks = function(future, callbacks) {
         };
 
         future.onIOPub = function(msg) {
-            if (callbacks.iopub && callbacks.iopub.status) callbacks.iopub.status(msg);
-            if (callbacks.iopub && callbacks.iopub.clear_output) callbacks.iopub.clear_output(msg);
-            if (callbacks.iopub && callbacks.iopub.output) callbacks.iopub.output(msg);
+            if(callbacks.iopub) {
+                if (callbacks.iopub.status && msg.msg_type === 'status') {
+                    callbacks.iopub.status(msg);
+                } else if (callbacks.iopub.clear_output && msg.msg_type === 'clear_output') {
+                    callbacks.iopub.clear_output(msg);
+                } else if (callbacks.iopub.output && msg.msg_type === 'display_data') {
+                    callbacks.iopub.output(msg);
+                }
+            }
         };
     }
 };


### PR DESCRIPTION
Currently, every iopub handler is invoked for every message type in the shim. Here's a fix that also checks the message type.

Things I'm not sure about:

* Is iopub.output supposed to be invoked for display_data only? Or is it supposed to handle other messages as well?
* I didn't touch onReply since there's only one callback in there at the moment.
