### PR TITLE
Handle custom serializers in manager.get_state

### DIFF
--- a/jupyter-js-widgets/src/manager-base.js
+++ b/jupyter-js-widgets/src/manager-base.js
@@ -355,7 +355,7 @@ ManagerBase.prototype.get_state = function(options) {
                     state[model_id] = {
                         model_name: model.name,
                         model_module: model.module,
-                        state: model.get_state(options.drop_defaults),
+                        state: model.constructor._serialize_state(model.get_state(options.drop_defaults), that),
                         views: [],
                     };
 

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -415,7 +415,7 @@ var WidgetModel = Backbone.Model.extend({
 }, {
     _deserialize_state: function(state, manager) {
         /**
-         * Returns a promised for the deserialized state. The second argument
+         * Returns a promise for the deserialized state. The second argument
          * is an instance of widget manager, which is required for the
          * deserialization of widget models.
          */
@@ -435,6 +435,27 @@ var WidgetModel = Backbone.Model.extend({
         }
         return utils.resolvePromisesDict(deserialized);
     },
+    _serialize_state: function(state, manager) {
+        /**
+         * Returns a promise for the serialized state. The second argument
+         * is an instance of widget manager.
+         */
+        var serializers = this.serializers;
+        var serialized;
+        if (serializers) {
+            serialized = {};
+            for (var k in state) {
+                if (serializers[k] && serializers[k].serialize) {
+                     serialized[k] = (serializers[k].serialize)(state[k], manager);
+                } else {
+                     serialized[k] = state[k];
+                }
+            }
+        } else {
+            serialized = state;
+        }
+        return utils.resolvePromisesDict(serialized);
+    }
 });
 
 


### PR DESCRIPTION
This is strictly a bug fix since we are using deserializers to load the state.