### PR TITLE
Refactor Selection widgets

### DIFF
--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -615,21 +615,21 @@ def test_multiple_selection():
 
     # degenerate multiple select
     w = smw()
-    check_widget(w, value=tuple(), options=None, selected_labels=tuple())
+    check_widget(w, value=tuple(), options=None)
 
     # don't accept random other value when no options
-    with nt.assert_raises(KeyError):
+    with nt.assert_raises(TraitError):
         w.value = (2,)
-    check_widget(w, value=tuple(), selected_labels=tuple())
+    check_widget(w, value=tuple())
 
     # basic multiple select
     w = smw(options=[(1, 1)], value=[1])
     check_widget(w, cls=smw, value=(1,), options=[(1, 1)])
 
     # don't accept random other value
-    with nt.assert_raises(KeyError):
+    with nt.assert_raises(TraitError):
         w.value = w.value + (2,)
-    check_widget(w, value=(1,), selected_labels=(1,))
+    check_widget(w, value=(1,))
 
     # change options
     w.options = w.options + [(2, 2)]
@@ -637,31 +637,14 @@ def test_multiple_selection():
 
     # change value
     w.value = w.value + (2,)
-    check_widget(w, value=(1, 2), selected_labels=(1, 2))
-
-    # change value name
-    w.selected_labels = (1,)
-    check_widget(w, value=(1,))
-
-    # don't accept random other names when no options
-    with nt.assert_raises(KeyError):
-        w.selected_labels = (3,)
-    check_widget(w, value=(1,))
-
-    # don't accept selected_label (from superclass)
-    with nt.assert_raises(AttributeError):
-        w.selected_label = 3
-
-    # don't return selected_label (from superclass)
-    with nt.assert_raises(AttributeError):
-        print(w.selected_label)
+    check_widget(w, value=(1, 2))
 
     # dict style
     w.options = {1: 1}
     check_widget(w, options={1: 1})
 
     # updating
-    with nt.assert_raises(KeyError):
+    with nt.assert_raises(TraitError):
         w.value = (2,)
     check_widget(w, options={1: 1})
 

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -74,7 +74,7 @@ class _Selection(DOMWidget):
         # If x is an ordinary list, use the option values as names.
         for y in x:
             if not isinstance(y, (list, tuple)) or len(y) < 2:
-                return [(i, i) for i in x]
+                return [(str(i), i) for i in x]
 
         # Value is already in the correct format.
         return x

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -5,16 +5,22 @@ Represents an enumeration using a widget.
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-
 from collections import OrderedDict
-from threading import Lock
 
 from .domwidget import DOMWidget
 from .widget import register
-from traitlets import (
-    Unicode, Bool, Any, Dict, TraitError, CaselessStrEnum, Tuple, List
-)
+from traitlets import (Unicode, Bool, Any, Dict, TraitError, CaselessStrEnum,
+                       Tuple, List, observe, validate)
 from ipython_genutils.py3compat import unicode_type
+
+def _value_to_label(value, obj):
+    # Reverse dictionary lookup for the value name
+    for k, v in obj._options_dict.items():
+        if obj.equals(value, v):
+            return k
+
+def _label_to_value(k, obj):
+    return obj._options_dict[k]
 
 
 class _Selection(DOMWidget):
@@ -24,14 +30,15 @@ class _Selection(DOMWidget):
     it will be transformed to a dict of the form ``{str(value):value}``.
 
     When programmatically setting the value, a reverse lookup is performed
-    among the options to set the value of ``selected_label`` accordingly. The
-    reverse lookup uses the equality operator by default, but an other
-    predicate may be provided via the ``equals`` argument. For example, when
-    dealing with numpy arrays, one may set equals=np.array_equal.
+    among the options to check that the value is valid. The reverse lookup uses
+    the equality operator by default, but another predicate may be provided via
+    the ``equals`` keyword argument. For example, when dealing with numpy arrays,
+    one may set equals=np.array_equal.
     """
 
-    value = Any(help="Selected value")
-    selected_label = Unicode(help="The label of the selected value").tag(sync=True)
+    value = Any(help="Selected value").tag(sync=True, to_json=_value_to_label,
+                from_json=_label_to_value)
+
     options = Any(help="""List of (key, value) tuples or dict of values that the
         user can select.
 
