### PR TITLE
Fix new_comm call

### DIFF
--- a/examples/Widget List.ipynb
+++ b/examples/Widget List.ipynb
@@ -42,7 +42,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_values([<class 'ipywidgets.widgets.widget_selection.Dropdown'>, <class 'ipywidgets.widgets.widget_image.Image'>, <class 'ipywidgets.widgets.widget_string.Textarea'>, <class 'ipywidgets.widgets.widget_int.IntText'>, <class 'ipywidgets.widgets.widget_selectioncontainer.Tab'>, <class 'ipywidgets.widgets.widget_box.Proxy'>, <class 'ipywidgets.widgets.widget_selection.RadioButtons'>, <class 'ipywidgets.widgets.widget_string.Text'>, <class 'ipywidgets.widgets.widget_controller.Controller'>, <class 'ipywidgets.widgets.widget_int.BoundedIntText'>, <class 'ipywidgets.widgets.widget_color.ColorPicker'>, <class 'ipywidgets.widgets.widget_selection.ToggleButtons'>, <class 'ipywidgets.widgets.widget_selection.SelectionSlider'>, <class 'ipywidgets.widgets.widget_bool.Checkbox'>, <class 'ipywidgets.widgets.widget_box.PlaceProxy'>, <class 'ipywidgets.widgets.widget_string.HTML'>, <class 'ipywidgets.widgets.widget_bool.ToggleButton'>, <class 'ipywidgets.widgets.widget_float.FloatRangeSlider'>, <class 'ipywidgets.widgets.widget_button.Button'>, <class 'ipywidgets.widgets.widget_box.Box'>, <class 'ipywidgets.widgets.widget_box.FlexBox'>, <class 'ipywidgets.widgets.widget_selectioncontainer.Accordion'>, <class 'ipywidgets.widgets.widget_int.IntProgress'>, <class 'ipywidgets.widgets.widget_float.FloatText'>, <class 'ipywidgets.widgets.widget_controller.Button'>, <class 'ipywidgets.widgets.widget_selection.Select'>, <class 'ipywidgets.widgets.widget_float.BoundedFloatText'>, <class 'ipywidgets.widgets.widget_selection.SelectMultiple'>, <class 'ipywidgets.widgets.widget_float.FloatSlider'>, <class 'ipywidgets.widgets.widget_controller.Axis'>, <class 'ipywidgets.widgets.widget_int.IntSlider'>, <class 'ipywidgets.widgets.widget_string.Latex'>, <class 'ipywidgets.widgets.widget_int.IntRangeSlider'>, <class 'ipywidgets.widgets.widget_float.FloatProgress'>, <class 'ipywidgets.widgets.widget_bool.Valid'>])"
+       "dict_values([<class 'ipywidgets.widgets.widget_selection.Dropdown'>, <class 'ipywidgets.widgets.widget_image.Image'>, <class 'ipywidgets.widgets.widget_string.Textarea'>, <class 'ipywidgets.widgets.widget_int.IntText'>, <class 'ipywidgets.widgets.widget_selectioncontainer.Tab'>, <class 'ipywidgets.widgets.widget_box.Proxy'>, <class 'ipywidgets.widgets.widget_selection.RadioButtons'>, <class 'ipywidgets.widgets.widget_string.Text'>, <class 'ipywidgets.widgets.widget_controller.Controller'>, <class 'ipywidgets.widgets.widget_int.BoundedIntText'>, <class 'ipywidgets.widgets.widget_color.ColorPicker'>, <class 'ipywidgets.widgets.widget_selection.ToggleButtons'>, <class 'ipywidgets.widgets.widget_selection.SelectionSlider'>, <class 'ipywidgets.widgets.widget_bool.Checkbox'>, <class 'ipywidgets.widgets.widget_box.PlaceProxy'>, <class 'ipywidgets.widgets.widget_string.HTML'>, <class 'ipywidgets.widgets.widget_bool.ToggleButton'>, <class 'ipywidgets.widgets.widget_float.FloatRangeSlider'>, <class 'ipywidgets.widgets.widget_button.Button'>, <class 'ipywidgets.widgets.widget_box.Box'>, <class 'ipywidgets.widgets.widget_box.FlexBox'>, <class 'ipywidgets.widgets.widget_selectioncontainer.Accordion'>, <class 'ipywidgets.widgets.widget_int.IntProgress'>, <class 'ipywidgets.widgets.widget_float.FloatText'>, <class 'ipywidgets.widgets.widget_controller.Button'>, <class 'ipywidgets.widgets.widget_selection.Select'>, <class 'ipywidgets.widgets.widget_float.BoundedFloatText'>, <class 'ipywidgets.widgets.widget_selection.SelectMultiple'>, <class 'ipywidgets.widgets.widget_float.FloatSlider'>, <class 'ipywidgets.widgets.widget_controller.Axis'>, <class 'ipywidgets.widgets.widget_int.IntSlider'>, <class 'ipywidgets.widgets.widget_string.Label'>, <class 'ipywidgets.widgets.widget_int.IntRangeSlider'>, <class 'ipywidgets.widgets.widget_float.FloatProgress'>, <class 'ipywidgets.widgets.widget_bool.Valid'>])"
       ]
      },
      "execution_count": 1,
