### PR TITLE
Use new trailets API for Range widgets

### DIFF
--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -14,6 +14,8 @@ import nose.tools as nt
 
 from ipykernel.comm import Comm
 import ipywidgets as widgets
+
+from traitlets import TraitError
 from ipywidgets import interact, interactive, Widget, interaction
 from ipython_genutils.py3compat import annotate
 
@@ -602,14 +604,6 @@ def test_float_range_logic():
     frsw = widgets.FloatRangeSlider
     w = frsw(value=(.2, .4), min=0., max=.6)
     check_widget(w, cls=frsw, value=(.2, .4), min=0., max=.6)
-    w.value = (.4, .2)
-    check_widget(w, cls=frsw, value=(.2, .4), min=0., max=.6)
-    w.value = (-.1, .7)
-    check_widget(w, cls=frsw, value=(0., .6), min=0., max=.6)
-    w.min = .3
-    check_widget(w, cls=frsw, value=(.3, .6), min=.3, max=.6)
-    w.max = .3
-    check_widget(w, cls=frsw, value=(.3, .3), min=.3, max=.3)
 
     w.min = 0.
     w.max = .6
@@ -620,41 +614,23 @@ def test_float_range_logic():
     check_widget(w, cls=frsw, value=(0., .1), min=0., max=.6)
     w.value = (.5, .6) #upper non-overlapping range
     check_widget(w, cls=frsw, value=(.5, .6), min=0., max=.6)
-    w.value = (-.1, .4) #semi out-of-range
-    check_widget(w, cls=frsw, value=(0., .4), min=0., max=.6)
     w.lower = .2
-    check_widget(w, cls=frsw, value=(.2, .4), min=0., max=.6)
-    w.value = (-.2, -.1) #wholly out of range
-    check_widget(w, cls=frsw, value=(0., 0.), min=0., max=.6)
-    w.value = (.7, .8)
-    check_widget(w, cls=frsw, value=(.6, .6), min=.0, max=.6)
+    check_widget(w, cls=frsw, value=(.2, .6), min=0., max=.6)
 
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         w.min = .7
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         w.max = -.1
-    with nt.assert_raises(ValueError):
-        w.lower = .5
-    with nt.assert_raises(ValueError):
-        w.upper = .1
+    with nt.assert_raises(TraitError):
+        w.lower = -.1
+    with nt.assert_raises(TraitError):
+        w.upper = .7
 
-    w = frsw(min=2, max=3)
+    w = frsw(min=2, max=3, value=(2.2, 2.5))
     check_widget(w, min=2, max=3)
-    w = frsw(min=1., max=2.)
-    check_widget(w, lower=1.25, upper=1.75, value=(1.25, 1.75))
 
-    with nt.assert_raises(ValueError):
-        frsw(value=(2, 4), lower=3)
-    with nt.assert_raises(ValueError):
-        frsw(value=(2, 4), upper=3)
-    with nt.assert_raises(ValueError):
-        frsw(value=(2, 4), lower=3, upper=3)
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         frsw(min=.2, max=.1)
-    with nt.assert_raises(ValueError):
-        frsw(lower=5)
-    with nt.assert_raises(ValueError):
-        frsw(upper=5)
 
 
 def test_multiple_selection():

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -545,14 +545,9 @@ def test_int_range_logic():
     irsw = widgets.IntRangeSlider
     w = irsw(value=(2, 4), min=0, max=6)
     check_widget(w, cls=irsw, value=(2, 4), min=0, max=6)
-    w.value = (4, 2)
-    check_widget(w, cls=irsw, value=(2, 4), min=0, max=6)
-    w.value = (-1, 7)
-    check_widget(w, cls=irsw, value=(0, 6), min=0, max=6)
-    w.min = 3
-    check_widget(w, cls=irsw, value=(3, 6), min=3, max=6)
+    w.upper = 3
     w.max = 3
-    check_widget(w, cls=irsw, value=(3, 3), min=3, max=3)
+    check_widget(w, cls=irsw, value=(2, 3), min=0, max=3)
 
     w.min = 0
     w.max = 6
@@ -563,41 +558,23 @@ def test_int_range_logic():
     check_widget(w, cls=irsw, value=(0, 1), min=0, max=6)
     w.value = (5, 6) #upper non-overlapping range
     check_widget(w, cls=irsw, value=(5, 6), min=0, max=6)
-    w.value = (-1, 4) #semi out-of-range
-    check_widget(w, cls=irsw, value=(0, 4), min=0, max=6)
     w.lower = 2
