### PR TITLE
Better validation in floatrangesliders

### DIFF
--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -565,8 +565,6 @@ def test_int_range_logic():
         w.min = 7
     with nt.assert_raises(TraitError):
         w.max = -1
-    with nt.assert_raises(TraitError):
-        w.upper = 1
 
     w = irsw(min=2, max=3, value=(2, 3))
     check_widget(w, min=2, max=3, value=(2, 3))
@@ -598,10 +596,6 @@ def test_float_range_logic():
         w.min = .7
     with nt.assert_raises(TraitError):
         w.max = -.1
-    with nt.assert_raises(TraitError):
-        w.lower = -.1
-    with nt.assert_raises(TraitError):
-        w.upper = .7
 
     w = frsw(min=2, max=3, value=(2.2, 2.5))
     check_widget(w, min=2, max=3)

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -211,19 +211,21 @@ class _BoundedFloatRange(_FloatRange):
     def _validate_bounds(self, proposal):
         trait = proposal['trait']
         new = proposal['value']
-        if trait.name == 'min' and new > self.lower:
-            raise TraitError('setting min > lower')
-        if trait.name == 'max' and new < self.upper:
-            raise TraitError('setting max < upper')
+        if trait.name == 'min' and new > self.max:
+            raise TraitError('setting min > max')
+        if trait.name == 'max' and new < self.min:
+            raise TraitError('setting max < min')
+        if trait.name == 'min':
+            self.value = (max(new, self.value[0]), max(new, self.value[1]))
+        if trait.name == 'max':
+            self.value = (min(new, self.value[0]), min(new, self.value[1]))
         return new
 
     @validate('value')
     def _validate_value(self, proposal):
         lower, upper = super(_BoundedFloatRange, self)._validate_value(proposal)
-        if lower < self.min:
-            raise TraitError('setting lower < min')
-        if upper > self.max:
-            raise TraitError('setting upper > max')
+        lower, upper = min(lower, self.max), min(upper, self.max)
+        lower, upper = max(lower, self.min), max(upper, self.min)
         return lower, upper
 
 


### PR DESCRIPTION
I found a  [float/int] range coercion logic that is closer to the old one *and* commutes (so that we are compatible with the hold_trait_notification).