### PR TITLE
Fix custom widget example

### DIFF
--- a/examples/Custom Widget - Hello World.ipynb
+++ b/examples/Custom Widget - Hello World.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -114,7 +114,8 @@
     "\n",
     "\n",
     "class HelloWidget(widgets.DOMWidget):\n",
-    "    _view_name = Unicode('HelloView').tag(sync=True)"
+    "    _view_name = Unicode('HelloView').tag(sync=True)\n",
+    "    _view_module = Unicode('hello').tag(sync=True)"
    ]
   },
   {
@@ -226,34 +227,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You first need to import the `jupyter-js-widgets` module. To import modules, use the `require` method of [require.js](http://requirejs.org/) (as seen below).\n"
+    "You first need to import the `jupyter-js-widgets` module. To import modules, use the `define` method of [require.js](http://requirejs.org/) (as seen below)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "define('hello', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "});"
    ]
@@ -273,49 +259,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next define your widget view class.  Inherit from the `DOMWidgetView` by using the `.extend` method.  Register the view class with the widget manager by calling `.register_widget_view`.  The first parameter is the widget view name (`_view_name` that you defined earlier in Python) and the second is a handle to the class type."
+    "Next define your widget view class.  Inherit from the `DOMWidgetView` by using the `.extend` method."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    // Define the HelloView\n",
-       "    var HelloView = widgets.DOMWidgetView.extend({\n",
-       "        \n",
-       "    });\n",
-       "    \n",
-       "    // Register the HelloView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "require.undef('hello');\n",
+    "\n",
+    "define('hello', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    // Define the HelloView\n",
     "    var HelloView = widgets.DOMWidgetView.extend({\n",
     "        \n",
     "    });\n",
-    "    \n",
-    "    // Register the HelloView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
+    "\n",
+    "    return {\n",
+    "        HelloView: HelloView\n",
+    "    }\n",
     "});"
    ]
   },
@@ -339,38 +306,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    var HelloView = widgets.DOMWidgetView.extend({\n",
-       "        \n",
-       "        // Render the view.\n",
-       "        render: function() { \n",
-       "            this.$el.text('Hello World!'); \n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "require.undef('hello');\n",
+    "\n",
+    "define('hello', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    var HelloView = widgets.DOMWidgetView.extend({\n",
     "        \n",
@@ -380,7 +325,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
+    "    return {\n",
+    "        HelloView: HelloView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -404,21 +351,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAfCAYAAABNngGqAAAGU0lEQVR4Xu2dZ6gdVRRGE8FCLFgIigWjYm/YFRGeoAh2IWqiUbF37L09QUXsigVBSWygWEFUsKBiBQtiQ7D8UFFBsFes34IzMA7J3NzLe3CQdeBj7rnT9lt3fnzsvc+8qVMcEpCABCQgAQlIQAJVEJhaRRQGIQEJSEACEpCABCQwRWPmQyABCUhAAhKQgAQqIaAxq+SHMAwJSEACEpCABCSgMfMZkIAEJCABCUhAApUQ0JhV8kMYhgQkIAEJSEACEtCY+QxIQAISkIAEJCCBSghozCr5IQxDAhKQgAQkIAEJaMx8BiQgAQlIQAISkEAlBDRmlfwQhiEBCUhAAhKQgAQmwpgtG4ynRTtF20XdeY2U105Q50c/RCd2Alwh8zOidaN9agzemCQgAQlIQAIS+H8SwJjtEF0ebR2dEN0b/RHtF90cfViM19MLQLB4vj8sOilaL+rOhyW3d06YG30fzYy+jm6Mdo+ujcYjDNW25bhHs70w+m2IG03LsbeXexzTOW/5zM+LNo0wm4wLypx4HBKQgAQkIAEJSGBSCDQZs1NzdYzV6p27vJ35I8X49AWwR3ZeGWHMGN35sMFzrb2idcqJK2f7WYRZfLB1sXn5fGj0z7A3yPFXR0tGXWPGpY4q92qMGWZ1o6IRbuUpEpCABCQgAQlIYDCBxpidnEPRjM4pb2WOMRsfcCmyWVdFjTHrzgdH8t8jtsj09WKE3iu7nsv24+jwMqfkeEpESXKUQbxLRfMzZkfk+1lRY8yuz+cNW/NR7uc5EpCABCQgAQlIoJfAsMZs81yNbBgmZdGIbNV30SBjRrbpyOiXaJvozAjj1Tc+ys67oovLQe9kS+ZspYhSK+YJ49hch942TNqv5R53Z3tntFl0bkRJduNoRtl2jdlu+X7XiBLqjtHPUWPMzspn/uaDB8TsbglIQAISkIAEJDAygbYxwwDd0rkSxovvxiOyS3w+qBzzUravRjT+9xkzyoWYJ3rYfozo07opWiv6qSfyy7JvzwhTh6HaPzo7whg+UWI5tnX+w/l8Q/RstEqEsRuLKMc+EC0X0QtHb9q8qG3MKOGSGdwy+iu6tcTXGDMMGcYMg+aQgAQkIAEJSEACk0JgmIzZvomALBWmiIFh+jZiBWOfMTsw+1n5iCFiLBLR0E8ZkozWggbN92TE1o8wZbdFLAr4PKInDpN0Tjl51Ww/jWjqbxYBYLS+iTBjNPp/FdHU34y2MaPfDBZcl9EtZWLQMGaUNB0SkIAEJCABCUhgUggMY8zIjJHlOm4+kfQZs/EcT5aLvrFmvJEPD0WXDvirPsj+e6LVIhry6S9jYQClUHrPXinnj2VLpmyZiKwcA7O1SbRzhKnDmLX70drG7Knsezm6qJzbNWYb5HuM2f0D4nW3BCQgAQlIQAISGJnAMMbsgNyF12rwDrDfyx3JglHO7DNmZKyuiaZH9IYx3owoVVJi7BuUV2nOx8BRpuRVFhgs+s0oOzarMdfMZxYGUC59rVyQey4W8QqQQcaMlZ6UMFn1yegaM8q4ZOUwig4JSEACEpCABCQwKQQaY3Z6rs6qTMxHe7yfCaaF93hhijA/9IuRtaIv68+I8iIZMTJQvJSV0Z6TxfokOj66L6JJn+wUGTQa9fsGmSpMGBmzL8qBj2dLIz+v92iPJzMhvqbv7Pl8poRKjxnGjPJpU/rkPDJqGK6jI1ZgUlYdK7FhBFkMsFWEmdwlWrEc07mtUwlIQAISkIAEJDAxBDBm20dXRGS/MDushMSM0NdFEzwlQ/rIeMEsL6OlcR+jdEdET9bS0XUR5obG/hc788fKtTFCGLIlIhYRYPoWZvCS23b59JDMMXovdE5mtSa9ZF9GrBRlcQILAihn8h6yvyOa+MnWrRFRliSW2dG7UZOdIwNIHxu9bZdEz5R9lHHnLEzAHiMBCUhAAhKQgARGITAR/5JplPt6jgQkIAEJSEACEpBAh4DGzEdCAhKQgAQkIAEJVEJAY1bJD2EYEpCABCQgAQlIQGPmMyABCUhAAhKQgAQqIaAxq+SHMAwJSEACEpCABCSgMfMZkIAEJCABCUhAApUQ0JhV8kMYhgQkIAEJSEACEtCY+QxIQAISkIAEJCCBSghozCr5IQxDAhKQgAQkIAEJaMx8BiQgAQlIQAISkEAlBP4F5pzzIB7iwuoAAAAASUVORK5CYII="
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "HelloWidget()"
    ]
@@ -443,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -451,6 +388,7 @@
    "source": [
     "class HelloWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('HelloView').tag(sync=True)\n",
+    "    _view_module = Unicode('hello').tag(sync=True)\n",
     "    value = Unicode('Hello World!').tag(sync=True)"
    ]
   },
@@ -492,37 +430,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    var HelloView = widgets.DOMWidgetView.extend({\n",
-       "        \n",
-       "        render: function() { \n",
-       "            this.$el.text(this.model.get('value')); \n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "require.undef('hello');\n",
+    "\n",
+    "define('hello', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    var HelloView = widgets.DOMWidgetView.extend({\n",
     "        \n",
@@ -531,7 +448,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
+    "    return {\n",
+    "        HelloView : HelloView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -555,42 +474,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    var HelloView = widgets.DOMWidgetView.extend({\n",
-       "        \n",
-       "        render: function() { \n",
-       "            this.value_changed();\n",
-       "            this.model.on('change:value', this.value_changed, this);\n",
-       "        },\n",
-       "        \n",
-       "        value_changed: function() {\n",
-       "            this.$el.text(this.model.get('value')); \n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "require.undef('hello');\n",
+    "\n",
+    "define('hello', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    var HelloView = widgets.DOMWidgetView.extend({\n",
     "        \n",
@@ -604,7 +497,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    widgets.ManagerBase.register_widget_view('HelloView', HelloView);\n",
+    "    return {\n",
+    "        HelloView : HelloView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -621,21 +516,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAfCAYAAABNngGqAAADJ0lEQVR4Xu3cP4jPcRzH8btkU/5slAxSQgaDLOosNqM/KfkpDERikIVV+bPInyy6gUxKyGA5RUkmg0GpK0kxoAyUwetT39/2W+7TZ/jUPa6efevuPp/73OP7Hd79rt9NT/kgQIAAAQIECBDoQmC6i1M4BAECBAgQIECAwJTBzENAgAABAgQIEOhEwGDWyY1wDAIECBAgQICAwcwzQIAAAQIECBDoRMBg1smNcAwCBAgQIECAgMHMM0CAAAECBAgQ6ETAYNbJjXAMAgQIECBAgIDBzDNAgAABAgQIEOhEwGDWyY1wDAIECBAgQICAwcwzQIAAAQIECBDoRGA8mG3NeVaml5XnOpV1NyrXWkaAAAECBAgQIBCBMpgtHwayM7nOVaiMsuZw2lWx1hICBAgQIECAAIFBoAxmx9LV9Cy9SPfStrQnbU5L05H0M11Kv9O+9CTdT+WVsvKK24N0M32mS4AAAQIECBAgsHCB8Z8y57N0lObSsnQ7HRq2e53rm/Qo7U+n06rh+68P17J2ZuE/3goCBAgQIECAAIGxwKTBbG++eDQ9H75pS64/Unl1rAxpF9KdtCJ9M5h5mAgQIECAAAECbQQmDWbnsvX6dGLCjxjlc9fSr3QgvTWYtbkRdiFAgAABAgQITBrMDoblctqQ/g5EO3L9MlReKbubNg2VYa00g5MAAQIECBAgQKBeYDyYfcwW59OH9D19Su/SlbQu/Utf05JU3iSwNpU3CmxMZZAra7en1Wm+/jhWEiBAgAABAgQWr8B4MLsYguPpZHqcdqbyDssygM2ms2l3ephupfJOzaep/N+zNelVep/Knzf/LF5OvzkBAgQIECBAoF7Af/6vt7OSAAECBAgQINBUwGDWlNNmBAgQIECAAIF6AYNZvZ2VBAgQIECAAIGmAgazppw2I0CAAAECBAjUCxjM6u2sJECAAAECBAg0FTCYNeW0GQECBAgQIECgXsBgVm9nJQECBAgQIECgqYDBrCmnzQgQIECAAAEC9QIGs3o7KwkQIECAAAECTQUMZk05bUaAAAECBAgQqBcwmNXbWUmAAAECBAgQaCrwH1PTRSAOZOlZAAAAAElFTkSuQmCC"
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "w = HelloWidget()\n",
     "w"
@@ -643,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -697,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -708,6 +593,7 @@
     "\n",
     "class SpinnerWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('SpinnerView').tag(sync=True)\n",
+    "    _view_module = Unicode('spinner').tag(sync=True)\n",
     "    value = CInt().tag(sync=True)"
    ]
   },