-    check_widget(w, cls=irsw, value=(2, 4), min=0, max=6)
-    w.value = (-2, -1) #wholly out of range
-    check_widget(w, cls=irsw, value=(0, 0), min=0, max=6)
-    w.value = (7, 8)
-    check_widget(w, cls=irsw, value=(6, 6), min=0, max=6)
+    check_widget(w, cls=irsw, value=(2, 6), min=0, max=6)
 
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         w.min = 7
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         w.max = -1
-    with nt.assert_raises(ValueError):
-        w.lower = 5
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         w.upper = 1
 
-    w = irsw(min=2, max=3)
-    check_widget(w, min=2, max=3)
-    w = irsw(min=100, max=200)
-    check_widget(w, lower=125, upper=175, value=(125, 175))
+    w = irsw(min=2, max=3, value=(2, 3))
+    check_widget(w, min=2, max=3, value=(2, 3))
+    w = irsw(min=100, max=200, value=(125, 175))
+    check_widget(w, value=(125, 175))
 
-    with nt.assert_raises(ValueError):
-        irsw(value=(2, 4), lower=3)
-    with nt.assert_raises(ValueError):
-        irsw(value=(2, 4), upper=3)
-    with nt.assert_raises(ValueError):
-        irsw(value=(2, 4), lower=3, upper=3)
-    with nt.assert_raises(ValueError):
+    with nt.assert_raises(TraitError):
         irsw(min=2, max=1)
-    with nt.assert_raises(ValueError):
-        irsw(lower=5)
-    with nt.assert_raises(ValueError):
-        irsw(upper=5)
 
 
 def test_float_range_logic():

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -10,7 +10,7 @@ from .domwidget import DOMWidget
 from .widget import register
 from .trait_types import Color
 from traitlets import (Unicode, CFloat, Bool, CaselessStrEnum,
-                                     Tuple, TraitError)
+                       Tuple, TraitError, validate)
 
 
 class _Float(DOMWidget):
@@ -38,7 +38,7 @@ class _BoundedFloat(_Float):
     def _min_validate(self, min, trait):
         """Enforce min <= value <= max"""
         if min > self.max:
-            raise TraitError("Setting min > max")
+            raise TraitError('Setting min > max')
         if min > self.value:
             self.value = min
         return min
@@ -46,7 +46,7 @@ class _BoundedFloat(_Float):
     def _max_validate(self, max, trait):
         """Enforce min <= value <= max"""
         if max < self.min:
-            raise TraitError("setting max < min")
+            raise TraitError('setting max < min')
         if max < self.value:
             self.value = max
         return max
@@ -161,95 +161,54 @@ class FloatProgress(_BoundedFloat):
 class _FloatRange(_Float):
     value = Tuple(CFloat(), CFloat(), default_value=(0.0, 1.0),
                   help="Tuple of (lower, upper) bounds").tag(sync=True)
-    lower = CFloat(0.0, help="Lower bound")
-    upper = CFloat(1.0, help="Upper bound")
 
-    def __init__(self, *pargs, **kwargs):
-        value_given = 'value' in kwargs
-        lower_given = 'lower' in kwargs
-        upper_given = 'upper' in kwargs
-        if value_given and (lower_given or upper_given):
-            raise ValueError("Cannot specify both 'value' and 'lower'/'upper' for range widget")
-        if lower_given != upper_given:
-            raise ValueError("Must specify both 'lower' and 'upper' for range widget")
+    @property
+    def lower(self):
+        return self.value[0]
 
-        DOMWidget.__init__(self, *pargs, **kwargs)
+    @lower.setter
+    def lower(self, lower):
+        self.value = (lower, self.value[1])
 
-        # ensure the traits match, preferring whichever (if any) was given in kwargs
-        if value_given:
-            self.lower, self.upper = self.value
-        else:
-            self.value = (self.lower, self.upper)
+    @property
+    def upper(self):
+        return self.value[1]
 
-        self.on_trait_change(self._validate, ['value', 'upper', 'lower'])
+    @upper.setter
+    def upper(self, upper):
+        self.value = (self.value[0], upper)
 
