### PR TITLE
Fix selection

### DIFF
--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -187,7 +187,7 @@ class RadioButtons(_Selection):
     Only one radio button can be toggled at any point in time.
     """
     _view_name = Unicode('RadioButtonsView').tag(sync=True)
-    _modelname = Unicode('RadioButtonsModel').tag(sync=True)
+    _model_name = Unicode('RadioButtonsModel').tag(sync=True)
 
 
 @register('Jupyter.Select')
@@ -200,8 +200,8 @@ class Select(_Selection):
 @register('Jupyter.SelectionSlider')
 class SelectionSlider(_Selection):
     """Slider to select a single item from a list or dictionary."""
-    _view_name = Unicode('SelectionSliderView', sync=True)
-    _modelname = Unicode('SelectionSliderModel', sync=True)
+    _view_name = Unicode('SelectionSliderView').tag(sync=True)
+    _model_name = Unicode('SelectionSliderModel').tag(sync=True)
 
     orientation = CaselessStrEnum(
         values=['horizontal', 'vertical'],

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -429,6 +429,7 @@ var WidgetViewMixin = {
         /**
          * Public constructor.
          */
+        console.log('Hooking up model update...');
         this.listenTo(this.model, 'change', this.update, this);
 
         this.options = parameters.options;

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -429,7 +429,6 @@ var WidgetViewMixin = {
         /**
          * Public constructor.
          */
-        console.log('Hooking up model update...');
         this.listenTo(this.model, 'change', this.update, this);
 
         this.options = parameters.options;

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -669,7 +669,6 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
          * Called when the model is changed.  The model may have been
          * changed by another view or by a state update from the back-end.
          */
-        console.log('Update called');
         if (options === undefined || options.updated_view != this) {
             var labels = this.model.get("_options_labels");
             var max = labels.length - 1;

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -606,7 +606,9 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
 
         this.$slider = $('<div />')
             .slider({})
-            .addClass('slider');
+            .addClass('slider')
+            .on('slidechange', $.proxy(this.handleSliderChange, this));
+
         // Put the slider in a container
         this.$slider_container = $('<div />')
             .addClass('slider-container')
@@ -667,6 +669,7 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
          * Called when the model is changed.  The model may have been
          * changed by another view or by a state update from the back-end.
          */
+        console.log('Update called');
         if (options === undefined || options.updated_view != this) {
             var labels = this.model.get("_options_labels");
             var max = labels.length - 1;
@@ -693,7 +696,7 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
             this.$readout.text(value);
 
             // Use the right CSS classes for vertical & horizontal sliders
-            if (orientation=='vertical') {
+            if (orientation === 'vertical') {
                 this.$el
                     .removeClass('widget-hslider')
                     .addClass('widget-vslider');


### PR DESCRIPTION
Fixes:

- [x] Incorrect class attribute name python-side for SelectionSlider.
- [x] Incorrect API for tagging `sync=True` for SelectionSlider.
- [x] Incorrect class attribute name python-side for RadioButtons.
- [x] Actually hook up slide change notification javascript-side for SelectionSlider.
- [x] Use strict equality + cleanup check.

With these fixes, the SelectionSlider readout value actually changes when the slider is moved (this doesn't work on master):

![selection](https://cloud.githubusercontent.com/assets/2343358/13637760/00ed0a0c-e601-11e5-8098-0a7417529e72.gif)
