### PR TITLE
Allow regular string representation of commless widgets

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -234,6 +234,7 @@ class Widget(LoggingConfigurable):
             Widget.widgets.pop(self.model_id, None)
             self.comm.close()
             self.comm = None
+            self._ipython_display_ = None
 
     def _split_state_buffers(self, state):
         """Return (state_without_buffers, buffer_keys, buffers) for binary message parts"""


### PR DESCRIPTION
If one does
```python
from ipywidgets import IntSlider
s1 = IntSlider()
s1
```
and then 
```python
s1.close()
```
Then any further attempt to "display" the s1 python object is going to yield an exception.

What is done here instead is that comm-less widgets fall back to the regular `__repr__`.