-    def _validate(self, name, old, new):
-        if name == 'value':
-            self.lower, self.upper = min(new), max(new)
-        elif name == 'lower':
-            self.value = (new, self.value[1])
-        elif name == 'upper':
-            self.value = (self.value[0], new)
+    @validate('value')
+    def _validate_value(self, proposal):
+        lower, upper = proposal['value']
+        if upper < lower:
+            raise TraitError('setting lower > upper')
+        return lower, upper
+
 
 class _BoundedFloatRange(_FloatRange):
     step = CFloat(1.0, help="Minimum step that the value can take (ignored by some views)").tag(sync=True)
     max = CFloat(100.0, help="Max value").tag(sync=True)
     min = CFloat(0.0, help="Min value").tag(sync=True)
 
-    def __init__(self, *pargs, **kwargs):
-        any_value_given = 'value' in kwargs or 'upper' in kwargs or 'lower' in kwargs
-        _FloatRange.__init__(self, *pargs, **kwargs)
+    @validate('min', 'max')
+    def _validate_bounds(self, proposal):
+        trait = proposal['trait']
+        new = proposal['value']
+        if trait.name == 'min' and new > self.lower:
+            raise TraitError('setting min > lower')
+        if trait.name == 'max' and new < self.upper:
+            raise TraitError('setting max < upper')
+        return new
 
-        # ensure a minimal amount of sanity
-        if self.min > self.max:
-            raise ValueError("min must be <= max")
-
-        if any_value_given:
-            # if a value was given, clamp it within (min, max)
-            self._validate("value", None, self.value)
-        else:
-            # otherwise, set it to 25-75% to avoid the handles overlapping
-            self.value = (0.75 * self.min + 0.25 * self.max,
-                          0.25 * self.min + 0.75 * self.max)
-        # callback already set for 'value', 'lower', 'upper'
-        self.on_trait_change(self._validate, ['min', 'max'])
-
-    def _validate(self, name, old, new):
-        if name == "min":
-            if new > self.max:
-                raise ValueError("setting min > max")
-            self.min = new
-        elif name == "max":
-            if new < self.min:
-                raise ValueError("setting max < min")
-            self.max = new
-
-        low, high = self.value
-        if name == "value":
-            low, high = min(new), max(new)
-        elif name == "upper":
-            if new < self.lower:
-                raise ValueError("setting upper < lower")
-            high = new
-        elif name == "lower":
-            if new > self.upper:
-                raise ValueError("setting lower > upper")
-            low = new
-
-        low = max(self.min, min(low, self.max))
-        high = min(self.max, max(high, self.min))
-
-        # determine the order in which we should update the
-        # lower, upper traits to avoid a temporary inverted overlap
-        lower_first = high < self.lower
-
-        self.value = (low, high)
-        if lower_first:
-            self.lower = low
-            self.upper = high
-        else:
-            self.upper = high
-            self.lower = low
+    @validate('value')
+    def _validate_value(self, proposal):
+        lower, upper = super(_BoundedFloatRange, self)._validate_value(proposal)
+        if lower < self.min:
+            raise TraitError('setting lower < min')
+        if upper > self.max:
+            raise TraitError('setting upper > max')
+        return lower, upper
 
 
 @register('Jupyter.FloatRangeSlider')

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -191,6 +191,13 @@ class _BoundedFloatRange(_FloatRange):
     max = CFloat(100.0, help="Max value").tag(sync=True)
     min = CFloat(0.0, help="Min value").tag(sync=True)
 
+    def __init__(self, *args, **kwargs):
+        min, max = kwargs.get('min', 0.0), kwargs.get('max', 100.0)
+        if not kwargs.get('value', None):
+            kwargs['value'] = (0.75 * min + 0.25 * max,
+                               0.25 * min + 0.75 * max)
+        super(_BoundedFloatRange, self).__init__(*args, **kwargs)
+
     @validate('min', 'max')
     def _validate_bounds(self, proposal):
         trait = proposal['trait']

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -213,7 +213,7 @@ class _BoundedFloatRange(_FloatRange):
 
 @register('Jupyter.FloatRangeSlider')
 class FloatRangeSlider(_BoundedFloatRange):
-    """ Slider/trackbar for displaying a floating value range (within the specified range of values).
+    """ Slider/trackbar that represents a pair of floats bounded by minimum and maximum value.
 
 	Parameters
 	----------

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -194,6 +194,13 @@ class _BoundedIntRange(_IntRange):
     max = CInt(100, help="Max value").tag(sync=True)
     min = CInt(0, help="Min value").tag(sync=True)
 