@@ -731,50 +617,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    var SpinnerView = widgets.DOMWidgetView.extend({\n",
-       "        \n",
-       "        render: function() { \n",
-       "            \n",
-       "            // jQuery code to create a spinner and append it to $el\n",
-       "            this.$input = $('<input />');\n",
-       "            this.$el.append(this.$input);\n",
-       "            this.$spinner = this.$input.spinner({\n",
-       "                change: function( event, ui ) {}\n",
-       "            });\n",
-       "            \n",
-       "            this.value_changed();\n",
-       "            this.model.on('change:value', this.value_changed, this);\n",
-       "        },\n",
-       "        \n",
-       "        value_changed: function() {\n",
-       "            \n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    widgets.ManagerBase.register_widget_view('SpinnerView', SpinnerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "define('spinner', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    var SpinnerView = widgets.DOMWidgetView.extend({\n",
     "        \n",
@@ -796,7 +646,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    widgets.ManagerBase.register_widget_view('SpinnerView', SpinnerView);\n",
+    "    return {\n",
+    "        SpinnerView: SpinnerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -820,60 +672,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "\n",
-       "    var SpinnerView = widgets.DOMWidgetView.extend({\n",
-       "        render: function() { \n",
-       "\n",
-       "            var that = this;\n",
-       "            this.$input = $('<input />');\n",
-       "            this.$el.append(this.$input);\n",
-       "            this.$spinner = this.$input.spinner({\n",
-       "                change: function( event, ui ) {\n",
-       "                    that.handle_spin(that.$spinner.spinner('value'));\n",
-       "                },\n",
-       "                spin: function( event, ui ) {\n",
-       "                    //ui.value is the new value of the spinner\n",
-       "                    that.handle_spin(ui.value);\n",
-       "                }\n",
-       "            });\n",
-       "            \n",
-       "            this.value_changed();\n",
-       "            this.model.on('change:value', this.value_changed, this);\n",
-       "        },\n",
-       "        \n",
-       "        value_changed: function() {\n",
-       "            this.$spinner.spinner('value', this.model.get('value'));\n",
-       "        },\n",
-       "        \n",
-       "        handle_spin: function(value) {\n",
-       "            this.model.set('value', value);\n",
-       "            this.touch();\n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    widgets.ManagerBase.register_widget_view('SpinnerView', SpinnerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "requirejs.undef('spinner');\n",
+    "\n",
+    "define('spinner', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "\n",
     "    var SpinnerView = widgets.DOMWidgetView.extend({\n",
     "        render: function() { \n",
@@ -905,7 +713,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    widgets.ManagerBase.register_widget_view('SpinnerView', SpinnerView);\n",
+    "    return {\n",
+    "        SpinnerView: SpinnerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -922,21 +732,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAnCAYAAAClt4RqAAAG3klEQVR4Xu3dTUhUXRzH8f+IliCIEbbIjQjioiJUEIwK26TgCyplb+DLxkW4SyTEClSSRBLFLESDCMEECTdBqwiJzIUoolhiCUKIFr6UmWROnvMwPk6Ozh2nmbnO/R5o0z333nM+58L8vC/n2ISCAAIIIIAAAgggYAoBmylaQSMQQAABBBBAAAEEhGDGRYAAAggggAACCJhEgGBmkoGgGQgggAACCCCAAMGMawABBBBAAAEEEDCJwLZgNjo6ajdJ22gGAqYQOHbsGH/AmGIkaAQCCCAQ/AL6B2dwcND++fNniY2NDf4e00NLC4SFhdk3im2jGHb49euXTE1NydGjRyUpKcn4jobPQEUEEEAAAQT+E9A/Mn19ffbTp09jgkDQC3z48EHW19clJCTE477Ozs7KmTNnCGYey7EDAggggIBRAdvLly/tKSkpEhUVZXQf6iGwbwW8CWaq0+rOWXp6OuFs314BNBwBBBAwt4Ctu7vbfvHiRXO3ktYh8I8EvA1mw8PDUlBQQDD7R+PBYRBAAAEEnAUIZlwRlhIgmFlquOksAgggsO8ECGb7bshosDcCuwWzhYUFqaiokPr6+h0f7XPHzBt99kUAAQQQcCdAMHMnxPagEtgpmDlCmaOzO4UzgllQXQ50BgEEEDCdgNtg9vXrV2ltbZV3797J9PS0HDx4UE6ePCnl5eWSkJDg1KHx8XGpra2VoaEhCQ0NlXPnzklVVZUcPnzYdB2nQdYUUMHs27dv+stMR1laWpKampptILdu3ZLIyEin/1cv//OOmTWvHXqNAAII+EPAbTB78+aNlJWVSVZWlhw/flzm5+fl6dOnsrq6Ki9evJAjR47odqoAd/78eT0XWklJifz48UOam5v19p6eHvFk3ih/dJxzWFNABbPv3787BTP1R8ZOpaGhwWnTp0+fCGbWvHToNQIIIOAXAbfB7MuXL3LgwAGnOwfqzlhmZqbcuXNHCgsLdUNbWlrk4cOHooKcY+qNgYEBuXLlijx58kSYJ80v48lJ3AioYLa8vOwUzDxB+/jxI8HMEzDqIoAAAgh4JOA2mLk62tramn6Mef36dblx44auogKYenyp7qZtLcnJyaKm47h586ZHDaMyAr4QcASzjdn/93T4yclJgtme5NgJAQQQQMCIwJ6C2cjIiOTm5kpjY6Pk5OTo85w6dUr/+/vRT3Z2tsTExMijR4+MtIc6CPhUQAWzlZUV2Wswm5iYIJj5dIQ4OAIIIGBtAY+DmfpBKy4uFvU48/Xr1xIeHq4FT5w4IXl5eVJdXe0keunSJX0nrbOz09rS9N4UAiqY/fz5c89tef/+PcFsz3rsiAACCCDgTsDjYHbv3j1pb2+Xx48fq3UDN4+vgtmFCxf0e2dbC8HM3RCw3Z8CMzMz9sXFRY8WMd/aPqbL8OdocS4EEEDAegIeBbMHDx7I/fv3RYUzFcK2ltTUVElLS5O6ujqn/+dRpvUuKjP3mJn/zTw6tA0BBBBAwHAwa2pq0l9eqlCWn5+/TU69/K8ec3Z1dW1u+/37tyQmJsrly5elsrISbQQCLkAwC/gQ0AAEEEAAgV0E3AYzNRGnem/s2bNn+mX/jIwMl4dTc5ap6TLevn27OV1Gf3+/XLt2TTo6OvTdNAoCgRYgmAV6BDg/AggggMBuAm6DmQpb6kvLq1evSkpKyrZjqfnMQkJCZG5uTk8wGxcXJ0VFRXqCWXWH7dChQ9Lb26vrUBAItADBLNAjwPkRQAABBLwKZnfv3tV3vHYqY2NjepkmVUZHR0XVV0syhYWFydmzZ0UtaxMdHc0oIGAKAVfBrLS0dMe2tbW1OW3j5X9TDCONQAABBIJWwO0ds6DtOR2zpICrYPb3AuYOGFcLmRPMLHnZ0GkEEEDAbwIEM79RcyIzCLhaxFy16++FzF0tYK7qsYi5GUaRNiCAAALBK0AwC96xpWcuBFwtYu6opsKZ+tDl9u3bTmvDbj0Mi5hzWSGAAAII+FKAYOZLXY5tOgEWMTfdkNAgBBBAAIEtAgQzLgdLCbCIuaWGm84igAAC+07A9urVK3t8fLxeaJyCQLALeLOIufq6WH15nJ6ebgt2J/qHAAIIIBAYAf0D09fXZ1cz9EdERASmFZwVAT8JeLOIuXoHbWN9WEKZn8aK0yCAAAJWFNj8kXn+/Lld3RFQE8JSEEDgf4H5+Xk9gXJeXh6hjAsDAQQQQMCnAvzQ+JSXgyOAAAIIIIAAAsYFCGbGraiJAAIIIIAAAgj4VIBg5lNeDo4AAggggAACCBgXIJgZt6ImAggggAACCCDgUwGCmU95OTgCCCCAAAIIIGBcgGBm3IqaCCCAAAIIIICATwX+APUKeUZmK3g/AAAAAElFTkSuQmCC"
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "w = SpinnerWidget(value=5)\n",
     "w"
@@ -944,29 +744,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "w.value"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -984,21 +773,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAABLCAYAAADagUtLAAAKjklEQVR4Xu3dXWgU6x3H8f9ufANrzFFEiHgRSgoxbmwgWkXE41XoRSleREWlUBFLPdVWEC2KXvgGRzyKbX3BiiAVCiKoUHyBai68UVCMREGNGkXxomAS82ISNbt9/ssm7XiSnWd2M3FevgND4Owzz/yfzzOH/TmzM5MQFgQQQAABBBBAAIFACCQCUQVFIIAAAggggAACCAjBjIMAAQQQQAABBBAIiADBLCATQRkIIIAAAggggADBjGMAAQQQQAABBBAIiIAjmN2/fz/T0dERkNIoA4FgCJSVlUltbS3/iAnGdFAFAgggEGmB7JfN7du3M+/fv5eKigrRLyEWBKIqoMf5wMCAJBL2OUvbtra2yvTp06Wurs5+w6giMi4EEEAAAd8EEg8fPsx0dXXJwoULfdsJHSMQFIGnT59KOp2WZDLpuaS2tjZZtGgRwcyzHBsggAACCNgKJK5fv55ZsGABZ8psxWgXaoFigpkO/OXLl1JfX084C/VRQPEIIIBAcAUS58+fzzQ0NAS3QipDYBQFig1mDx48kBUrVhDMRnFO6AoBBBBA4H8CBDOOhlgJEMxiNd0MFgEEEAidAMEsdFNGwcUI5Atmekfytm3b5ODBgyNe2ueMWTH6bIsAAggg4CZAMHMT4vNICYwUzAZD2eBgRwpnBLNIHQ4MBgEEEAicgFUwa29vlwMHDsiNGzekr69PampqZOfOnZJKpQI3IApCIJ+ABjO9C1nvzBxcOjs7Ze/evT/abNeuXVJaWur47/rjf35jxjGGAAIIIOCXgFUwW7Vqlbx69Uo2b94sU6dOlbNnz4p+wV27dk1mzpzpV230i8CoC+hx293d7QhmW7duHXE/hw4dcnymzzMjmI36tNAhAggggEBOwDWY3b17V1auXClnzpyRpUuXZjfTMw5LliyRtWvXSr4vNZQRCJqABrOenh5HMPNS44sXLwhmXsBoiwACCCDgScA1mB09elROnjwp5kG0UlJSMtT5xo0b5e3bt3Lp0iVPO6QxAl9TYDCYZTKZgsp4/vw5wawgOTZCAAEEELARcA1mW7ZsET1rduvWLUd/+/btkwsXLkhTU5PNfmiDQCAENJj19vZKocGspaWFYBaImaQIBBBAIJoCrsFs/fr18vr1azFvCHAIHDlyRI4dOybPnj2LpgyjiqSABjO9gaXQ5cmTJwSzQvHYDgEEEEDAVcAqmOklyytXrjg6O3z4sBw/fpxg5kpMgyAJ6E0sGsy8vMT8/+vncRlBmk1qQQABBKIn4BrM9FKmfhndvHnTMXouZUbvYIjDiHjyfxxmmTEigAAC4RVwDWb64/8TJ05kw9nEiROHRrpu3Tp59+6dXL58Obyjp/LYCRDMYjflDBgBBBAIlYBrMLtz546sXr1aTp8+LcuWLcsOTh+XsXjxYlmzZo1s3749VAOm2HgLEMziPf+MHgEEEAi6gGsw0wE0NDTImzdvZNOmTTJlyhQ5d+6cPH78WK5evSrl5eVBHyP1ITAkQDDjYEAAAQQQCLKAVTDTS5b79++XxsbGoVcy7dixQ+bNmxfksVEbAj8SGC6YbdiwYUSpU6dOOT7jx/8cVAgggAACfgpYBTM/C6BvBMZSYLhg9uULzAfrGe5F5gSzsZwt9oUAAgjET4BgFr85j/WIh3uJuYJ8+SLz4V5gru14iXmsDx8GjwACCPguQDDznZgdBElguJeYD9an4WzPnj2ye/duKS0tHbZsXmIepNmkFgQQQCB6AgSz6M0pI8ojwEvMOTwQQAABBIIsQDAL8uxQ26gL8BLzUSelQwQQQACBURRImDstM5WVlTJr1qxR7JauEAimQDEvMZ8xY4Y8evRI6uvrE8EcHVUhgAACCIRdIPsFo+Fs/vz5Mnny5LCPh/oRyCtQzEvM29ra9CHLhDKOMQQQQAAB3wSGvmQuXryYKSsr821HdIxAmAX0kRrLly8nlIV5EqkdAQQQCIEAXzQhmCRKRAABBBBAAIF4CBDM4jHPjBIBBBBAAAEEQiBAMAvBJFEiAggggAACCMRDgGAWj3lmlAgggAACCCAQAgGCWQgmiRIRQAABBBBAIB4CjmDW3Nz8bcYs+YY+fvz4V1VVVS/jwcMoEUAAAQQQQACBsRMYCmYtLS2Z/v5+SSTyn0TT3GbWX6VSqX+NXZnsCQEEEEAAAQQQiL5ANoWZp5n/PJlM3jer64jT6bToWl1dzWVQVy0aIIAAAggggAAC9gLZcKWXMM0lyka3s2XalmBmj0tLBBBAAAEEEEDAiwDBzIsWbRFAAAEEEEAAAR8FCGY+4tI1AggggAACCCDgRYBg5kWLtggggAACCCCAgI8CBDMfcekagZgK/NKM+9e5sf/b/L0QUweGjQACCHgWIJh5JmMDBBDII/BT85k+Sidl1gGz3jPrb8z6EDUEEEAAAXcBgpm7ES0QQMBe4Fiu6Xe5vz+Yv9PM+lv7LmiJAAIIxFeAYBbfuWfkCPgh8MR0esas3+c6/535+2ezVvixM/pEAAEEoiZAMIvajDIeBL6uQI/Z/Z/M+vdcGWtyQW3i1y2LvSOAAALhECg4mJnh/SccQ6RKBBBQgUmTJrV3dnYurK2t7fBRpNv0/Xuz/iO3D72E+Vez/sTHfdI1AgggEBmBgoPZ7NmzI4PAQBCIg0BXV5d8+PBBKisr/Xydml7K1CD2t5zpZvP3D2b9WRyMGSMCCCBQrEDBwWzOnDnF7pvtEUBgjAXu3bsndXV1fgYzDWR6N+Yfc0P7i/mrlzH1t2YsCCCAAAIuAgQzDhEEYiIwMDAgTU1NfgezuYbzn2bVx2UkzaqPy1hr1kcxYWaYCCCAQFECjmBmfn/i2lkymRTzwnP9vYprWxoggEBwBD59+iTTpk2T8vJyP8+Y6YD1B/+/MGvGrDfNejk4ClSCAAIIBFvAEcz0NyhuiwazcePGycePH5e5teVzBBAIjoD5/7bD/PC/KTgVUQkCCCCAwJcCjmDW3a03VOVfBoNZTU2N3//qdiuFzxFAAAEEEEAAgUgJOIJZT48+gij/kkgksmfMCGZuUnyOAAIIIIAAAgh4E3AEs97eXtetNZjpWTOCmSsVDRBAAAEEEEAAAU8CjmDW399vtbEGs1QqxaVMKy0aIYAAAggggAACdgKOYKZ3bdkuBDNbKdohgAACCCCAAAJ2Ao5gps85clsyGb0DXmTu3LmcMXPD4nMEEEAAAQQQQMCDgCOYDYaufNtrm3Q6TTDzgExTBBBAAAEEEEDARqDgJ/9XV1dzxsxGmDYIIIAAAggggIClgCOYlZSUuG6mZ8s+f/4sBDNXKhoggAACCCCAAAKeBLLBrLW1tayvr69d77bUx2HkWzSY6eXMqqoqzph5oqYxAggggAACCCCQX2AoXDU3N39rzpg1uoHpWbUJEyZ8U1FR0eHWls8RQAABBBBAAAEE7AU462VvRUsEEEAAAQQQQMBXAYKZr7x0jgACCCCAAAII2AsQzOytaIkAAggggAACCPgqQDDzlZfOEUAAAQQQQAABewGCmb0VLRFAAAEEEEAAAV8FCGa+8tI5AggggAACCCBgL0Aws7eiJQIIIIAAAggg4KsAwcxXXjpHAAEEEEAAAQTsBf4Lib+JeaxN4REAAAAASUVORK5CYII="
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import display\n",
     "w1 = SpinnerWidget(value=0)\n",

--- a/examples/Date Picker Widget.ipynb
+++ b/examples/Date Picker Widget.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -70,14 +70,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "class DateWidget(widgets.DOMWidget):\n",
-    "    _view_name = Unicode('DatePickerView').tag(sync=True)"
+    "    _view_name = Unicode('DatePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('datepicker').tag(sync=True)"
    ]
   },
   {
@@ -107,31 +108,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
     "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "define('datepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "\n",
     "});"
    ]
@@ -152,46 +137,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    // Define the DatePickerView\n",
-       "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
-       "        render: function() { this.$el.text('Hello World!'); },\n",
-       "    });\n",
-       "    \n",
-       "    // Register the DatePickerView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
+    "requirejs.undef('datepicker');\n",
     "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "define('datepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    // Define the DatePickerView\n",
     "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
     "        render: function() { this.$el.text('Hello World!'); },\n",
     "    });\n",
     "    \n",
-    "    // Register the DatePickerView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
+    "    return {\n",
+    "        DatePickerView: DatePickerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -211,21 +175,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAfCAYAAABNngGqAAAGVklEQVR4Xu2dZ6gdVRRGE8FCLKghKBaMijUW7IoIT1AEu2CJHXvH3tsTVMSuWBCUxAaKFUQFCypWsCA2BMsPFRUEe8X6LTgDkyGZm3t5Dw6yDnzMPXfafuvOj4+995k3dYpDAhKQgAQkIAEJSKAKAlOriMIgJCABCUhAAhKQgASmaMx8CCQgAQlIQAISkEAlBDRmlfwQhiEBCUhAAhKQgAQ0Zj4DEpCABCQgAQlIoBICGrNKfgjDkIAEJCABCUhAAhoznwEJSEACEpCABCRQCQGNWSU/hGFIQAISkIAEJCABjZnPgAQkIAEJSEACEqiEwEQYs2Xzt5we7RBtE3Xnlfyp84SxVmYXRD9GJ3UCnJ75mdE60V41Bm9MEpCABCQgAQn8PwlgzLaLroi2jE6M7ov+jPaNbok+KsbrmQUgWDzfHx6dHK0bdefDktszJ8yJfoj2jr6Jbop2ja6LxiMM1dbluMeyvSj6fYgbTcuxd5R7HNs5b/nMz482jjCbjAvLnHgcEpCABCQgAQlIYFIINBmz03J1jNVqnbu8k/mjxfj0BbBbdl4VYcwY3fmwwXOtPaK1y4krZft5hFl8qHWxufl8WPTvsDfI8ddES0ZdY8alji73aowZZnWDohFu5SkSkIAEJCABCUhgMIHGmJ2SQ9HMzilvZ44xGx9wKbJZV0eNMevOB0cy7xGbZfpGMULvl13PZ/tJdESZU3I8NaIkOcog3qWi+RmzI/P97KgxZjfk86zWfJT7eY4EJCABCUhAAhLoJTCsMds0VyMbhklZNCJb9X00yJiRbToq+jXaKjorwnj1jY+z8+7oknLQu9mSOVsxotSKecI4Ntehtw2T9lu5xz3Z3hVtEp0XUZLdMJpZtl1jtku+3zmihLp99EvUGLOz85m/+ZABMbtbAhKQgAQkIAEJjEygbcwwQLd2roTx4rvxiOwSnw8ux7yc7WsRjf99xoxyIeaJHrafIvq0bo7WjH7uifzy7Ns9wtRhqPaLzokwhk+WWI5rnf9IPt8YPRetHGHsxiLKsQ9Gy0X0wtGbNjdqGzNKuGQGN4/+jm4r8TXGDEOGMcOgOSQgAQlIQAISkMCkEBgmY7ZPIiBLhSliYJi+i1jB2GfMDsx+Vj5iiBiLRDT0U4Yko7WgQfM9GbH1IkzZ7RGLAr6I6InDJJ1bTl4l288imvqbRQAYrW8jzBiN/l9HNPU3o23M6DeDBddldEuZGDSMGSVNhwQkIAEJSEACEpgUAsMYMzJjZLmOn08kfcZsPMeT5aJvrBlv5sPD0WUD/qoPs//eaNWIhnz6y1gYQCmU3rNXy/lj2ZIpWyYiK8fAbG0U7Rhh6jBm7X60tjF7OvteiS4u53aN2fr5HmP2wIB43S0BCUhAAhKQgARGJjCMMTsgd+G1GrwD7I9yR7JglDP7jBkZq2ujGRG9YYy3IkqVlBj7BuVVmvMxcJQpeZUFBot+M8qOzWrMNfKZhQGUS18vF+Sei0W8AmSQMWOlJyVMVn0yusaMMi5ZOYyiQwISkIAEJCABCUwKgcaYnZGrsyoT89EeH2SCaeE9XpgizA/9YmSt6Mv6K6K8SEaMDBQvZWW052SxPo1OiO6PaNInO0UGjUb9vkGmChNGxuzLcuAT2dLIz+s92uOpTIiv6Tt7IZ8podJjhjGjfNqUPjmPjBqG65iIFZiUVcdKbBhBFgNsEWEmd4pWKMd0butUAhKQgAQkIAEJTAwBjNm20ZUR2S/MDishMSP0ddEET8mQPjJeMMvLaGncxyjdGdGTtXR0fYS5obH/pc788XJtjBCGbImIRQSYvoUZvOS2XT49NHOM3oudk1mtSS/ZVxErRVmcwIIAypm8h+yfiCZ+snWrR5QliWX/6L2oyc6RAaSPjd62S6Nnyz7KuActTMAeIwEJSEACEpCABEYhMBH/kmmU+3qOBCQgAQlIQAISkECHgMbMR0ICEpCABCQgAQlUQkBjVskPYRgSkIAEJCABCUhAY+YzIAEJSEACEpCABCohoDGr5IcwDAlIQAISkIAEJKAx8xmQgAQkIAEJSEAClRDQmFXyQxiGBCQgAQlIQAIS0Jj5DEhAAhKQgAQkIIFKCGjMKvkhDEMCEpCABCQgAQlozHwGJCABCUhAAhKQQCUENGaV/BCGIQEJSEACEpCABP4Dqk/zIBEv0/IAAAAASUVORK5CYII="
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "DateWidget()"
    ]
@@ -257,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -265,6 +219,7 @@
    "source": [
     "class DateWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('DatePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('datepicker').tag(sync=True)\n",
     "    value = Unicode().tag(sync=True)"
    ]
   },
@@ -287,45 +242,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    // Define the DatePickerView\n",
-       "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
-       "        render: function() {\n",
-       "            \n",
-       "            // Create the date picker control.\n",
-       "            this.$date = $('<input />')\n",
-       "                .attr('type', 'date')\n",
-       "                .appendTo(this.$el);\n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    // Register the DatePickerView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
+    "requirejs.undef('datepicker');\n",
     "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-    "    \n",
+    "define('datepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
+    "     \n",
     "    // Define the DatePickerView\n",
     "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
     "        render: function() {\n",
@@ -337,8 +264,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    // Register the DatePickerView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
+    "    return {\n",
+    "        DatePickerView: DatePickerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -351,51 +279,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    // Define the DatePickerView\n",
-       "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
-       "        render: function() {\n",
-       "            \n",
-       "            // Create the date picker control.\n",
-       "            this.$date = $('<input />')\n",
-       "                .attr('type', 'date')\n",
-       "                .appendTo(this.$el);\n",
-       "        },\n",
-       "        \n",
-       "        update: function() {\n",
-       "            \n",
-       "            // Set the value of the date control and then call base.\n",
-       "            this.$date.val(this.model.get('value')); // ISO format \"YYYY-MM-DDTHH:mm:ss.sssZ\" is required\n",
-       "            return DatePickerView.__super__.update.apply(this);\n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    // Register the DatePickerView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
+    "requirejs.undef('datepicker');\n",
     "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "define('datepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    // Define the DatePickerView\n",
     "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
@@ -415,8 +308,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    // Register the DatePickerView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
+    "    return {\n",
+    "        DatePickerView: DatePickerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -435,64 +329,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    // Define the DatePickerView\n",
-       "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
-       "        render: function() {\n",
-       "            \n",
-       "            // Create the date picker control.\n",
-       "            this.$date = $('<input />')\n",
-       "                .attr('type', 'date')\n",
-       "                .appendTo(this.$el);\n",
-       "        },\n",
-       "        \n",
-       "        update: function() {\n",
-       "            \n",
-       "            // Set the value of the date control and then call base.\n",
-       "            this.$date.val(this.model.get('value')); // ISO format \"YYYY-MM-DDTHH:mm:ss.sssZ\" is required\n",
-       "            return DatePickerView.__super__.update.apply(this);\n",
-       "        },\n",
-       "        \n",
-       "        // Tell Backbone to listen to the change event of input controls (which the HTML date picker is)\n",
-       "        events: {\"change\": \"handle_date_change\"},\n",
-       "        \n",
-       "        // Callback for when the date is changed.\n",
-       "        handle_date_change: function(event) {\n",
-       "            this.model.set('value', this.$date.val());\n",
-       "            this.touch();\n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    // Register the DatePickerView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
+    "requirejs.undef('datepicker');\n",
     "\n",
-    "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-    "    \n",
+    "define('datepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
+    "   \n",
     "    // Define the DatePickerView\n",
     "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
     "        render: function() {\n",
@@ -520,8 +368,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    // Register the DatePickerView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
+    "    return {\n",
+    "        DatePickerView: DatePickerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -541,21 +390,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAlCAYAAADofyVhAAAHeUlEQVR4Xu3dW0hUWxzH8f+kGdLNtJtFN8uHIBSTgoKgHqSHHooiyiDyGlGUSoJFRS8RUUE+BBXWQ1DaFbSoyBcpiMBMkaKHworsXpRaahjo8b8ODo7Ontk7HJzZfvdTnb1m7f/+rA39ztpr1niEAwEEEEAAAQQQQCAsBDxhUQVFIIAAAggggAACCAjBjIcAAQQQQAABBBAIEwGCWZgMBGUggAACCCCAAAIEM54BBBBAAAEEEEAgTAQIZmEyEJSBAAIIIIAAAgh4Dh061NPa2ip//vxBA4EhFZg0aZLs2bNHZs6cyf8ADKksnSGAAAIIuFXAs3379p5p06bJkiVL3HqP3NcwCaSnp4vH45EZM2YQzIZpDLgsAggggEBkCZhgpiWfO3cusiqn2rAX+PTpk6mRYBb2Q0WBCCCAAAJhIkAwC5OBcGMZBDM3jir3hAACCCAQSgGCWSh1R3jfBLMR/gBw+wgggAACjgUIZo7J+IBdAYKZXSnaIYAAAggg8L8AwYwnIWQCBLOQ0dIxAggggIBLBfwGs+rqajlw4IBcv35d5s6d6731uro6OX/+vOi3ON++fSunTp2S+Ph4cz7QucbGRrlw4YIkJSVJU1OT5OfnS0pKim1Sq3ru3r0rhYWF8u3bN1m3bp2cPn1axo4dG7Dfzs5O2bt3r0ycOFF+/PghJ06ckAkTJng/Y3Ut28XS0CtAMONhQAABBBBAwJnAoGD25csXefTokWzYsEHevHnjDWa/f/82W2poANPwc+XKFamoqJCqqioJdE7LWbRokTx+/FjGjx8vnz9/loyMDHn27JmtSq3q+fr1q9kjS0OW1tn77VLJzs42YTHQkZeXJ8uWLZPc3Fy5ceOG3Lx509yHHlbXslUojQYJEMx4KBBAAAEEEHAm4HfGrLu7W6KionyC2dWrV+XkyZPy5MkTc4X29nYTtF68eCE6I2Z1Ljk5WWJiYuTly5cyf/58E3404L179852pf7q0fC4ePFiiY2NNf0cPXpUtEatxerQUNi72akJh1OmTJG2tjbRTVB1Fq9vZtDftWwXSkMfAYIZDwQCCCCAAALOBCzXmOnGoP1nzMrKyuTw4cPy8eNH7xUSEhLk7Nmz0tLSYnlu48aNZvZNw8+9e/fMjNby5cvNq0cnx8B6Bn724sWLZgbs9u3blt3qzFhOTo7o68y+IzExUY4dOybbtm3z/rdg13JS90huSzAbyaPPvSOAAAII/IuA7WD26tUr80pS15ht3bpV9O8LFy6Uy5cvm5krq3ObNm0S/cmnNWvWyPPnz83Mmr5OdHoEC0s7d+6UtWvXyurVqy271vVkpaWl8uHDB28bndHTsLZ//36CmdNBCdKeYDbEoHSHAAIIIOB6AdvBTCXu3LljFsvrK8mpU6eamSZ9dagL+QOd03+gjx8/Ls3NzXL//n3RRfsrVqxwhBsomGn/+/btE501C3RoKDxz5oyZves75syZI7t375bi4mKCmaMRCd6YYBbciBYIIIAAAgj0F3AUzPp/UBfeP3jwwO+aroHn9NWlvkacNWuWZGVlSU1Njbx+/VpGjx7t7VK/Udk/HGl40vVgfYdVMOvp6ZGSkhI5ePCgz7cr/fX38OFDE8K+f//u7Ve/Vaptt2zZEvRaPDrOBAhmzrxojQACCCCAwD8Fs/fv35vXmLdu3ZJVq1b5KA48p39PS0szW1ro0dXVZRbaa0hasGCB97M/f/40XwzoO/RcdHR00LCka9Z0vdq8efN86vDXnway2bNniwYGXR+n22VMnjzZzOTZCYE8Ls4ECGbOvGiNAAIIIICA32Cms1CjRo0ys1oDA09HR4dZL6Zrx3bs2OEj6O/c379/TR+1tbX6Y9aifetrTJ016z9jFmgorOrR9WLad2pqqum3vr7eXEO3w7A6MjMzzVq0zZs3y7Vr16SyslLKy8u9zQPdO4+LMwGCmTMvWiOAAAIIIDAomP369UsuXbokuphev4W5a9cus7WEzjbp5qu6Xcb69et91ogFOqfET58+Nd/eXLp0qehM1sqVK82f7RxW9WgoKyoq8ulCZ780DPSfaRt4Db2+7n2mm93qN0x17du4ceNMM6tr2amTNoMFCGY8FQgggAACCDgT4CeZnHnR2oEAwcwBFk0RQAABBBDoFSCY8RiETIBgFjJaOkYAAQQQcKkAwcylAxsOt0UwC4dRoAYEEEAAgUgSIJhF0mhFWK0EswgbMMpFAAEEEBh2AYLZsA+BewsgmLl3bLkzBBBAAIHQCBDMQuNKr70CBDMeAwQQQAABBJwJmGAWGxsrR44ccfZJWiMQRKC9vV26u7t1bzkPWAgggAACCCAQXMBTUFDQoz/irXuVcSAwlAJRUVFm49/p06cTzIYSlr4QQAABBFwr4GloaKju/SHvMa69Q25sWAV6f0GiKy4uLmNYi+DiCCCAAAIIRIgAMxkRMlCUiQACCCCAAALuFyCYuX+MuUMEEEAAAQQQiBABglmEDBRlIoAAAggggID7BQhm7h9j7hABBBBAAAEEIkSAYBYhA0WZCCCAAAIIIOB+gf8AQnwhU1zZ4noAAAAASUVORK5CYII="
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_widget = DateWidget()\n",
     "display(my_widget)"
@@ -570,21 +409,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAlCAYAAADofyVhAAAHVklEQVR4Xu3dWUhUbxjH8Wda5B9taBsWZWki0UZBQUFQF9FFF4YxpEJYuSBFUSRUFHQXbWAXQUV1EZhlC2ihYTdhIEJWEEUXRQuZ7bRrVKD/eV5wcMY5M/OGw8yZ+Z4r7bzznud83gP+es97zniEDQEEEEAAAQQQQCAhBDwJUQVFIIAAAggggAACCAjBjIsAAQQQQAABBBBIEAGCWYIMBGUggAACCCCAAAIEM64BBBBAAAEEEEAgQQQIZgkyEJSBAAIIIIAAAgh4Dh061Pvs2TMkEIiJwM6dOyUvL4//AMREl04RQAABBJJNwFNRUdGbk5MjhLNkG9r4n4+GstGjR8vkyZMJZvEfDipAAAEEEHCBgAlmWuepU6dcUC4lukng7du3plyCmZtGjVoRQAABBOIpQDCLp36SH5tgluQDzOkhgAACCAy6AMFs0EnpsE+AYMa1gAACCCCAgJ0AwczOi9YWAgQzCyyaIoAAAggg4BMgmHEZxEyAYBYzWjpGAAEEEEhSgZDB7ObNm7J37165fPmyTJ8+3X/qd+/elTNnzsikSZPk5cuXUl1dLRkZGWZ/uH0PHjyQs2fPSnZ2tnn6s7y8XObNmxc1qVM9TU1Nsn37dvn48aOsWbNGjh8/LiNHjgzb769fv0SfFhw7dqx8/vxZjhw5ImPGjPF/xulYURdLQ78AwYyLAQEEEEAAATuBAcHs/fv30traKmvXrpUXL174g9nPnz9l0aJFJoBp+Ll48aJcuHBBGhoaJNw+LWfOnDnS1tZmXp3w7t07WblypTx8+DCqSp3q+fDhg2zbts2ELK3T93SpbNy40YTFcFtZWZksWbJESktL5cqVK3L16lVzHro5HSuqQmk0QIBgxkWBAAIIIICAnUDIGbOenh4ZOnRoQDCrq6uTo0ePSnt7uzlCV1eXCVqPHz8WnRFz2pebmytpaWny5MkT0felafjRgPfq1auoKw1Vj4bHhQsXyogRI0w/Bw4cEK1Ra3HaNBROmTLFhMMJEybI9+/fJT093czi9c0MhjpW1IXSMECAYMYFgQACCCCAgJ2A4xozj8cTEMxOnz4t+/fvlzdv3viPMG7cODl58qR8/frVcZ/X6zWzbxp+bty4YWa0li5dam492mzB9QR/9ty5c2YG7Pr1647d6szYpk2bRG9n9m2ZmZly8OBBKSkp8f9bpGPZ1J3KbQlmqTz6nDsCCCCAwL8IRB3Mnj59am5J6hqz9evXi/4+a9YsOX/+vJm5ctq3bt06+fbtm6xevVoePXpkZtb0dqLtFiksbd68WfLz82XVqlWOXet6smPHjklnZ6e/jc7oaVjbs2cPwcx2UCK0J5gNMijdIYAAAggkvUDUwUwlGhsbzWJ5vSU5ceJEM9Oktw51IX+4ffoH+vDhw9LR0SHNzc2ii/aXLVtmhRsumGn/u3fvFp01C7dpKDxx4kTA109lZWXJ1q1bpaqqimBmNSKRGxPMIhvRAgEEEEAAgf4CVsGs/wd14X1LS0vINV3B+/TWpd5GnDp1qmzYsEFu3bolz58/l+HDh/u71Ccq+4cjvfWp68H6Nqdg1tvbK7t27ZJ9+/YFPF0Zqr/bt2+bEPbp0yd/v/pUqbYtLi6OeCwuHTsBgpmdF60RQAABBBD4p2D2+vVrcxvz2rVrsmLFigDF4H36+4IFC8wrLXT78+ePWWivIWnmzJn+z3758sU8GNC36b5hw4ZFDEu6Zk3Xq82YMSOgjlD9aSCbNm2aaGDQ9XH6uozx48ebmbxoQiCXi50AwczOi9YIIIAAAgiEDGY6CzVkyBAzqxUceLq7u816MV07VllZGSAYat/fv39NH3fu3NEvsxbtW29j6qxZ/xmzcEPhVI+uF9O+58+fb/q9f/++OYa+DsNpKyoqMmvRCgsL5dKlS1JfXy+1tbX+5uHOncvFToBgZudFawQQQAABBAYEsx8/fkhNTY3oYnp9CnPLli3m1RI626QvX9XXZRQUFASsEQu3T4nv3btnnt5cvHix6EzW8uXLzc/RbE71aCjbsWNHQBc6+6VhoP9MW/Ax9Pj67jN92a0+Yapr30aNGmWaOR0rmjppM1CAYMZVgQACCCCAgJ0AX8lk50VrCwGCmQUWTRFAAAEEEPAJEMy4DGImQDCLGS0dI4AAAggkqQDBLEkHNhFOi2CWCKNADQgggAACbhIgmLlptFxWK8HMZQNGuQgggAACcRcgmMV9CJK3AIJZ8o4tZ4YAAgggEBsBgllsXOnVJ0Aw4zJAAAEEEEDAToBgZudFawsBgpkFFk0RQAABBBDwCZhg5vV6Zfbs2YAgMKgC+gJhfcGw76W/nkHtmM4QQAABBBBIUgGP70vFf8+dOzctSc+P04qzgC+c/fa9oPi/OJfB4RFAAAEEEHCFADMZrhgmikQAAQQQQACBVBAgmKXCKHOOCCCAAAIIIOAKAYKZK4aJIhFAAAEEEEAgFQQIZqkwypwjAggggAACCLhCgGDmimGiSAQQQAABBBBIBYH/Ac7KHlPie8WLAAAAAElFTkSuQmCC"
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_widget"
    ]
@@ -598,22 +427,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "''"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_widget.value"
    ]
@@ -627,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -652,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -689,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -697,6 +515,7 @@
    "source": [
     "class DateWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('DatePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('datepicker').tag(sync=True)\n",
     "    value = Unicode().tag(sync=True)\n",
     "    description = Unicode().tag(sync=True)"
    ]
@@ -712,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -720,6 +539,7 @@
    "source": [
     "class DateWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('DatePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('datepicker').tag(sync=True)\n",
     "    value = Unicode().tag(sync=True)\n",
     "    description = Unicode().tag(sync=True)\n",
     "\n",
@@ -739,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -747,6 +567,7 @@
    "source": [
     "class DateWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('DatePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('datepicker').tag(sync=True)\n",
     "    value = Unicode().tag(sync=True)\n",
     "    description = Unicode().tag(sync=True)\n",
     "    \n",
@@ -779,7 +600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -787,6 +608,7 @@
    "source": [
     "class DateWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('DatePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('datepicker').tag(sync=True)\n",
     "    value = Unicode().tag(sync=True)\n",
     "    description = Unicode().tag(sync=True)\n",
     "    \n",
@@ -841,77 +663,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "    \n",
-       "    // Define the DatePickerView\n",
-       "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
-       "        render: function() {\n",
-       "            this.$el.addClass('widget-hbox-single'); /* Apply this class to the widget container to make\n",
-       "                                                        it fit with the other built in widgets.*/\n",
-       "            // Create a label.\n",
-       "            this.$label = $('<div />')\n",
-       "                .addClass('widget-hlabel')\n",
-       "                .appendTo(this.$el)\n",
-       "                .hide(); // Hide the label by default.\n",
-       "            \n",
-       "            // Create the date picker control.\n",
-       "            this.$date = $('<input />')\n",
-       "                .attr('type', 'date')\n",
-       "                .appendTo(this.$el);\n",
-       "        },\n",
-       "        \n",
-       "        update: function() {\n",
-       "            \n",
-       "            // Set the value of the date control and then call base.\n",
-       "            this.$date.val(this.model.get('value')); // ISO format \"YYYY-MM-DDTHH:mm:ss.sssZ\" is required\n",
-       "            \n",
-       "            // Hide or show the label depending on the existance of a description.\n",
-       "            var description = this.model.get('description');\n",
-       "            if (description == undefined || description == '') {\n",
-       "                this.$label.hide();\n",
-       "            } else {\n",
-       "                this.$label.show();\n",
-       "                this.$label.text(description);\n",
-       "            }\n",
-       "            \n",
-       "            return DatePickerView.__super__.update.apply(this);\n",
-       "        },\n",
-       "        \n",
-       "        // Tell Backbone to listen to the change event of input controls (which the HTML date picker is)\n",
-       "        events: {\"change\": \"handle_date_change\"},\n",
-       "        \n",
-       "        // Callback for when the date is changed.\n",
-       "        handle_date_change: function(event) {\n",
-       "            this.model.set('value', this.$date.val());\n",
-       "            this.touch();\n",
-       "        },\n",
-       "    });\n",
-       "    \n",
-       "    // Register the DatePickerView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
+    "requirejs.undef('datepicker');\n",
     "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "define('datepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "    \n",
     "    // Define the DatePickerView\n",
     "    var DatePickerView = widgets.DOMWidgetView.extend({\n",
@@ -957,8 +718,9 @@
     "        },\n",
     "    });\n",
     "    \n",
-    "    // Register the DatePickerView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('DatePickerView', DatePickerView);\n",
+    "    return {\n",
+    "        DatePickerView: DatePickerView\n",
+    "    };\n",
     "});"
    ]
   },
@@ -978,21 +740,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAACBCAYAAABq8naZAAAQRUlEQVR4Xu3dfazdd10H8HPFdbNNgY4MRu1wsJEuHbus3LZE56LGh/CggtGaIfgYraKgG8MJBKLIdFYJTEB0JMqDky3+AZihrEhQnBFcO0uqKBXH0GZMNoUqaUsten1/l3PN4Wb1nnPP99z7e3jd5J3T2/3O9/5+r883N++dp84NfBEgQIAAAQIECDRCYK4RZ+EkCBAgQIAAAQIEBoqZTUCAAAECBAgQaIiAYtaQQTgNAgQIECBAgIBiZg8QIECAAAECBBoioJg1ZBBOgwABAgQIECCgmNkDBAgQIECAAIGGCChmDRmE0yBAgAABAgQIKGaV9sDBgwevmZubu63ScpYhQOAsAouLiy/YvXv37YAIECDQRQHFrNJUDx8+vLhjx47Bhg0bKq1oGQIElgucOnVqcPTo0cHOnTv97rI9CBDopIBfbpXGeujQocWFhYVKq1mGAIGzCdxzzz2DXbt2+d1lixAg0EkBv9wqjVUxqwRpGQIrCChmtggBAl0WUMwqTVcxqwRpGQKKmT1AgECPBRSzSsNXzCpBWoaAYmYPECDQYwHFrNLwFbNKkJYhoJjZAwQI9FhAMas0fMWsEqRlCChm9gABAj0WUMwqDV8xqwRpGQKKmT1AgECPBbpYzD6ceb4ped9azlUxW0ttP6vPAt6V2efpu3YC3RdoWzH7poxkf3JZ8o7heDbn9vuTZySfSp6XHEruX8vxKWZrqe1n9VlAMevz9F07ge4LtK2YlYnckOxLLh0Zz7Py539NPj7FyF6a+755tfdXzFYr534EJhNQzCbzcjQBAu0SaGMxe3mIf2pZMSvXUf4tpNOr5J/P/e5KHrPK+w8Us9XKuR+ByQQUs8m8HE2AQLsEulDMfiTktyZfTp6dvCJ5a/KR5BeS7clHk2uTXcnVyROGf35cbp+b3JRcl5SnST+QlKdBP5Y8ffjnFaeqmK1I5AACVQQUsyqMFiFAoKECbS1mr4nnbcl5yfcmW5JSzDYmf5e8KnlvUsrYzyXfk1yZvDv5UPLM4TxuzO2rk4uT+5Ilj0cP13htbk+NMzvFbBwlxxCYXkAxm97QCgQINFegrcVs9KnMnw7v24bFrEj/dfLG5PbkB5Ny7FXDEXxVbh8a/rdfzG35/sFHKGYTT0wxm5jMHQisSkAxWxWbOxEg0BKBLhSzrbF+IFkcmpenIG8elq8XDYvZN47Mozxa9nvJk5KfTd6umLVktzpNAhFQzGwDAgS6LNCFYrZ8Pv9fMXtUDn5iUt7BWd7d+cvJRcm5yehTmRPP3CNmE5O5A4FVCShmq2JzJwIEWiLQxmJWXtz/k8mTz2Jcnsosj5iV16CVR8x+Jvn64bHlNWmvS35++H353LPy2Wjlq7zg//zk8cnnkvL6s/IO0C+NM0vFbBwlxxCYXkAxm97QCgQINFegbcWsPCX5+qS8u7I8DVnejfmfI7zlHZd3JH+c/EpSXrz/nKQUtPJmgFLMTiTl6ctPD+/7ltwWhzuTC5O9SXntWXmTwJ7ks+OMTzEbR8kxBKYXUMymN7QCAQLNFWhbMWuspGLW2NE4sY4JKGYdG6jLIUDgKwQUs0obQjGrBGkZAisIKGa2CAECXRZQzCpNVzGrBGkZAoqZPUCAQI8FFLNKw1fMKkFahoBiZg8QINBjAcWs0vAVs0qQliGgmNkDBAj0WEAxqzR8xawSpGUIKGb2AAECPRZQzCoNXzGrBGkZAoqZPUCAQI8FFLNKw1fMKkFahoBiZg8QINBjAcWs0vAVs0qQliGgmNkDBAj0WEAxqzR8xawSpGUIKGb2AAECPRZQzCoN/8iRI4vbtm0bbNmypdKKliFAYLnA8ePHB8eOHRvMz8/73WV7ECDQSQG/3CqNNZ9GPr9x48a7T5w4cW6lJS1DgMAygU2bNp0+efLknoWFhSNwCBAg0EUBxayLU3VNBAgQIECAQCsFFLNWjs1JEyBAgAABAl0UUMy6OFXXRIAAAQIECLRSQDFr5dicNAECBAgQINBFAcWs0lQPHjx4zdzc3G2VlrMMAQJnEVhcXHzB7t27bwdEgACBLgooZpWmevjw4cUdO3YMNmzYUGlFyxAgsFzg1KlTg6NHjw527tzpd5ftQYBAJwX8cqs0Vh8wWwnSMgRWEMhH0wx27drld5edQoBAJwX8cqs0VsWsEqRlCChm9gABAj0WUMwqDV8xqwRpGQKKmT1AgECPBRSzSsNXzCpBWoaAYmYPECDQYwHFrNLwFbNKkJYhoJjZAwQI9FhAMas0fMWsEqRlCChm9gABAj0WUMwqDV8xqwRpGQKKmT1AgECPBRSzSsNXzCpBWoaAYmYPECDQY4E2FrPnZ16/lWxMrkv+KPnCes9QMVvvCfj5fRHwOWZ9mbTrJNBPgTYWszKp8s+xfE3yvEpje2nWefM0aylm0+i5L4HxBRSz8a0cSYBA+wTaWsxuDfV5yfdVIJ/PGnclj5lmLcVsGj33JTC+gGI2vpUjCRBon0BXi9nejOLq5MvJZUn5/kSyJ3lusil5cXJ+clNSnhLdn3wg+UhyNHll8p5xR6qYjSvlOALTCShm0/m5NwECzRboajE7HvYrk88MS9YNuS2vRftgck3y+eTG5NXJxcl9yajFUikrBW2sL8VsLCYHEZhaQDGbmtACBAg0WKCrxexbY/7h5KrkXclrkj9I3peUpyxfkjyUPHiWYjbxyBSzicncgcCqBBSzVbG5EwECLRHoajHbGf8XJuVNAjcnv5OU16VdmPxu8qzkrcm1yUXJ8kfMJh6fYjYxmTsQWJWAYrYqNnciQKAlAl0rZs+Me3n6seTS5IvJX44Us4vz588k35mUR9B+IrlbMWvJbnWaBCKgmNkGBAh0WaCtxeyRPi7jsRlU+diLP0n+KtmelHdu3pn8anIgKS/yf1nyP0l55OxPk79I7k/KGwEen5RSV15/Vh5h++S4w/eI2bhSjiMwnYBiNp2fexMg0GyBNhazpQ+Y3RLaO5IzSfmw2fJ6svLU5B8mpZyVF/+/IXlq8rSkPEr2/qQ8ilZK2hOT8qaAUtJKeStPc5Z3b34q+URS3gBQ3jAw1pdiNhaTgwhMLaCYTU1oAQIEGizQxmLWSE7FrJFjcVIdFFDMOjhUl0SAwP8JKGaVNoNiVgnSMgRWEFDMbBECBLosoJhVmq5iVgnSMgQUM3uAAIEeCyhmlYavmFWCtAwBxcweIECgxwKKWaXhK2aVIC1DQDGzBwgQ6LGAYlZp+IpZJUjLEFDM7AECBHosoJhVGr5iVgnSMgQUM3uAAIEeCyhmlYavmFWCtAwBxcweIECgxwKKWaXhK2aVIC1DQDGzBwgQ6LGAYlZp+IpZJUjLEFDM7AECBHosoJhVGv6RI0cWt23bNtiypfxLUb4IEJiFwPHjxwfHjh0bzM/P+901C2BrEiCw7gJ+uVUaQT6NfH7jxo13nzhx4txKS1qGAIFlAps2bTp98uTJPQsLC0fgECBAoIsCilkXp+qaCBAgQIAAgVYKKGatHJuTJkCAAAECBLoooJh1caquiQABAgQIEGilgGLWyrE5aQIECBAgQKCLAopZF6fqmggQIECAAIFWCihmrRybkyZAgAABAgS6KKCYdXGqrokAAQIECBBopUApZt+Q/EayO/lgcl9yUfLfyVuSP1t2ZVfk+5clX0w2JOcnb0w+Ojzuqbm9Ifnx5Lbkn5OvTS5MXpfc1UopJ02AAAECBAgQmLHA0iNm1+XnXJ9sG/l5L8qf3z4sWO8c/v3Vuf395NuSfxr+3ZNyW8rbtckdw7/bmdu/SUpJWzruR/Pn3052JJ+e8XVZngABAgQIECDQOoGlYvaSnPkrlhWzcjE3D4tZKWynkn9MyqNo5RG20a8X55sbk6ck/5E8LfnbZLSYPS7f/1vyA0l5JM0XAQIECBAgQIDAiMBKxaw8bVn+6ZMfSx5M3p+UR8M+vkyxFLBS2sqjYu84SzErj8q9Nrk8OZZcmnwseXpyv6kQIECAAAECBPousFIxOydA/5XclHwh+fXkCcOSNmp3Xr4pj6iVR9LK68uWHjErT4V+Lvnm5Mrkhcl7hnd8dG5flZSyVu7riwABAgQIECDQa4GVitlXR+fMsJD9e273J+VF/KVsjX4tFbhfy1++Mln+VOaj8ne/lJSnS78rubPX6i6eAAECBAgQIPAIAisVs/JC/U8kP5x8Pikv7t+THFy2VnkX578k5RGxdz9CMSuHl59VnsL8++Q7TIMAAQIECBAgQOArBVYqZuURsn3J1yWnk/JRGuWdleVjL0a/fijfvD55cnLiLMWsHF/eEHA8Ke/u9EWAAAECBAgQIDAisFTMykddvDwZ/biM78735d2T5WMz3ju8z7fn9l3JtySfHP5dec3ZnydljQPDvyuvJzucjL4rs3xeWvkMs/IOzrclj03KOznLz/2SqRAgQIAAAQIE+i5QitlVSXnRfnm35a3JQ0n5QNjygv7yYv97liGVD6ItZao8tVkeHSvF7DeTQ8PjRj9g9kP5u39INifPGK6/9FEbl+X78t/LU6Of7fsgXD8BAgQIECBAwD/JZA8QIECAAAECBBoioJg1ZBBOgwABAgQIECCgmNkDBAgQIECAAIGGCChmDRmE0yBAgAABAgQIKGb2AAECBAgQIECgIQJz+/fvX7z33nsbcjpOo2sC119//WD79u3+B6Brg3U9BAgQIDATgbl9+/YtXnLJJQPlbCa+vV60lLLNmzcPtm7dqpj1eie4eAIECBAYV+DhYlYOvuWWW8a9j+MIjCXwwAMPPHycYjYWl4MIECBAgMBAMbMJZiagmM2M1sIECBAg0FEBxayjg23CZSlmTZiCcyBAgACBNgkoZm2aVsvOVTFr2cCcLgECBAisu4Bitu4j6O4JKGbdna0rI0CAAIHZCChms3G1agQUM9uAAAECBAhMJqCYTebl6AkEFLMJsBxKgAABAgQioJjZBjMTUMxmRmthAgQIEOiogGLW0cE24bIUsyZMwTkQIECAQJsEFLM2Tatl56qYtWxgTpcAAQIE1l1AMVv3EXT3BBSz7s7WlREgQIDAbAQUs9m4WjUCipltQIAAAQIEJhNQzCbzcvQEAorZBFgOJUCAAAECEVDMbIOZCShmM6O1MAECBAh0VEAx6+hgm3BZilkTpuAcCBAgQKBNAopZm6bVsnNVzFo2MKdLgAABAusuoJit+wi6ewKKWXdn68oIECBAYDYCitlsXK0aAcXMNiBAgAABApMJKGaTeTl6AgHFbAIshxIgQIAAgQgoZrbBzAQUs5nRWpgAAQIEOiqgmHV0sE24LMWsCVNwDgQIECDQJgHFrE3Tatm5KmYtG5jTJUCAAIF1F3i4mO3du3dw+eWXr/vJOIFuCZxzzjmDM2fODLZu3TrXrStzNQQIECBAYDYCcwcOHDh9xRVXbJjN8lbtu0DK2ekLLrjgvL47uH4CBAgQIDCOgEcyxlFyDAECBAgQIEBgDQQUszVA9iMIECBAgAABAuMIKGbjKDmGAAECBAgQILAGAorZGiD7EQQIECBAgACBcQQUs3GUHEOAAAECBAgQWAOB/wWN7q2v3CTMUAAAAABJRU5ErkJggg=="
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Add some additional widgets for aesthetic purpose\n",
     "display(widgets.Text(description=\"First:\"))\n",
@@ -1012,21 +764,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAlCAYAAADofyVhAAAGlUlEQVR4Xu3dTUhUbxTH8TMq/JN8wUpBE01RaCe4EFy4CwJbJNpCRQhNggpfwkDDQBCxqKSCwFoKUpQKguDCpdBWaNXKWogvZRSoIGLo3/PADJpz58VmnPvc+d5NkHPPPc/nDMyPe+/c8QkbAggggAACCCCAgCsEfK7ogiYQQAABBBBAAAEEhGDGmwABBBBAAAEEEHCJAMHMJYOgDQQQQAABBBBAgGDGewABBBBAAAEEEHCJgO/Vq1erm5ub/7mkH9rwmMDly5d3bty4ke+xZbEcBBBAAAEE4iLg6+rq2s/MzJQfP37E5QAUTV6BiooKqa+vl/z8fM7MJu/bgJUjgAACCEQh4Lt9+/Z+enq63LlzJ4rdeCkC4QWys7Nlf39fCgoKCGbhuXgFAggggAACYoKZOrx9+xYOBGIqsLq6auoRzGLKSjEEEEAAAQ8LEMw8PNxEL41glugJcHwEEEAAAdsECGa2TcyifglmFg2LVhFAAAEEXCFAMHPFGLzZBMHMm3NlVQgggAAC8RM4FsxmZ2elu7tb1tfXpa6uTl6/fi1nz541HWxvb0tPT4/oTd2/fv2SZ8+eSVZWVqC7ubk56e/vl4mJCbl06dKxrnd3d6Wqqsrsd+XKlYhX5VQ3VK9OxUOt4ST1Il5EEr6QYJaEQ2fJCCCAAAL/JHAkmOkjMzo7O034+vbtmxx8MUBaW1vlxYsX5iDt7e1SXV0tt27dksnJSZmampL379+bv33//l0+ffokDQ0NZt9gwWxoaEhGRkZMcIs0mDnVDderk4rTGk5a75/0Pb4zwczjA2Z5CCCAAAIxFzgSzDRYVVZWij4+Q7fh4WH58OGDfP78WdbW1uTixYvm39zcXNnY2JCcnBxZXFwMhLC9vT1JTU0NGsy09pcvX+TJkyfy5s2biIOZ9hGsbqhenZRCrWF5edlx7TFXT5KCBLMkGTTLRAABBBCImUDIe8zGxsbMmbGZmRlzZqytrc1czvRvBw8ONUHr5s2bgf/z+XzHgtnW1pY8evRIXr58KWVlZVEHMy0erO5hhcO9OulEugbdP5J6MZuCRwsRzDw6WJaFAAIIIBA3gZDB7O7du3L9+nW5evWquS9Mg5WeWfJv5eXlJqw9fPgwZDDT+84OfmFA8vLy4hbMDvfqpBXpGnT/SOrFbSoeKUww88ggWQYCCCCAwKkJOAYz/VDt6+szZ450e/78uYyOjppLl/6tuLhYOjo65MGDB47BTM+2paSkyLVr18xr4nHG7O9enfQiXUOk9U5tSpYeiGBm6eBoGwEEEEAgYQJBg5n+jE5vb6+5/Oj/1qVeBtQQ9vPnz0Cz586dM9/abG5udgxmNTU15t4y//b792/JyMgwoe/wmTatczjgaQDUe9r8m9OlzGC96j7B6s3Pz4ddg1O9hE3I4gMTzCweHq0jgAACCCREIGgw029h6qMySkpKAk3pjfNFRUWiH7bnz583j8u4cOGCLC0thQxQ+tiNnZ2dQB0Nao8fP5ba2tojj9rQwKbfwPRvemYtLS0tbDAL1qvuFKyehspwa3Cql5DpWH5QgpnlA6R9BBBAAIFTFzgWzPQ+Mg1kFRUV5geoFxYW9LcOzWMympqazD1njY2N8vHjR5menpZ3794FmtbX62XLr1+/Hgl1h1d1kkuZTnVD9eokGWoNJ6l36hOz6IAEM4uGRasIIIAAAq4QOBLMNJjcv3//SGN6Vkw/YPXslZ6F0meclZaWysrKijx9+tRcltRtc3NTxsfHzU3zAwMDcu/ePfNYjb+3aIOZU91wvTrpOq3hpPVcMUWXNkEwc+lgaAsBBBBAwLUC/CSTa0djf2MEM/tnyAoQQAABBE5XgGB2ut5JdTSCWVKNm8UigAACCMRAgGAWA0RKBBcgmPHOQAABBBBAIDoBgll0Xrw6CgGCWRRYvBQBBBBAAIEDAYIZb4O4CRDM4kZLYQQQQAABjwoQzDw6WDcsi2DmhinQAwIIIICATQIEM5umZVmvBDPLBka7CCCAAAIJFzDBrLCw0Dx/jA2BWArs7e3Jnz9/9AHFvljWpRYCCCCAAAJeFfANDg7ut7S0yJkzZ7y6RtaVIAH9fdPU1FTJy8sjmCVoBhwWAQQQQMAuAT4w7ZoX3SKAAAIIIICAhwUIZh4eLktDAAEEEEAAAbsECGZ2zYtuEUAAAQQQQMDDAgQzDw+XpSGAAAIIIICAXQIEM7vmRbcIIIAAAggg4GEBgpmHh8vSEEAAAQQQQMAugf8BAuIGU6Qekv8AAAAASUVORK5CYII="
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_widget = DateWidget()\n",
     "display(my_widget)\n",
@@ -1038,7 +780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -1050,7 +792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -1062,25 +804,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'2014-12-02'"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_widget.value"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/File Upload Widget.ipynb
+++ b/examples/File Upload Widget.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -31,6 +31,8 @@
    "source": [
     "class FileWidget(widgets.DOMWidget):\n",
     "    _view_name = Unicode('FilePickerView').tag(sync=True)\n",
+    "    _view_module = Unicode('filepicker').tag(sync=True)\n",
+    "\n",
     "    value = Unicode().tag(sync=True)\n",
     "    filename = Unicode().tag(sync=True)\n",
     "    \n",
@@ -61,74 +63,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "require([\"jupyter-js-widgets\"], function(widgets) {\n",
-       "\n",
-       "    var FilePickerView = widgets.DOMWidgetView.extend({\n",
-       "\n",
-       "        render: function() {\n",
-       "            // Render the view.\n",
-       "            this.setElement($('<input />')\n",
-       "                .attr('type', 'file'));\n",
-       "        },\n",
-       "        \n",
-       "        events: {\n",
-       "            // List of events and their handlers.\n",
-       "            'change': 'handle_file_change',\n",
-       "        },\n",
-       "       \n",
-       "        handle_file_change: function(evt) { \n",
-       "            // Handle when the user has changed the file.\n",
-       "            \n",
-       "            // Retrieve the first (and only!) File from the FileList object\n",
-       "            var file = evt.target.files[0];\n",
-       "            if (file) {\n",
-       "\n",
-       "                // Read the file's textual content and set value to those contents.\n",
-       "                var that = this;\n",
-       "                var file_reader = new FileReader();\n",
-       "                file_reader.onload = function(e) {\n",
-       "                    that.model.set('value', e.target.result);\n",
-       "                    that.touch();\n",
-       "                }\n",
-       "                file_reader.readAsText(file);\n",
-       "            } else {\n",
-       "\n",
-       "                // The file couldn't be opened.  Send an error msg to the\n",
-       "                // back-end.\n",
-       "                this.send({ 'event': 'error' });\n",
-       "            }\n",
-       "\n",
-       "            // Set the filename of the file.\n",
-       "            this.model.set('filename', file.name);\n",
-       "            this.touch();\n",
-       "        },\n",
-       "    });\n",
-       "        \n",
-       "    // Register the FilePickerView with the widget manager.\n",
-       "    widgets.ManagerBase.register_widget_view('FilePickerView', FilePickerView);\n",
-       "});"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
     "\n",
-    "require([\"jupyter-js-widgets\"], function(widgets) {\n",
+    "requirejs.undef('filepicker');\n",
+    "\n",
+    "define('filepicker', [\"jupyter-js-widgets\"], function(widgets) {\n",
     "\n",
     "    var FilePickerView = widgets.DOMWidgetView.extend({\n",
     "\n",
@@ -170,9 +115,10 @@
     "            this.touch();\n",
     "        },\n",
     "    });\n",
-    "        \n",
-    "    // Register the FilePickerView with the widget manager.\n",
-    "    widgets.ManagerBase.register_widget_view('FilePickerView', FilePickerView);\n",
+    "    \n",
+    "    return {\n",
+    "        FilePickerView: FilePickerView\n",
+    "    };  \n",
     "});"
    ]
   },
@@ -185,21 +131,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAhCAYAAABz7md3AAAByElEQVR4Xu3WMREAAAwCseLfdG38kCrgUgZ2jgABAgQIECBAICGwRAohCBAgQIAAAQIEzjBTAgIECBAgQIBARMAwizxCDAIECBAgQICAYaYDBAgQIECAAIGIgGEWeYQYBAgQIECAAAHDTAcIECBAgAABAhEBwyzyCDEIECBAgAABAoaZDhAgQIAAAQIEIgKGWeQRYhAgQIAAAQIEDDMdIECAAAECBAhEBAyzyCPEIECAAAECBAgYZjpAgAABAgQIEIgIGGaRR4hBgAABAgQIEDDMdIAAAQIECBAgEBEwzCKPEIMAAQIECBAgYJjpAAECBAgQIEAgImCYRR4hBgECBAgQIEDAMNMBAgQIECBAgEBEwDCLPEIMAgQIECBAgIBhpgMECBAgQIAAgYiAYRZ5hBgECBAgQIAAAcNMBwgQIECAAAECEQHDLPIIMQgQIECAAAEChpkOECBAgAABAgQiAoZZ5BFiECBAgAABAgQMMx0gQIAAAQIECEQEDLPII8QgQIAAAQIECBhmOkCAAAECBAgQiAgYZpFHiEGAAAECBAgQMMx0gAABAgQIECAQETDMIo8QgwABAgQIECBgmOkAAQIECBAgQCAi8EZMACLC2F2RAAAAAElFTkSuQmCC"
-     },
-     "metadata": {
-      "isWidgetSnapshot": true
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "file_widget = FileWidget()\n",
     "\n",
@@ -225,6 +161,15 @@
     "\n",
     "file_widget"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -235,23 +180,37 @@
    ]
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3+"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  },
+  "widgets": {
+   "48391923bea543fd8c12ca0e10cec8a8": {
+    "model_module": "jupyter-js-widgets",
+    "model_name": "LayoutModel",
+    "state": {},
+    "views": []
+   },
+   "af7d1336864743bd8ed68f04df35fd4b": {
+    "model_module": "jupyter-js-widgets",
+    "model_name": "DOMWidgetModel",
+    "state": {},
+    "views": []
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -13,8 +13,8 @@ from warnings import warn # TODO: Remove when traitlet deprection is removed pos
 class DOMWidget(Widget):
     """Widget that can be inserted into the DOM"""
 
-    _model_name = Unicode('DOMWidgetModel', help="""Name of the backbone model
-        registered in the front-end to create and sync this widget with.""").tag(sync=True)
+    _model_name = Unicode('DOMWidgetModel').tag(sync=True)
+
     visible = Bool(True, allow_none=True, help="Whether the widget is visible.  False collapses the empty space, while None preserves the empty space.").tag(sync=True)  # TODO: Deprecated in ipywidgets 5.0
     _dom_classes = Tuple(help="DOM classes applied to widget.$el.").tag(sync=True)
 

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -148,11 +148,11 @@ class Widget(LoggingConfigurable):
     #-------------------------------------------------------------------------
     # Traits
     #-------------------------------------------------------------------------
-    _model_module = Unicode(None, allow_none=True, help="""A requirejs module name
+    _model_module = Unicode('jupyter-js-widgets', help="""A requirejs module name
         in which to find _model_name. If empty, look in the global registry.""").tag(sync=True)
     _model_name = Unicode('WidgetModel', help="""Name of the backbone model
         registered in the front-end to create and sync this widget with.""").tag(sync=True)
-    _view_module = Unicode(help="""A requirejs module in which to find _view_name.
+    _view_module = Unicode(None, allow_none=True, help="""A requirejs module in which to find _view_name.
         If empty, look in the global registry.""").tag(sync=True)
     _view_name = Unicode(None, allow_none=True, help="""Default view registered in the front-end
         to use to represent the widget.""").tag(sync=True)


### PR DESCRIPTION
This makes the custom widget example notebooks work despite the removal of the registry. It was actually rather simple, using `define` and `requirejs.undef`.