### PR TITLE
Fix broken int/float sliders,

### DIFF
--- a/jupyter-js-widgets/src/widget_int.js
+++ b/jupyter-js-widgets/src/widget_int.js
@@ -49,7 +49,10 @@ var IntSliderView = widget.DOMWidgetView.extend({
             .hide();
 
         this.$slider = $('<div />')
-            .slider({})
+            .slider({
+                slide: this.handleSliderChange.bind(this),
+                stop: this.handleSliderChange.bind(this)
+            })
             .addClass('slider');
         // Put the slider in a container
         this.$slider_container = $('<div />')


### PR DESCRIPTION
The JS event was not triggering the callback.  I think these
changes were caused by the small split.  An accidental update
of components may have cause the problem.