### PR TITLE
Fix replaceWith, a jqueryism, with DOM operations.

### DIFF
--- a/jupyter-js-widgets/src/widget_box.js
+++ b/jupyter-js-widgets/src/widget_box.js
@@ -188,11 +188,13 @@ var BoxView = widget.DOMWidgetView.extend({
          * Called when a model is added to the children list.
          */
         var that = this;
+        // we insert a dummy element so the order is preserved when we add
+        // the rendered content later.
         var dummy = document.createElement('div');
         that.box.appendChild(dummy);
 
         return this.create_child_view(model).then(function(view) {
-            dummy.replaceWith(view.el);
+            that.box.replaceChild(view.el, dummy);
 
             // Trigger the displayed event of the child view.
             that.displayed.then(function() {

--- a/jupyter-js-widgets/src/widget_controller.js
+++ b/jupyter-js-widgets/src/widget_controller.js
@@ -311,7 +311,7 @@ var ControllerView = widget.DOMWidgetView.extend({
 
         that.button_box.appendChild(dummy);
         return this.create_child_view(model).then(function(view) {
-            dummy.replaceWith(view.el);
+            that.button_box.replaceChild(view.el, dummy);
             that.displayed.then(function() {
                 view.trigger('displayed', that);
             });
@@ -325,7 +325,7 @@ var ControllerView = widget.DOMWidgetView.extend({
 
         that.axis_box.appendChild(dummy);
         return this.create_child_view(model).then(function(view) {
-            dummy.replaceWith(view.el);
+            that.axis_box.replaceChild(view.el, dummy);
             that.displayed.then(function() {
                 view.trigger('displayed', that);
             });


### PR DESCRIPTION
The box widget uses a jquery function replaceWith at https://github.com/ipython/ipywidgets/blob/4936b86a87804053eb3d719ff67b527e7f5beb4b/jupyter-js-widgets/src/widget_box.js#L195 (see http://api.jquery.com/replacewith/ for documentation). Since the dummy element is now a div, `replaceWith` is undefined and box widgets won't display their children.

CC @afshin @dwillmer, @jdfreder, @SylvainCorlay 