### PR TITLE
Add support for conda builds on RTD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,14 @@
+name: ipywidget_docs
+dependencies:
+- python=3.5
+- sphinx_rtd_theme
+- jinja2
+- tornado
+- nbformat
+- jupyter_client
+- ipykernel
+- ipywidgets
+- pip:
+  - sphinx==1.3.6
+  - nbsphinx
+  - jupyter_sphinx_theme==0.0.6

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,4 @@
+conda:
+    file: docs/environment.yml
+python:
+    version: 3


### PR DESCRIPTION
@jdfreder As discussed. Rendered on my [test version](https://test-widgets.readthedocs.org/en/conda-rtd/index.html)

It looks like the move of examples broke some links to images. Let me know if you need help with that.