### PR TITLE
Move jupyter-js-widgets PRs out of master and into 6.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.4
     - 3.5
 env:
-    - GROUP=python
+    - GROUP=python TRAVIS_NODE_VERSION=5.1
 sudo: false
 before_install:
     - 'if [[ $GROUP == python ]] ; then bash ./scripts/travis_before_install_py.sh ; fi'
@@ -19,8 +19,8 @@ script:
 matrix:
     include:
         - python: 2.7
-          env: GROUP=js; BROWSER=firefox
+          env: GROUP=js BROWSER=firefox TRAVIS_NODE_VERSION=5.1
         - python: 2.7
-          env: GROUP=js; BROWSER=chrome
+          env: GROUP=js BROWSER=chrome TRAVIS_NODE_VERSION=5.1
 after_success:
     - coveralls

--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -273,6 +273,94 @@
     }
 }
 
+.widget-tab {
+    /* TabView */
+    height: 100%;
+
+    .widget-tab-contents {
+        height: 100%;
+
+        .widget-tab-child {
+            display: none;
+            height: 100%;
+
+            &.mod-active {
+              display: block;
+            }
+        }
+    }
+
+    .widget-tab-bar {
+        &.p-TabBar {
+            min-height: 28px;
+            max-height: 28px;
+            color: #757575;
+            background: #F5F5F5;
+            font: 12px Helvetica, Arial, sans-serif;
+        }
+
+        &.p-TabBar > .p-TabBar-header {
+            flex: 0 0 1px;
+            background: #BDBDBD;
+        }
+
+        &.p-TabBar > .p-TabBar-footer {
+            flex: 0 0 3px;
+            background: #FAFAFA;
+            border-top: 1px solid #BDBDBD;
+            border-bottom: 1px solid #E0E0E0;
+        }
+
+        .p-TabBar-content {
+            min-width: 0;
+            max-height: 22px;
+        }
+
+        .p-TabBar-tab {
+            flex-basis: 124px;
+            min-height: 23px;
+            max-height: 23px;
+            min-width: 35px;
+            margin-left: -1px;
+            padding: 0px 10px;
+            background: #EEEEEE;
+            border: 1px solid #BDBDBD;
+            border-bottom: none;
+            transform: translateY(-1px);
+
+            &:last-child {
+                margin-right: -1px;
+            }
+
+            &.p-mod-current {
+                min-height: 24px;
+                max-height: 24px;
+                background: #FAFAFA;
+                border-top: 1px solid #F27624;
+            }
+
+            &:hover:not(.p-mod-current) {
+                background: #FAFAFA;
+            }
+
+            &.p-mod-closable > .p-TabBar-tabCloseIcon {
+                margin-left: 4px;
+
+                &:before {
+                    font-family: FontAwesome;
+                    content: '\f00d'; /* close */
+                }
+            }
+        }
+
+        .p-TabBar-tabIcon,
+        .p-TabBar-tabText,
+        .p-TabBar-tabCloseIcon {
+            line-height: 22px;
+        }
+    }
+}
+
 .widget-text {
     /* Textbox */
     width : @widget-width;

--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -215,9 +215,9 @@
 }
 
 .widget-button, .widget-toggle-button {
-    background-image: none;
-    border: 1px solid #dbdbdb;
-    color: white;
+    background: #888888;
+    border: 1px solid #111111;
+    color: #eeeeee;
     cursor: pointer;
     display: inline-block;
     margin-bottom: 0;
@@ -231,33 +231,44 @@
     &:hover {
         outline: none !important;
     }
+
     &:active {
         .outside-shadow-4dp();
+    }
+
+    &:empty:before {
+        /* Add a space character if the button text is empty */
+        content: "\00a0"
     }
 
     &.mod-primary {
       background-color: #337ab7;
       border-color: #245580;
+      color: #eeeeee;
     }
 
     &.mod-success {
       background-color: #5cb85c;
       border-color: #3e8f3e;
+      color: #eeeeee;
     }
 
     &.mod-info {
       background-color: #5bc0de;
       border-color: #28a4c9;
+      color: #eeeeee;
     }
 
     &.mod-warning {
       background-color: #f0ad4e;
       border-color: #e38d13;
+      color: #eeeeee;
     }
 
     &.mod-danger {
       background-color: #d9534f;
       border-color: #b92c28;
+      color: #eeeeee;
     }
 
     &.mod-active {

--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run css",
     "precss": "rimraf ./css/",
-    "css": "npm run css:less && npm run css:cleancss",
+    "css": "npm run precss && npm run css:less && npm run css:cleancss",
     "test": "npm run test:unit && npm run test:examples",
     "test:unit": "npm run test:unit:firefox && npm run test:unit:chrome",
     "test:unit:default": "karma start karma.conf.js --log-level debug",
@@ -59,6 +59,8 @@
     "bootstrap": "^3.3.5",
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
+    "phosphor-tabs": "^1.0.0-rc.2",
+    "phosphor-widget": "^1.0.0-rc.1",
     "underscore": "^1.8.3"
   }
 }

--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -36,6 +36,7 @@
     "bower": "^1.5.3",
     "chai": "^3.4.1",
     "clean-css": "^3.4.6",
+    "css-loader": "^0.23.1",
     "font-awesome": "^4.5.0",
     "karma": "^0.13.15",
     "karma-chai": "^0.1.0",
@@ -52,6 +53,7 @@
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
     "spawn-sync": "^1.0.14",
