### PR TITLE
Use wheel `data_files`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ or
 
 Then run
 
-    jupyter nbextension install --py widgetsnbextension
     jupyter nbextension enable --py widgetsnbextension
 
 See the [Installation](docs/source/user_install.md) section of the documentation for additional details.

--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -28,8 +28,8 @@ available in the PATH used with sudo.
         npm run update:widgets
         pip install -v -e .
         cd ..
-        jupyter nbextension install --py --symlink widgetsnbextension
-        jupyter nbextension enable --py widgetsnbextension
+        jupyter nbextension install --py --symlink --user widgetsnbextension
+        jupyter nbextension enable --py --user widgetsnbextension
 
 3. Dev-install of the package (run from ipywidgets repo directory):
 

--- a/widgetsnbextension/setup.py
+++ b/widgetsnbextension/setup.py
@@ -202,6 +202,12 @@ setup_args = dict(
         'sdist': js_prerelease(sdist, strict=True),
         'jsdeps': NPM,
     },
+    data_files      = [(
+            'share/jupyter/nbextensions/jupyter-js-widgets', [
+                'widgetsnbextension/static/extension.js',
+                'widgetsnbextension/static/extension.js.map'
+        ]),
+    ],
     include_package_data = True,
 )
 


### PR DESCRIPTION
The `widgetsnbextension` package is a package that does not have the ipywidgets' python. All it does is installing the `jupyter-js-widgets` nbextension on the notebook server.

The problem with the new notebook nbextension mechanism is that it does not handle dependencies. For example, if you do `pip install [bqplot/pythreejs/ipyleaflet]`, then the `widgetsnbextension` package gets installed as a dependency, but the nbextension package is not installed. 

One must then do

```
jupyter nbextension install --py widgetsnbextension
jupyter nbextension enable --py widgetsnbextension
jupyter nbextension install --py [bqplot/pythreejs/ipyleaflet]
jupyter nbextension enable --py [bqplot/pythreejs/ipyleaflet]
```

wouhou, a **5 steps** installation!

What this does is make the `jupyter-js-widgets` nbextension a `data_file` attribute of the wheel. So that the installation of the nbextension is just a byproduct of the one of the widgetsnbextension python package, and pip's dependency installation takes care of it.

Now the only thing that we need to do in **notebook** side is enable a list of dependency to also *enable* when you enable an extension. 