### PR TITLE
Add missing displayed event trigger in embed manager

### DIFF
--- a/jupyter-js-widgets/src/embed-manager.js
+++ b/jupyter-js-widgets/src/embed-manager.js
@@ -15,6 +15,7 @@ EmbedManager.prototype.display_widget_state = function(models, el) {
 EmbedManager.prototype.display_view = function(msg, view, options) {
     return Promise.resolve(view).then(function(view) {
         options.el.appendChild(view.el);
+        view.trigger('displayed');
         view.on('remove', function() {
             console.log('View removed', view);
         });


### PR DESCRIPTION
The embed manager was missing the 'displayed' event triggering.