### PR TITLE
Add web4 example with inline widget state

### DIFF
--- a/jupyter-js-widgets/examples/web4/README.md
+++ b/jupyter-js-widgets/examples/web4/README.md
@@ -1,0 +1,19 @@
+# Using jupyter-js-widgets in non-notebook, web context
+## Description
+This directory is an example project that shows how you can embed the widgets in
+a context other than the notebook, and declare widget manager state in the html
+document.
+
+## Try it
+1. Start with a development install of jupyter-js-widgets by running `npm install` in the `jupyter-js-widgets` subfolder of the repo root (see the [README.md](../../../README.md) in the repo root for more details).
+2. Cd into this directory and run `npm install`.
+3. Now open the `index.html` file.
+
+## Details
+If you plan to reproduce this in your own project, pay careful attention to the
+package.json file.  The dependency to jupyter-js-widgets, which reads
+`"jupyter-js-widgets": "file:../../../ipywidgets"`, **should not** point to `"file:../../../ipywidgets"`.
+Instead point it to the version you want to use on npm.
+
+(but really, you should let npm do this for you by running
+`npm install --save jupyter-js-widgets`.)

--- a/jupyter-js-widgets/examples/web4/index.html
+++ b/jupyter-js-widgets/examples/web4/index.html
@@ -2,6 +2,14 @@
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF8">
         <link rel="stylesheet" type="text/css" href="./node_modules/font-awesome/css/font-awesome.css">
+        <style>
+        .jupyter-widgetarea {
+            margin: 5px;
+            margin-left: auto;
+            margin-right: auto;
+            max-width: 900px;
+        }
+        </style>
     </head>
     <body>
         <script src="built/index.built.js"></script>

--- a/jupyter-js-widgets/examples/web4/index.html
+++ b/jupyter-js-widgets/examples/web4/index.html
@@ -1,0 +1,96 @@
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF8">
+        <link rel="stylesheet" type="text/css" href="./node_modules/font-awesome/css/font-awesome.css">
+    </head>
+    <body>
+        <script src="built/index.built.js"></script>
+        <script>
+        w({
+            "79c5cde32c044e4d95cfa27a54982bde": {
+                "model_name": "LayoutModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {},
+                "views": []
+            },
+            "7687c2dd3f344143ae1e87ee9704c774": {
+                "model_name": "IntSliderModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {
+                    "layout": "IPY_MODEL_79c5cde32c044e4d95cfa27a54982bde",
+                    "max": 200,
+                    "value": 100
+                },
+                "views": []
+            },
+            "06ad7ea9cf7b4029b312e8fc012c3294": {
+                "model_name": "LayoutModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {},
+                "views": []
+            },
+            "0c3957dbb4734762a84ad924f77197b3": {
+                "model_name": "IntSliderModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {
+                    "layout": "IPY_MODEL_06ad7ea9cf7b4029b312e8fc012c3294",
+                    "value": 40
+                },
+                "views": []
+            },
+            "f326c34c26034acdbab8ca4610d49bae": {
+                "model_name": "LayoutModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {},
+                "views": []
+            },
+            "2e4ca159b05a4f3295c8b59695359428": {
+                "model_name": "ButtonModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {
+                    "layout": "IPY_MODEL_f326c34c26034acdbab8ca4610d49bae",
+                    "icon": "fa-legal"
+                },
+                "views": []
+            },
+            "e7c5849fbfe7415ab5896fc749d71164": {
+                "model_name": "DirectionalLinkModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {
+                    "target": [
+                        "IPY_MODEL_0c3957dbb4734762a84ad924f77197b3",
+                        "max"
+                    ],
+                    "source": [
+                        "IPY_MODEL_7687c2dd3f344143ae1e87ee9704c774",
+                        "value"
+                    ]
+                },
+                "views": []
+            },
+            "4e6ee45ef7c64f0f953c79150d4ae0ca": {
+                "model_name": "LayoutModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {
+                    "flex_flow": "column",
+                    "display": "flex"
+                },
+                "views": []
+            },
+            "4c5a49e52ae54ad5bdbe973353a58931": {
+                "model_name": "BoxModel",
+                "model_module": "jupyter-js-widgets",
+                "state": {
+                    "children": [
+                        "IPY_MODEL_7687c2dd3f344143ae1e87ee9704c774",
+                        "IPY_MODEL_0c3957dbb4734762a84ad924f77197b3",
+                        "IPY_MODEL_2e4ca159b05a4f3295c8b59695359428"
+                    ],
+                    "layout": "IPY_MODEL_4e6ee45ef7c64f0f953c79150d4ae0ca"
+                },
+                "views": [{}]
+            }
+        });
+        </script>
+    </body>
+</html>

