### PR TITLE
Prevent widgets from shrinking super small by setting a max-width,

### DIFF
--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -407,8 +407,8 @@
         padding-top    : 5px;
         text-align     : center;
         vertical-align : text-top;
-        min-width      : 3.5em;
-        max-width      : 3.5em;
+        min-width      : 4em;
+        max-width      : 4em;
 
         word-wrap: break-word;
     }

--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -393,10 +393,13 @@
     .widget-label {
         /* Horizontal Label */
         min-width      : 10ex;
+        max-width      : 10ex;
         padding-right  : 8px;
         padding-top    : 5px;
         text-align     : right;
         vertical-align : text-top;
+
+        word-wrap: break-word;
     }
 
     .widget-readout {
@@ -405,6 +408,9 @@
         text-align     : center;
         vertical-align : text-top;
         min-width      : 3.5em;
+        max-width      : 3.5em;
+
+        word-wrap: break-word;
     }
 }
 


### PR DESCRIPTION
on both the labels and readouts.

closes #380