### PR TITLE
Allow initial values for model attributes to be specified on creation of the models

### DIFF
--- a/jupyter-js-widgets/src/widget_controller.js
+++ b/jupyter-js-widgets/src/widget_controller.js
@@ -111,7 +111,7 @@ var ControllerModel = widget.DOMWidgetModel.extend({
         connected: false,
         timestamp: 0,
         buttons: [],
-        axez: [],
+        axes: [],
     }),
 
     initialize: function() {
@@ -123,18 +123,15 @@ var ControllerModel = widget.DOMWidgetModel.extend({
             // Start the wait loop, and listen to updates of the only
             // user-provided attribute, the gamepad index.
             this.readout = 'Connect gamepad and press any button.';
-            // Wait for the state to be provided by the backend.
-            this.on('ready', function() {
-                if (this.get('connected')) {
-                    // No need to re-create Button and Axis widgets, re-use
-                    // the models provided by the backend which may already
-                    // be wired to other things.
-                    this.update_loop();
-                } else {
-                    // Wait for a gamepad to be connected.
-                    this.wait_loop();
-                }
-            }, this);
+            if (this.get('connected')) {
+                // No need to re-create Button and Axis widgets, re-use
+                // the models provided by the backend which may already
+                // be wired to other things.
+                this.update_loop();
+            } else {
+                 // Wait for a gamepad to be connected.
+                this.wait_loop();
+            }
         }
     },
 

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -67,13 +67,9 @@ var WidgetManager = function (comm_manager, notebook) {
                     model_name: widget_info.msg.content.data.state._model_name,
                     model_module: widget_info.msg.content.data.state._model_module,
                     comm: widget_info.comm,
-                }).then(function(model) {
-                    return model._handle_comm_msg(widget_info.msg).then(function() {
-                        return model.id;
-                    });
-                });
+                }, widget_info.msg.content.data.state);
             }));
-        }).then(function(model_ids) {
+        }).then(function(models) {
 
             // Load the initial state of the widget manager if a load callback was
             // registered.


### PR DESCRIPTION
- The base widget model constructor now takes the standard backbonejs `attributes` argument so that we can create widget models with initial values.
- The private helper function `_deserialize_state` is now a class method. We need that so that we can deserialize state before instantiating the model, and pass the full deserialized state to the model constructors.
- A consequence is that `_deserialize_state` cannot take the model instance as a second argument anymore. *And therefore, the same is also true for the custom serializers*. Custom deserializers were actually not using this second argument, except the model deserialization (`IPY_MODEL_***` to model instance) which in fact only needed a reference to the widget manager. Hence, the second argument passed to `_deserialize_state` and the custom serializers is now the widget manager itself.
- The `_first_state` attribute has been removed from the base model, simplifying our overload of backbone.Model.set.
- The widget controller does not use the `ready` event that was removed since it is not needed anymore. This should solve the last issues with Controller widget persistence.


This is a negative contribution in the number of lines, so a good sign!