+    def __init__(self, *args, **kwargs):
+        min, max = kwargs.get('min', 0), kwargs.get('max', 100)
+        if not kwargs.get('value', None):
+            kwargs['value'] = (0.75 * min + 0.25 * max,
+                               0.25 * min + 0.75 * max)
+        super(_BoundedIntRange, self).__init__(*args, **kwargs)
+
     @validate('min', 'max')
     def _validate_bounds(self, proposal):
         trait = proposal['trait']

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -9,8 +9,8 @@ Represents an unbounded int using a widget.
 from .domwidget import DOMWidget
 from .widget import register
 from .trait_types import Color
-from traitlets import Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError
-
+from traitlets import (Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError,
+                       validate)
 
 _int_doc_t = """
 Parameters
@@ -100,7 +100,7 @@ class _BoundedInt(_Int):
     def _min_validate(self, min, trait):
         """Enforce min <= value <= max"""
         if min > self.max:
-            raise TraitError("Setting min > max")
+            raise TraitError('setting min > max')
         if min > self.value:
             self.value = min
         return min
@@ -108,7 +108,7 @@ class _BoundedInt(_Int):
     def _max_validate(self, max, trait):
         """Enforce min <= value <= max"""
         if max < self.min:
-            raise TraitError("setting max < min")
+            raise TraitError('setting max < min')
         if max < self.value:
             self.value = max
         return max
@@ -162,108 +162,69 @@ class IntProgress(_BoundedInt):
 
 
 class _IntRange(_Int):
-    value = Tuple(CInt(), CInt(), default_value=(0, 1), help="Tuple of (lower, upper) bounds").tag(sync=True)
-    lower = CInt(0, help="Lower bound")
-    upper = CInt(1, help="Upper bound")
+    value = Tuple(CInt(), CInt(), default_value=(0, 1),
+                  help="Tuple of (lower, upper) bounds").tag(sync=True)
 
-    def __init__(self, *pargs, **kwargs):
-        value_given = 'value' in kwargs
-        lower_given = 'lower' in kwargs
-        upper_given = 'upper' in kwargs
-        if value_given and (lower_given or upper_given):
-            raise ValueError("Cannot specify both 'value' and 'lower'/'upper' for range widget")
-        if lower_given != upper_given:
-            raise ValueError("Must specify both 'lower' and 'upper' for range widget")
+    @property
+    def lower(self):
+        return self.value[0]
 
-        super(_IntRange, self).__init__(*pargs, **kwargs)
+    @lower.setter
+    def lower(self, lower):
+        self.value = (lower, self.value[1])
 
-        # ensure the traits match, preferring whichever (if any) was given in kwargs
-        if value_given:
-            self.lower, self.upper = self.value
-        else:
-            self.value = (self.lower, self.upper)
+    @property
+    def upper(self):
+        return self.value[1]
 
-        self.on_trait_change(self._validate, ['value', 'upper', 'lower'])
+    @upper.setter
+    def upper(self, upper):
+        self.value = (self.value[0], upper)
 
-    def _validate(self, name, old, new):
-        if name == 'value':
-            self.lower, self.upper = min(new), max(new)
-        elif name == 'lower':
-            self.value = (new, self.value[1])
-        elif name == 'upper':
-            self.value = (self.value[0], new)
+    @validate('value')
+    def _validate_value(self, proposal):
+        lower, upper = proposal['value']
+        if upper < lower:
+            raise TraitError('setting lower > upper')
+        return lower, upper
+
 
 class _BoundedIntRange(_IntRange):
     step = CInt(1, help="Minimum step that the value can take (ignored by some views)").tag(sync=True)
     max = CInt(100, help="Max value").tag(sync=True)
     min = CInt(0, help="Min value").tag(sync=True)
 
-    def __init__(self, *pargs, **kwargs):
-        any_value_given = 'value' in kwargs or 'upper' in kwargs or 'lower' in kwargs
-        _IntRange.__init__(self, *pargs, **kwargs)
+    @validate('min', 'max')
+    def _validate_bounds(self, proposal):
+        trait = proposal['trait']
+        new = proposal['value']
+        if trait.name == 'min' and new > self.lower:
+            raise TraitError('setting min > lower')
+        if trait.name == 'max' and new < self.upper:
+            raise TraitError('setting max < upper')
+        return new
 
-        # ensure a minimal amount of sanity
-        if self.min > self.max:
-            raise ValueError("min must be <= max")
+    @validate('value')
+    def _validate_value(self, proposal):
+        lower, upper = super(_BoundedIntRange, self)._validate_value(proposal)
+        if lower < self.min:
+            raise TraitError('setting lower < min')
+        if upper > self.max:
+            raise TraitError('setting upper > max')
+        return lower, upper
 
-        if any_value_given:
-            # if a value was given, clamp it within (min, max)
-            self._validate("value", None, self.value)
-        else:
-            # otherwise, set it to 25-75% to avoid the handles overlapping
-            self.value = (0.75 * self.min + 0.25 * self.max,
-                          0.25 * self.min + 0.75 * self.max)
-        # callback already set for 'value', 'lower', 'upper'
-        self.on_trait_change(self._validate, ['min', 'max'])
-
-    def _validate(self, name, old, new):
-        if name == "min":
-            if new > self.max:
-                raise ValueError("setting min > max")
-        elif name == "max":
-            if new < self.min:
-                raise ValueError("setting max < min")
-
-        low, high = self.value
-        if name == "value":
-            low, high = min(new), max(new)
-        elif name == "upper":
-            if new < self.lower:
-                raise ValueError("setting upper < lower")
-            high = new
-        elif name == "lower":
-            if new > self.upper:
-                raise ValueError("setting lower > upper")
-            low = new
-
-        low = max(self.min, min(low, self.max))
-        high = min(self.max, max(high, self.min))
-
-        # determine the order in which we should update the
-        # lower, upper traits to avoid a temporary inverted overlap
-        lower_first = high < self.lower
-
-        self.value = (low, high)
-        if lower_first:
-            self.lower = low
-            self.upper = high
-        else:
-            self.upper = high
-            self.lower = low
 
 @register('Jupyter.IntRangeSlider')
 class IntRangeSlider(_BoundedIntRange):
-    """Slider widget that represents a pair of ints bounded by minimum and maximum value.
+    """Slider/trackbar that represents a pair of ints bounded by minimum and maximum value.
 
     Parameters
     ----------
-    lower: int
-        The lower bound of the range
-    upper: int
-        The upper bound of the range
-    min: int
+    value : int tuple
+        The pair (`lower`, `upper`) of integers
+    min : int
         The lowest allowed value for `lower`
-    max: int
+    max : int
         The highest allowed value for `upper`
     """
     _view_name = Unicode('IntSliderView').tag(sync=True)


