### PR TITLE
Clear state before setting persisted widgets

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-js-widgets",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Jupyter widget Javascript",
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",

--- a/jupyter-js-widgets/src/manager-base.js
+++ b/jupyter-js-widgets/src/manager-base.js
@@ -302,6 +302,25 @@ ManagerBase.prototype.new_model = function(options, serialized_state) {
     return model_promise;
 };
 
+/**
+
+ * Close all widgets and empty the widget state.
+ * @param  {boolean} commlessOnly should only commless widgets be removed
+ * @return {Promise}              promise that resolves when the widget state is
+ *                                cleared.
+ */
+ManagerBase.prototype.clear_state = function(commlessOnly) {
+    var that = this;
+    return utils.resolvePromisesDict(this._models).then(function(models) {
+        Object.keys(models).forEach(function(id) {
+            if (!commlessOnly || models[id].comm) {
+                models[id].close();
+            }
+        });
+        that._models = {};
+    });
+};
+
 ManagerBase.prototype.get_state = function(options) {
     /**
      * Asynchronously get the state of the widget manager.

--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -24,7 +24,7 @@
     "backbone": "^1.2.3",
     "html2canvas": "^0.5.0-beta4",
     "jquery": "^2.2.0",
-    "jupyter-js-widgets": "0.0.16",
+    "jupyter-js-widgets": "0.0.17",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -74,7 +74,7 @@ var WidgetManager = function (comm_manager, notebook) {
             // Load the initial state of the widget manager if a load callback was
             // registered.
             if (WidgetManager._load_callback) {
-                Promise.resolve().then(function () {
+                that.clear_state(true).then(function () {
                     return WidgetManager._load_callback.call(that);
                 }).then(function(state) {
                     that.set_state(state);


### PR DESCRIPTION
Should address the widgets problem seen by @fperez in https://github.com/jupyter/notebook/issues/1210

This will need jupyter-js-widgets to be published to npm after merge, I bumped the version numbers already in the PR