@@ -825,7 +825,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 4 widgets that can be used to display a string value.  Of those, the `Text` and `Textarea` widgets accept input.  The `Latex` and `HTML` widgets display the string as either Latex or HTML respectively, but do not accept input."
+    "There are 4 widgets that can be used to display a string value.  Of those, the `Text` and `Textarea` widgets accept input.  The `Label` and `HTML` widgets display the string as either Label or HTML respectively, but do not accept input."
    ]
   },
   {
@@ -902,7 +902,7 @@
     }
    },
    "source": [
-    "### Latex"
+    "### Label"
    ]
   },
   {
@@ -923,7 +923,7 @@
     }
    ],
    "source": [
-    "widgets.Latex(\n",
+    "widgets.Label(\n",
     "    value=\"$$\\\\frac{n!}{k!(n-k)!} = \\\\binom{n}{k}$$\",\n",
     ")"
    ]

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -137,7 +137,7 @@ class Widget(LoggingConfigurable):
     @staticmethod
     def handle_comm_opened(comm, msg):
         """Static method, called when a widget is constructed."""
-        class_name = str(msg['content']['data']['widget_class'])
+        class_name = str(msg['metadata']['widget_class'])
         if class_name in Widget.widget_types:
             widget_class = Widget.widget_types[class_name]
         else:

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -586,9 +586,11 @@ WidgetManager.prototype.deleteSnapshots = function() {
 };
 
 WidgetManager.prototype._create_comm = function(comm_target_name, model_id, metadata) {
+    var that = this;
     return this._get_connected_kernel().then(function(kernel) {
         if (metadata) {
-            return kernel.comm_manager.new_comm(comm_target_name, metadata, model_id);
+            return kernel.comm_manager.new_comm(comm_target_name, {},
+                                                that.callbacks(), metadata, model_id);
         } else {
             return new Promise(function(resolve) {
                 requirejs(["services/kernels/comm"], function(comm) {


### PR DESCRIPTION
@jdfreder this fixes the issue reported by @jasongrout regarding the signature of `manager.new_comm` ie the difference between [services/kernels/comm#L33]( https://github.com/jupyter/notebook/blob/41d6da235cbf3bcf6d7f818e11a066e0fd12ff8b/notebook/static/services/kernels/comm.js#L33) and [manager#L588](https://github.com/ipython/ipywidgets/blob/6.x/widgetsnbextension/src/manager.js#L588).

The widget list notebook change is just replacing Latex with Label since Latex is deprecated.