+    "style-loader": "^0.13.1",
     "webpack": "^1.12.11"
   },
   "dependencies": {

--- a/jupyter-js-widgets/scripts/travis_install_js.sh
+++ b/jupyter-js-widgets/scripts/travis_install_js.sh
@@ -1,7 +1,9 @@
-nvm install 5.3
-nvm use 5.3
+source ~/.nvm/nvm.sh
+nvm install "v$TRAVIS_NODE_VERSION"
+nvm use "v$TRAVIS_NODE_VERSION"
+nvm alias default "v$TRAVIS_NODE_VERSION"
 npm update -g npm
-npm -v
-node -v
+echo `npm -v`
+echo `node -v`
 cd jupyter-js-widgets
 npm install

--- a/jupyter-js-widgets/scripts/travis_script_js.sh
+++ b/jupyter-js-widgets/scripts/travis_script_js.sh
@@ -1,6 +1,9 @@
 set -ex
 export CHROME_BIN=chromium-browser
 export DISPLAY=:99.0
+source ~/.nvm/nvm.sh
+nvm use "v$TRAVIS_NODE_VERSION"
+nvm alias default "v$TRAVIS_NODE_VERSION"
 sh -e /etc/init.d/xvfb start
 cd jupyter-js-widgets
 npm run test:unit:$BROWSER && npm run test:examples:$BROWSER

--- a/jupyter-js-widgets/src/jquery.js
+++ b/jupyter-js-widgets/src/jquery.js
@@ -11,7 +11,6 @@ if (typeof window !== 'undefined' && window['$']) {
 } else {
     $ = require('jquery');
     global.jQuery = $; // Required for bootstrap to load correctly
-
-    require('jquery-ui');
 }
+require('jquery-ui');
 module.exports = $;

--- a/jupyter-js-widgets/src/jquery.js
+++ b/jupyter-js-widgets/src/jquery.js
@@ -12,5 +12,4 @@ if (typeof window !== 'undefined' && window['$']) {
     $ = require('jquery');
     global.jQuery = $; // Required for bootstrap to load correctly
 }
-require('jquery-ui');
 module.exports = $;

--- a/jupyter-js-widgets/src/widget_button.js
+++ b/jupyter-js-widgets/src/widget_button.js
@@ -31,7 +31,12 @@ var ButtonView = widget.DOMWidgetView.extend({
          * Called when view is rendered.
          */
         this.el.className = 'jupyter-widgets widget-button';
-        this.listenTo(this.model, 'change:button_style', this.update_button_style, this);
+        this.listenTo(
+            this.model,
+            'change:button_style',
+            this.update_button_style,
+            this
+        );
         this.update_button_style();
         this.update(); // Set defaults.
     },
@@ -48,9 +53,7 @@ var ButtonView = widget.DOMWidgetView.extend({
 
         var description = this.model.get('description');
         var icon = this.model.get('icon');
-        if (description.trim().length === 0 && icon.trim().length === 0) {
-            this.el.innerHTML = '&nbsp;'; // Preserve button height
-        } else {
+        if (description.trim().length || icon.trim().length) {
             this.el.textContent = '';
             if (icon.trim().length) {
                 var i = document.createElement('i');

--- a/jupyter-js-widgets/src/widget_int.js
+++ b/jupyter-js-widgets/src/widget_int.js
@@ -5,6 +5,7 @@
 var widget = require('./widget');
 var _ = require('underscore');
 var $ = require('jquery');
+require('jquery-ui');
 
 
 var IntModel = widget.DOMWidgetModel.extend({

--- a/jupyter-js-widgets/src/widget_selectioncontainer.js
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.js
@@ -358,13 +358,22 @@ var TabView = widget.DOMWidgetView.extend({
     },
 
     _onTabCloseRequested: function(sender, args) {
+        /*
+         * When a tab is removed, the titles dictionary must be reset for all
+         * indices that are larger than the index of the tab that was removed.
+         */
+        var len = this.model.get('children').length;
+        var titles = this.model.get('_titles') || {};
+        delete titles[args.index];
+        for (var i = args.index + 1; i < len; i++) {
+            titles[i - 1] = titles[i];
+            delete titles[i];
+        }
+
         var children = _.filter(
             this.model.get('children'),
             function(child, index) { return index !== args.index; }
         );
-
-        var titles = this.model.get('_titles') || {};
-        delete titles[args.index];
 
         this.model.set(
             { 'children': children, '_titles': titles },


### PR DESCRIPTION
- [x] fix bug: travis build not working; turns out it's been using an old version of `node` all along but since the build worked, nobody noticed (https://github.com/ipython/ipywidgets/pull/457/commits/6d5eb8d6119c62ea3f3853779d117186047c754f)
- [x] fix bug: `IntSlider` not rendering (https://github.com/ipython/ipywidgets/pull/457/commits/0b0c64fb276b8f492cd153b9436e56263ba80efe)
- [x] add: new implementation of `TabView` that does not use Bootstrap or jQuery. It uses the phosphor `TabBar` (https://github.com/ipython/ipywidgets/pull/457/commits/9f9c826d9afab592bd06dac1ac3c6e5f49b30adf, https://github.com/ipython/ipywidgets/pull/457/commits/3fb4536bf6d39f68c62dc2191a3f907cdad1f4a2, https://github.com/ipython/ipywidgets/pull/457/commits/0997bb34148823c5b29b7ed8213b9938a07de41f, https://github.com/ipython/ipywidgets/pull/457/commits/54b5702e81ff99f23035fbc629f39a27a9b02041)
- [x] add: new button styles (https://github.com/ipython/ipywidgets/pull/457/commits/93bb594054ee2bdadeb4b4df6807d26ccd333b29)

cc: @jdfreder @SylvainCorlay @jasongrout @dwillmer