### PR TITLE
Scrolls and mousedowns dismiss dropdown.

### DIFF
--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -430,7 +430,7 @@ ul.widget-dropdown-droplist {
     list-style-type: none;
     position: absolute;
     margin: 0;
-    z-index: 2; /* This might not be necessary once Bootstrap is gone. */
+    z-index: 101; /* This is to appear above the #header */
     width : @widget-width;
     padding: 0;
     height: auto;

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -216,7 +216,7 @@ var DropdownView = widget.DOMWidgetView.extend({
         // Close the drop list.
         this.droplist.classList.remove('mod-active');
         // Remove global keydown listener.
-        document.removeEventListener('keydown', this.keydown);
+        document.removeEventListener('keydown', this.onKeydown);
         // Remove global click listener.
         document.removeEventListener('click', this.onDismiss);
         // Remove global scroll listener.
@@ -338,7 +338,7 @@ var DropdownView = widget.DOMWidgetView.extend({
             // Close the drop list.
             this.droplist.classList.remove('mod-active');
             // Remove global keydown listener.
-            document.removeEventListener('keydown', this.keydown);
+            document.removeEventListener('keydown', this.onKeydown);
             // Remove global click listener.
             document.removeEventListener('click', this.onDismiss);
             // Remove global scroll listener.

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -217,8 +217,10 @@ var DropdownView = widget.DOMWidgetView.extend({
         this.droplist.classList.remove('mod-active');
         // Remove global keydown listener.
         document.removeEventListener('keydown', this.keydown);
+        // Remove global click listener.
+        document.removeEventListener('click', this.onDismiss);
         // Remove global scroll listener.
-        window.removeEventListener('scroll', this.scroll);
+        window.removeEventListener('scroll', this.onDismiss);
         return;
     },
 
@@ -337,8 +339,10 @@ var DropdownView = widget.DOMWidgetView.extend({
             this.droplist.classList.remove('mod-active');
             // Remove global keydown listener.
             document.removeEventListener('keydown', this.keydown);
+            // Remove global click listener.
+            document.removeEventListener('click', this.onDismiss);
             // Remove global scroll listener.
-            window.removeEventListener('scroll', this.scroll);
+            window.removeEventListener('scroll', this.onDismiss);
             return;
         }
 

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -193,8 +193,8 @@ var DropdownView = widget.DOMWidgetView.extend({
         var dropdownEvent;
         while (node !== document.documentElement) {
             dropdownEvent = node === this.droplist ||
-                node === this.droplabel || // This is only relevant for clicks.
-                node === this.dropbutton;  // This is only relevant for clicks.
+                node === this.droplabel || // This is relevant for mousedowns.
+                node === this.dropbutton;  // This is relevant for mousedowns.
             if (dropdownEvent) {
                 return;
             }
@@ -204,7 +204,7 @@ var DropdownView = widget.DOMWidgetView.extend({
         // despite the drop list being invisible, remove all global listeners.
         if (!this.droplist.classList.contains('mod-active')) {
             document.removeEventListener('keydown', this.onKeydown);
-            document.removeEventListener('click', this.onDismiss);
+            document.removeEventListener('mousedown', this.onDismiss);
             window.removeEventListener('scroll', this.onDismiss);
             return;
         }
@@ -217,8 +217,8 @@ var DropdownView = widget.DOMWidgetView.extend({
         this.droplist.classList.remove('mod-active');
         // Remove global keydown listener.
         document.removeEventListener('keydown', this.onKeydown);
-        // Remove global click listener.
-        document.removeEventListener('click', this.onDismiss);
+        // Remove global mousedown listener.
+        document.removeEventListener('mousedown', this.onDismiss);
         // Remove global scroll listener.
         window.removeEventListener('scroll', this.onDismiss);
         return;
@@ -236,7 +236,7 @@ var DropdownView = widget.DOMWidgetView.extend({
         // despite the drop list being invisible, remove all global listeners.
         if (!this.droplist.classList.contains('mod-active')) {
             document.removeEventListener('keydown', this.onKeydown);
-            document.removeEventListener('click', this.onDismiss);
+            document.removeEventListener('mousedown', this.onDismiss);
             window.removeEventListener('scroll', this.onDismiss);
             return;
         }
@@ -339,8 +339,8 @@ var DropdownView = widget.DOMWidgetView.extend({
             this.droplist.classList.remove('mod-active');
             // Remove global keydown listener.
             document.removeEventListener('keydown', this.onKeydown);
-            // Remove global click listener.
-            document.removeEventListener('click', this.onDismiss);
+            // Remove global mousedown listener.
+            document.removeEventListener('mousedown', this.onDismiss);
             // Remove global scroll listener.
             window.removeEventListener('scroll', this.onDismiss);
             return;
@@ -348,8 +348,8 @@ var DropdownView = widget.DOMWidgetView.extend({
 
         // Add a global keydown listener for drop list events.
         document.addEventListener('keydown', this.onKeydown);
-        // Add a global click listener to dismiss drop list.
-        document.addEventListener('click', this.onDismiss, true);
+        // Add a global mousedown listener to dismiss drop list.
+        document.addEventListener('mousedown', this.onDismiss, true);
         // Add a global scroll listener to dismiss drop list.
         window.addEventListener('scroll', this.onDismiss, true); // useCapture
 


### PR DESCRIPTION
This PR resolves https://github.com/ipython/ipywidgets/issues/466

- [x] `window` `scroll` events dismiss a dropdown (which is similar to native behavior).
- [x] `document` `mousedown` events dismiss a dropdown (which is similar to native behavior).
- [x] Bugfix: drop list `max-height` and `top` were calculated incorrectly on some occasions.

cc: @SylvainCorlay @jdfreder @jasongrout