--- a/jupyter-js-widgets/examples/web4/index.js
+++ b/jupyter-js-widgets/examples/web4/index.js
@@ -1,10 +1,11 @@
-require("jupyter-js-widgets/css/widgets.min.css");
+require('jupyter-js-widgets/css/widgets.min.css');
 
 var WidgetManager = require("./manager").WidgetManager;
 
 window.w = function renderWidgetState (state) {
     console.info('Inserting widget(s)...');
     var widgetarea = document.createElement('div');
+    widgetarea.className = 'jupyter-widgetarea'
     var manager = new WidgetManager(widgetarea);
     manager.set_state(state);
     var context = Array.prototype.slice.call(document.querySelectorAll('script'), -1)[0];

--- a/jupyter-js-widgets/examples/web4/index.js
+++ b/jupyter-js-widgets/examples/web4/index.js
@@ -1,0 +1,12 @@
+require("jupyter-js-widgets/css/widgets.min.css");
+
+var WidgetManager = require("./manager").WidgetManager;
+
+window.w = function renderWidgetState (state) {
+    console.info('Inserting widget(s)...');
+    var widgetarea = document.createElement('div');
+    var manager = new WidgetManager(widgetarea);
+    manager.set_state(state);
+    var context = Array.prototype.slice.call(document.querySelectorAll('script'), -1)[0];
+    context.parentElement.insertBefore(widgetarea, context);
+};

--- a/jupyter-js-widgets/examples/web4/manager.js
+++ b/jupyter-js-widgets/examples/web4/manager.js
@@ -1,4 +1,4 @@
-require('bootstrap/dist/css/bootstrap.css');
+require('bootstrap/dist/css/bootstrap.css')
 require('jquery-ui/themes/smoothness/jquery-ui.min.css');
 
 var widgets = require('jupyter-js-widgets');

--- a/jupyter-js-widgets/examples/web4/package.json
+++ b/jupyter-js-widgets/examples/web4/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "jupyter-js-widgets-test",
+  "version": "1.0.0",
+  "description": "Project that tests the ability to npm install jupyter-js-widgets within an npm project.",
+  "main": "index.js",
+  "scripts": {
+    "prepublish": "webpack",
+    "test": "npm run test:default",
+    "test:default": "echo \"No test specified\""
+  },
+  "author": "IPython",
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "bootstrap": "^3.3.6",
+    "font-awesome": "^4.5.0",
+    "jquery": "^2.1.4",
+    "jquery-ui": "^1.10.5",
+    "jupyter-js-widgets": "file:../.."
+  },
+  "devDependencies": {
+    "bower": "^1.7.0",
+    "css-loader": "^0.23.1",
+    "file-loader": "^0.8.5",
+    "style-loader": "^0.13.0",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.12.10"
+  }
+}

--- a/jupyter-js-widgets/examples/web4/webpack.config.js
+++ b/jupyter-js-widgets/examples/web4/webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+    entry: './index.js',
+    output: {
+        filename: 'index.built.js',
+        path: './built/'
+    },
+    module: {
+        loaders: [
+            { test: /\.css$/, loader: "style-loader!css-loader" },
+            // jquery-ui loads some images
+            { test: /\.(jpg|png|gif)$/, loader: "file" },
+            // required to load font-awesome
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=application/font-woff" },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=application/font-woff" },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=application/octet-stream" },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=image/svg+xml" }
+        ]
+    },
+};

--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -24,6 +24,7 @@
     "test:example:web1": "cd examples/web && npm install && npm run test:default",
     "test:example:web2": "cd examples/web2 && npm install && npm run test:default",
     "test:example:web3": "cd examples/web3 && npm install && npm run test:default",
+    "test:example:web4": "cd examples/web3 && npm install && npm run test:default",
     "prepublish": "npm run build",
     "css:less": "lessc --include-path=./node_modules ./less/widgets.less ./css/widgets.css",
     "css:cleancss": "cleancss --source-map --skip-restructuring -o ./css/widgets.min.css ./css/widgets.css"


### PR DESCRIPTION
@jdfreder this is essentially the web2 example manager and the script tag trick that you used for the doc. 

This `index.built.js` is probably what we would want cdn-ed for this to work anywhere with the future embed button.