### PR DESCRIPTION
- The range widgets were doing validation on trait change, which was allowing intermediate inconsistent states for the widgets to exist and be notified to the front-end.

  Now we use custom cross validation to validate that `lower <= upper` for `_FloatRange` and `min <= lower <= upper <= max` for `_BoundedFloatRange`.

- Cross validation occurs before any notification is sent, which solves the problem of intermediate inconsistent states, but it comes with constraints:

  With the `hold_trait_notifications` context manager, we allow delaying cross-validation and trait notifications to the time when the context is exited. At that time, all the cross-validation are called. If any of them fails, all the changes done with the context manager are reverted.

  However, we don't control the order of the cross validation calls which are set by the order of the iteration in a dictionary. Therefore, we must enforce that the operations done in the custom validator **commute**. One simple way to enforce this is to only allow the cross-validation to reject a change or change the proposed attribute value, but **not** change other trait attributes. (See traitlets documentation [here]( https://github.com/ipython/traitlets/blob/d13f22d93a826dedd2199c08cd89791cf393f16f/traitlets/traitlets.py#L798).)

    For example, if you have a `min` and `max`, you should not have max push min down if set to low and min push max up if set too high. Otherwise, the following code has unpredictable outcomes:
 
   ```python
   # min, max is 0, 1 
   with w.hold_trait_notifications():
       w.min = 2
       w.max = -2

   print(w.min, w.max)  # could give (-2, -2) or (2, 2)
   ```
   *So the new behavior for the range widget is that we reject if the min is set too high or the max is set too low*, which is a behavior change.

- Range widgets are "value" widgets in that like many other core widgets, they represent a "value", which here is a tuple for the  lower and upper bounds of the range.

  Originally, two other trait attributes (`lower` and `upper`) were added to facilitate direct access to the lower and upper bounds. Since the link was done on trait change, again, intermediate inconsistent state was possible. Using cross validation to do the link was not a solution for the same reason explained above.

   Instead, I use a *property* to bind `upper` and `lower` to the `value` tuple attribute. It is a behavior change in that you cannot register to change of upper or lower, and you must register to changes of `value` instead. Doing that also solves the issue met when the constructors has initial values for both `upper`, `lower` on the one hand and `value` on the other hand.