@@ -40,22 +47,16 @@ class _Selection(DOMWidget):
 
     The keys of this list are also available as _options_labels.
     """)
-
-    _options_dict = Dict()
-    _options_labels = Tuple().tag(sync=True)
-    _options_values = Tuple()
+    _options_dict = Dict(read_only=True)
+    _options_labels = Tuple(read_only=True).tag(sync=True)
+    _options_values = Tuple(read_only=True)
 
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     description = Unicode(help="Description of the value this widget represents").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
-        self.value_lock = Lock()
-        self.options_lock = Lock()
         self.equals = kwargs.pop('equals', lambda x, y: x == y)
-        self.observe(self._options_readonly_changed, names=['_options_dict', '_options_labels', '_options_values', '_options'])
-        if 'options' in kwargs:
-            self.options = kwargs.pop('options')
-        DOMWidget.__init__(self, *args, **kwargs)
+        super(_Selection, self).__init__(*args, **kwargs)
         self._value_in_options()
 
     def _make_options(self, x):
@@ -79,57 +80,40 @@ class _Selection(DOMWidget):
         # Value is already in the correct format.
         return x
 
-    def _options_changed(self, name, old, new):
+    @validate('options')
+    def _validate_options(self, proposal):
         """Handles when the options tuple has been changed.
 
         Setting options implies setting option labels from the keys of the dict.
         """
-        if self.options_lock.acquire(False):
-            try:
-                self.options = new
-
-                options = self._make_options(new)
-                self._options_dict = {i[0]: i[1] for i in options}
-                self._options_labels = [i[0] for i in options]
-                self._options_values = [i[1] for i in options]
-                self._value_in_options()
-            finally:
-                self.options_lock.release()
+        new = proposal['value']
+        options = self._make_options(new)
+        self.set_trait('_options_dict', { i[0]: i[1] for i in options })
+        self.set_trait('_options_labels', [ i[0] for i in options ])
+        self.set_trait('_options_values', [ i[1] for i in options ])
+        self._value_in_options()
+        return new
 
     def _value_in_options(self):
         # ensure that the chosen value is one of the choices
-
         if self._options_values:
             if self.value not in self._options_values:
                 self.value = next(iter(self._options_values))
 
-    def _options_readonly_changed(self, change):
-        if not self.options_lock.locked():
-            raise TraitError("`.%s` is a read-only trait. Use the `.options` tuple instead." % change['name'])
+    @validate('value')
+    def _validate_value(self, proposal):
+        value = proposal['value']
+        if _value_to_label(value, self) is not None:
+            return value
+        else:
+            raise TraitError('Invalid selection')
 
-    def _value_changed(self, name, old, new):
-        """Called when value has been changed"""
-        if self.value_lock.acquire(False):
-            try:
-                # Reverse dictionary lookup for the value name
-                for k, v in self._options_dict.items():
-                    if self.equals(new, v):
-                        # set the selected value name
-                        self.selected_label = k
-                        return
-                # undo the change, and raise KeyError
-                self.value = old
-                raise KeyError(new)
-            finally:
-                self.value_lock.release()
 
-    def _selected_label_changed(self, name, old, new):
-        """Called when the value name has been changed (typically by the frontend)."""
-        if self.value_lock.acquire(False):
-            try:
-                self.value = self._options_dict[new]
-            finally:
-                self.value_lock.release()
+def _values_to_labels(values, obj):
+    return tuple(_value_to_label(v, obj) for v in values)
+
+def _labels_to_values(k, obj):
+    return tuple(_label_to_value(l, obj) for l in k)
 
 
 class _MultipleSelection(_Selection):
@@ -139,20 +123,14 @@ class _MultipleSelection(_Selection):
     given as a list, it will be transformed to a dict of the form
     ``{str(value): value}``.
 
-    Despite their names, ``value`` (and ``selected_label``) will be tuples, even
-    if only a single option is selected.
+    Despite its name, the ``value`` attribute is a tuple, even if only a single
+    option is selected.
     """
 
