### PR TITLE
Remove comm:dead and comm:live events

### DIFF
--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -82,25 +82,11 @@ var WidgetModel = Backbone.Model.extend({
             comm.on_close(_.bind(this._handle_comm_closed, this));
             comm.on_msg(_.bind(this._handle_comm_msg, this));
 
-            this.set_comm_live(true);
+            this.comm_live = true;
         } else {
             this.comm_live = false;
         }
 
-        // Listen for the events that lead to the websocket being terminated.
-        var that = this;
-        var died = function() {
-            that.set_comm_live(false);
-        };
-
-        // TODO: Move this logic into manager-base, so users can override it.
-        // Also, notebook related logic should not live in widget!!!
-        if (widget_manager.notebook) {
-            widget_manager.notebook.events.on('kernel_disconnected.Kernel', died);
-            widget_manager.notebook.events.on('kernel_killed.Kernel', died);
-            widget_manager.notebook.events.on('kernel_restarting.Kernel', died);
-            widget_manager.notebook.events.on('kernel_dead.Kernel', died);
-        }
         WidgetModel.__super__.constructor.apply(this, [attributes]);
     },
 
@@ -112,16 +98,6 @@ var WidgetModel = Backbone.Model.extend({
             var data = {method: 'custom', content: content};
             this.comm.send(data, callbacks, {}, buffers);
             this.pending_msgs++;
-        }
-    },
-
-    set_comm_live: function(live) {
-        /**
-         * Change the comm_live state of the model.
-         */
-        if (this.comm_live === undefined || this.comm_live != live) {
-            this.comm_live = live;
-            this.trigger(live ? 'comm:live' : 'comm:dead', {model: this});
         }
     },
 
@@ -454,14 +430,6 @@ var WidgetViewMixin = {
          * Public constructor.
          */
         this.listenTo(this.model, 'change', this.update, this);
-
-        // Bubble the comm live events.
-        this.listenTo(this.model, 'comm:live', function() {
-            this.trigger('comm:live', this);
-        }, this);
-        this.listenTo(this.model, 'comm:dead', function() {
-            this.trigger('comm:dead', this);
-        }, this);
 
         this.options = parameters.options;
         /**

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -43,13 +43,6 @@ var handle_cell = function(cell) {
     if (cell.cell_type==='code') {
         var area = new widgetarea.WidgetArea(cell);
         cell.widgetarea = area;
-        var died = function () {
-            area._widget_dead();
-        }
-        cell.notebook.events.on('kernel_disconnected.Kernel', died);
-        cell.notebook.events.on('kernel_killed.Kernel', died);
-        cell.notebook.events.on('kernel_restarting.Kernel', died);
-        cell.notebook.events.on('kernel_dead.Kernel', died);
     }
 };
 

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -43,6 +43,13 @@ var handle_cell = function(cell) {
     if (cell.cell_type==='code') {
         var area = new widgetarea.WidgetArea(cell);
         cell.widgetarea = area;
+        var died = function () {
+            area._widget_dead();
+        }
+        cell.notebook.events.on('kernel_disconnected.Kernel', died);
+        cell.notebook.events.on('kernel_killed.Kernel', died);
+        cell.notebook.events.on('kernel_restarting.Kernel', died);
+        cell.notebook.events.on('kernel_dead.Kernel', died);
     }
 };
 

--- a/widgetsnbextension/src/widgetarea.js
+++ b/widgetsnbextension/src/widgetarea.js
@@ -19,6 +19,13 @@ var WidgetArea = function(cell) {
     requirejs(['base/js/events'], (function(events) {
         events.trigger('create.WidgetArea', {widgetarea: this, cell: cell});
     }).bind(this));
+
+    var that = this;
+    var died = function () { that._widget_dead(); };
+    cell.notebook.events.on('kernel_disconnected.Kernel', died);
+    cell.notebook.events.on('kernel_killed.Kernel', died);
+    cell.notebook.events.on('kernel_restarting.Kernel', died);
+    cell.notebook.events.on('kernel_dead.Kernel', died);
 };
 
 /**
@@ -63,6 +70,10 @@ WidgetArea.prototype.display_widget_view = function(view_promise) {
  * Disposes of the widget area and its widgets.
  */
 WidgetArea.prototype.dispose = function() {
+    this._cell.notebook.events.off('kernel_disconnected.Kernel');
+    this._cell.notebook.events.off('kernel_killed.Kernel');
+    this._cell.notebook.events.off('kernel_restarting.Kernel');
+    this._cell.notebook.events.off('kernel_dead.Kernel');
     this._clear();
     this.disposed = true;
 };

--- a/widgetsnbextension/src/widgetarea.js
+++ b/widgetsnbextension/src/widgetarea.js
@@ -44,10 +44,6 @@ WidgetArea.prototype.display_widget_view = function(view_promise) {
             that._widget_dead(view);
         }
 
-        // Listen to comm live events for the view.
-        view.on('comm:live', that._widget_live, that);
-        view.on('comm:dead', that._widget_dead, that);
-
         // If the view is removed, check to see if the widget area is empty.
         // If the widget area is empty, close it.
         view.on('remove', function() {
@@ -96,10 +92,6 @@ WidgetArea.prototype._create_elements = function() {
                 for (var i = 0; i < that.widget_views.length; i++) {
                     var view = that.widget_views[i];
                     view.remove();
-
-                    // Remove widget live events.
-                    view.off('comm:live', that._widget_live);
-                    view.off('comm:dead', that._widget_dead);
                 }
                 that.widget_views = [];
                 widget_subarea.html('');
@@ -131,7 +123,7 @@ WidgetArea.prototype._bind_events = function() {
  * Handles when a widget loses it's comm connection.
  * @param {WidgetView} view
  */
-WidgetArea.prototype._widget_dead = function(view) {
+WidgetArea.prototype._widget_dead = function() {
     if (this._widgets_live) {
         this._widgets_live = false;
         this.widget_area.addClass('connection-problems');
@@ -141,14 +133,15 @@ WidgetArea.prototype._widget_dead = function(view) {
 
 /**
  * Handles when a widget is connected to a live comm.
- * @param {WidgetView} view
  */
-WidgetArea.prototype._widget_live = function(view) {
+WidgetArea.prototype._widget_live = function() {
     if (!this._widgets_live) {
         // Check that the other widgets are live too.  O(N) operation.
         // Abort the function at the first dead widget found.
         for (var i = 0; i < this.widget_views.length; i++) {
-            if (!this.widget_views[i].model.comm_live) return;
+            if (!this.widget_views[i].model.comm_live) {
+                return;
+            }
         }
         this._widgets_live = true;
         this.widget_area.removeClass('connection-problems');
@@ -163,10 +156,6 @@ WidgetArea.prototype._clear = function() {
     for (var i = 0; i < this.widget_views.length; i++) {
         var view = this.widget_views[i];
         view.remove();
-
-        // Remove widget live events.
-        view.off('comm:live', this._widget_live);
-        view.off('comm:dead', this._widget_dead);
     }
     this.widget_views = [];
     this.widget_subarea.html('');
@@ -175,4 +164,6 @@ WidgetArea.prototype._clear = function() {
     this.widget_area.hide();
 };
 
-module.exports = {WidgetArea: WidgetArea};
+module.exports = {
+    WidgetArea: WidgetArea
+};


### PR DESCRIPTION
This is an attempt to remove the `comm:[dead/live]` event bubbling mechanism.