### PR TITLE
Add jupyter client as a build req for the notebook files

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+jupyter_client
 sphinx==1.3.6
 jupyter_sphinx_theme==0.0.6


### PR DESCRIPTION
@willingc I'm seeing a `jupyter_client` missing dependency error on RTD.  I'm not quite sure what of nbsphinx is triggering the error.  Let me know if you see it too.  If you do, we'll add it to the sphinx theme.