### PR TITLE
Use registry in web example for link widget

### DIFF
--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -6,7 +6,7 @@ Propagate changes between widgets on the javascript side.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import Widget, widget_serialization
+from .widget import Widget, register, widget_serialization
 from traitlets import Unicode, Tuple, List,Instance, TraitError
 
 
@@ -30,6 +30,7 @@ class WidgetTraitTuple(Tuple):
         return value
 
 
+@register('jupyter.Link')
 class Link(Widget):
     """Link Widget
 
@@ -53,6 +54,9 @@ class Link(Widget):
 def jslink(attr1, attr2):
     """Link two widget attributes on the frontend so they remain in sync.
 
+    The link is created in the front-end and does not rely on a roundtrip
+    to the backend.
+
     Parameters
     ----------
     source : a (Widget, 'trait_name') tuple for the first trait
@@ -66,6 +70,7 @@ def jslink(attr1, attr2):
     return Link(attr1, attr2)
 
 
+@register('jupyter.DirectionalLink')
 class DirectionalLink(Link):
     """A directional link
 
@@ -77,8 +82,10 @@ class DirectionalLink(Link):
 
 
 def jsdlink(source, target):
-    """Link a source widget attribute with a target widget attribute on the
-    frontend.
+    """Link a source widget attribute with a target widget attribute.
+
+    The link is created in the front-end and does not rely on a roundtrip
+    to the backend.
 
     Parameters
     ----------

--- a/jupyter-js-widgets/examples/web/index.js
+++ b/jupyter-js-widgets/examples/web/index.js
@@ -23,15 +23,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
             model.set({
                 description: description || '',
-                value: value || null,
-                visible: true
+                value: value,
             });
 
             return  manager.create_view(model);
-        }, console.error.bind(console)
-
-        // Display the view.
-        ).then(function(view) {
+        }, console.error.bind(console))
+        .then(function(view) {
             console.log(widgetType + ' view created');
             manager.display_view(null, view);
             return view;
@@ -45,7 +42,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     // Create a link model.
     manager.new_widget({
         model_name: 'LinkModel',
-        widget_class: 'ipywidgets.JSLink',
+        widget_class: 'jupyter.JSLink',
         model_id: uuid()
 
     // Set the link model state.


### PR DESCRIPTION
Just to be consistent in the examples.

Besides, now that we have js default values, no need to specify `visible: true`