-    value = Tuple(help="Selected values")
-    selected_labels = Tuple(help="The labels of the selected options").tag(sync=True)
-
-    @property
-    def selected_label(self):
-        raise AttributeError(
-            "Does not support selected_label, use selected_labels")
+    value = Tuple(help="Selected values").tag(sync=True,
+                  to_json=_values_to_labels, from_json=_labels_to_values)
 
     def _value_in_options(self):
-        # ensure that the chosen value is one of the choices
         if self.options:
             old_value = self.value or []
             new_value = []
@@ -164,28 +142,13 @@ class _MultipleSelection(_Selection):
             else:
                 self.value = [next(iter(self._options_dict.values()))]
 
-    def _value_changed(self, name, old, new):
-        """Called when value has been changed"""
-        if self.value_lock.acquire(False):
-            try:
-                self.selected_labels = [
-                    self._options_labels[self._options_values.index(v)]
-                    for v in new
-                ]
-            except:
-                self.value = old
-                raise KeyError(new)
-            finally:
-                self.value_lock.release()
-
-    def _selected_labels_changed(self, name, old, new):
-        """Called when the selected label has been changed (typically by the
-        frontend)."""
-        if self.value_lock.acquire(False):
-            try:
-                self.value = [self._options_dict[name] for name in new]
-            finally:
-                self.value_lock.release()
+    @validate('value')
+    def _validate_value(self, proposal):
+        value = proposal['value']
+        if all(_value_to_label(v, self) is not None for v in value):
+            return value
+        else:
+            raise TraitError('Invalid selection')
 
 
 @register('Jupyter.ToggleButtons')

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -10,7 +10,7 @@ var _ = require("underscore");
 var SelectionModel = widget.DOMWidgetModel.extend({
     defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
         _model_name: "SelectionModel",
-        selected_label: "",
+        value: "",
         _options_labels: [],
         disabled: false,
         description: "",
@@ -103,7 +103,7 @@ var DropdownView = widget.DOMWidgetView.extend({
          */
 
         if (options === undefined || options.updated_view != this) {
-            var selected_item_text = this.model.get('selected_label');
+            var selected_item_text = this.model.get('value');
             if (selected_item_text.trim().length === 0) {
                 this.$droplabel.html("&nbsp;");
             } else {
@@ -182,7 +182,7 @@ var DropdownView = widget.DOMWidgetView.extend({
          * Calling model.set will trigger all of the other views of the
          * model to update.
          */
-        this.model.set('selected_label', $(e.target).text(), {updated_view: this});
+        this.model.set('value', $(e.target).text(), {updated_view: this});
         this.touch();
 
         // Manually hide the droplist.
@@ -250,7 +250,7 @@ var RadioButtonsView = widget.DOMWidgetView.extend({
                 }
 
                 var $item_element = that.$container.find(item_query);
-                if (that.model.get('selected_label') == item) {
+                if (that.model.get('value') == item) {
                     $item_element.prop('checked', true);
                 } else {
                     $item_element.prop('checked', false);
@@ -304,7 +304,7 @@ var RadioButtonsView = widget.DOMWidgetView.extend({
          * Calling model.set will trigger all of the other views of the
          * model to update.
          */
-        this.model.set('selected_label', $(e.target).val(), {updated_view: this});
+        this.model.set('value', $(e.target).val(), {updated_view: this});
         this.touch();
     },
 });
@@ -379,7 +379,7 @@ var ToggleButtonsView = widget.DOMWidgetView.extend({
                     that.update_style_traits($item_element);
                     $icon_element = $('<i class="fa"></i>').prependTo($item_element);
                 }
-                if (that.model.get('selected_label') == item) {
+                if (that.model.get('value') == item) {
                     $item_element.addClass('active');
                 } else {
                     $item_element.removeClass('active');
@@ -465,7 +465,7 @@ var ToggleButtonsView = widget.DOMWidgetView.extend({
          * Calling model.set will trigger all of the other views of the
          * model to update.
          */
-        this.model.set('selected_label', $(e.target).attr('value'), {updated_view: this});
+        this.model.set('value', $(e.target).attr('value'), {updated_view: this});
         this.touch();
     },
 });
@@ -520,7 +520,7 @@ var SelectView = widget.DOMWidgetView.extend({
             });
 
             // Select the correct element
-            this.$listbox.val(this.model.get('selected_label'));
+            this.$listbox.val(this.model.get('value'));
 
             // Disable listbox if needed
             var disabled = this.model.get('disabled');
@@ -578,7 +578,7 @@ var SelectView = widget.DOMWidgetView.extend({
          * Calling model.set will trigger all of the other views of the
          * model to update.
          */
-        this.model.set('selected_label', this.$listbox.val(), {updated_view: this});
+        this.model.set('value', this.$listbox.val(), {updated_view: this});
         this.touch();
     },
 });
@@ -687,10 +687,10 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
             this.$slider.slider('option', 'value', min);
             this.$slider.slider('option', 'orientation', orientation);
 
-            var selected_label = this.model.get("selected_label");
-            var index = labels.indexOf(selected_label);
+            var value = this.model.get('value');
+            var index = labels.indexOf(value);
             this.$slider.slider('option', 'value', index);
-            this.$readout.text(selected_label);
+            this.$readout.text(value);
 
             // Use the right CSS classes for vertical & horizontal sliders
             if (orientation=='vertical') {
@@ -731,8 +731,8 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
      */
     handleSliderChange: function(e, ui) {
         var actual_value = this._validate_slide_value(ui.value);
-        var selected_label = this.model.get("_options_labels")[actual_value];
-        this.$readout.text(selected_label);
+        var value = this.model.get("_options_labels")[actual_value];
+        this.$readout.text(value);
 
         // Only persist the value while sliding if the continuous_update
         // trait is set to true.
@@ -749,9 +749,9 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
      */
     handleSliderChanged: function(e, ui) {
         var actual_value = this._validate_slide_value(ui.value);
-        var selected_label = this.model.get("_options_labels")[actual_value];
-        this.$readout.text(selected_label);
-        this.model.set('selected_label', selected_label, {updated_view: this});
+        var value = this.model.get("_options_labels")[actual_value];
+        this.$readout.text(value);
+        this.model.set('value', value, {updated_view: this});
         this.touch();
     },
 
@@ -769,7 +769,6 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
 var MultipleSelectionModel = SelectionModel.extend({
     defaults: _.extend({}, SelectionModel.prototype.defaults, {
         _model_name: "MultipleSelectionModel",
-        selected_labels: [],
     }),
 });
 
@@ -792,7 +791,7 @@ var SelectMultipleView = SelectView.extend({
           .on('change', $.proxy(this.handle_change, this));
 
         // set selected labels *after* setting the listbox to be multiple selection
-        this.$listbox.val(this.model.get('selected_labels'));
+        this.$listbox.val(this.model.get('value'));
         return this;
     },
 
@@ -804,7 +803,7 @@ var SelectMultipleView = SelectView.extend({
          * changed by another view or by a state update from the back-end.
          */
         SelectMultipleView.__super__.update.apply(this, arguments);
-        this.$listbox.val(this.model.get('selected_labels'));
+        this.$listbox.val(this.model.get('value'));
     },
 
     handle_click: function() {
@@ -828,12 +827,12 @@ var SelectMultipleView = SelectView.extend({
         // type information correctly, we need to map the selected indices
         // to the options list.
         var items = this.model.get('_options_labels');
-        var values = Array.prototype.map.call(this.$listbox[0].selectedOptions || [], function(option) {
+        var value = Array.prototype.map.call(this.$listbox[0].selectedOptions || [], function(option) {
             return items[option.index];
         });
 
-        this.model.set('selected_labels',
-            values,
+        this.model.set('value',
+            value,
             {updated_view: this});
         this.touch();
     },


### PR DESCRIPTION
Same type of refactoring using the new traitlets API to simplify the selection and multi-selection widgets.

One change here is that the `selection_label` attribute was removed and it is directly `value` that is synced with the front-end, but with a custom serializer that actually sends the label through the wire.

It allows to remove a complicated logic of locks that was put in place to cross-update `label` and `value`.

Besides, like for the range widgets, this fixes the potential inconsistent state issues that was due to validating things on change of attributes rather than before.