### PR TITLE
javascript link act on initial data.

### DIFF
--- a/jupyter-js-widgets/src/widget_link.js
+++ b/jupyter-js-widgets/src/widget_link.js
@@ -57,6 +57,7 @@ var LinkModel = BaseLinkModel.extend({
 
     initialize: function() {
         this.on("change", this.update_bindings, this);
+        this.update_bindings();
     },
 
     update_bindings: function() {
@@ -87,6 +88,7 @@ var DirectionalLinkModel = BaseLinkModel.extend({
 
     initialize: function() {
         this.on("change", this.update_bindings, this);
+        this.update_bindings();
     },
 
     update_bindings: function() {


### PR DESCRIPTION
Now that we are initializing widget models with data, we must do more than registering callbacks in initialize, we must also act on the initial data. This is a case where it was missing (javascript link). This fixes the web2 example.