### PR TITLE
Fix Slider Readout: add formatter and prevent overflow of readout box.

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -151,6 +151,7 @@
     "    step=0.1,\n",
     "    description='Test',\n",
     "    orientation='vertical',\n",
+    "    readout_format='.3f'\n",
     ")"
    ]
   },

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -124,7 +124,8 @@ class FloatSlider(_BoundedFloat):
         default is True, display the current value of the slider next to it
     readout_format : str
         default is '.2f', specifier for the format function used to represent
-        slider value as a string in the readout.
+        slider value for human consumption, modeled after Python 3’s format
+        specification mini-language (PEP 3101).
     slider_color : str Unicode color code (eg. '#C13535')
         color of the slider
     color : str Unicode color code (eg. '#C13535')
@@ -256,6 +257,10 @@ class FloatRangeSlider(_BoundedFloatRange):
         default is 'horizontal'
     readout : {True, False}
         default is True, display the current value of the slider next to it
+    readout_format : str
+        default is '.2f', specifier for the format function used to represent
+        slider value for human consumption, modeled after Python 3’s format
+        specification mini-language (PEP 3101).
     slider_color : str Unicode color code (eg. '#C13535')
         color of the slider
     color : str Unicode color code (eg. '#C13535')

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -9,7 +9,7 @@ Represents an unbounded float using a widget.
 from .domwidget import DOMWidget
 from .widget import register
 from .trait_types import Color
-from traitlets import (Unicode, CFloat, Bool, CaselessStrEnum,
+from traitlets import (Unicode, CFloat, Bool, Int, CaselessStrEnum,
                        Tuple, TraitError, validate)
 
 
@@ -64,74 +64,78 @@ class _BoundedFloat(_Float):
 @register('Jupyter.FloatText')
 class FloatText(_Float):
     """ Displays a float value within a textbox. For a textbox in
-	which the value must be within a specific range, use BoundedFloatText.
+    which the value must be within a specific range, use BoundedFloatText.
 
-	Parameters
-	----------
-	value : float
-	    value displayed
-	description : str
-	    description displayed next to the text box
-	color : str Unicode color code (eg. '#C13535'), optional
-	    color of the value displayed
+    Parameters
+    ----------
+    value : float
+        value displayed
+    description : str
+        description displayed next to the text box
+    color : str Unicode color code (eg. '#C13535'), optional
+        color of the value displayed
     """
     _view_name = Unicode('FloatTextView').tag(sync=True)
-    _model_name = Unicode('IntTextModel').tag(sync=True)
+    _model_name = Unicode('FloatTextModel').tag(sync=True)
 
 
 @register('Jupyter.BoundedFloatText')
 class BoundedFloatText(_BoundedFloat):
     """ Displays a float value within a textbox. Value must be within the range specified.
-	For a textbox in which the value doesn't need to be within a specific range, use FloatText.
 
-	Parameters
-	----------
-	value : float
-	    value displayed
-	min : float
-	    minimal value of the range of possible values displayed
-	max : float
-	    maximal value of the range of possible values displayed
-	description : str
-	    description displayed next to the textbox
-	color : str Unicode color code (eg. '#C13535'), optional
-	    color of the value displayed
+    For a textbox in which the value doesn't need to be within a specific range, use FloatText.
+
+    Parameters
+    ----------
+    value : float
+        value displayed
+    min : float
+        minimal value of the range of possible values displayed
+    max : float
+        maximal value of the range of possible values displayed
+    description : str
+        description displayed next to the textbox
+    color : str Unicode color code (eg. '#C13535'), optional
+        color of the value displayed
     """
     _view_name = Unicode('FloatTextView').tag(sync=True)
-    _model_name = Unicode('IntTextModel').tag(sync=True)
+    _model_name = Unicode('FloatTextModel').tag(sync=True)
 
 
 @register('Jupyter.FloatSlider')
 class FloatSlider(_BoundedFloat):
     """ Slider/trackbar of floating values with the specified range.
 
-	Parameters
-	----------
-	value : float
-	    position of the slider
-	min : float
-	    minimal position of the slider
-	max : float
-	    maximal position of the slider
-	step : float
-	    step of the trackbar
-	description : str
-	    name of the slider
-	orientation : {'vertical', 'horizontal}, optional
-        default is horizontal
-	readout : {True, False}, optional
-	    default is True, display the current value of the slider next to it
-	slider_color : str Unicode color code (eg. '#C13535'), optional
-	    color of the slider
-	color : str Unicode color code (eg. '#C13535'), optional
-	    color of the value displayed (if readout == True)
+    Parameters
+    ----------
+    value : float
+        position of the slider
+    min : float
+        minimal position of the slider
+    max : float
+        maximal position of the slider
+    step : float
+        step of the trackbar
+    description : str
+        name of the slider
+    orientation : {'horizontal', 'vertical'}, optional
+        default is 'horizontal', orientation of the slider
+    readout : {True, False}, optional
+        default is True, display the current value of the slider next to it
+    readout_precision : int, optional
+        default is True, display the current value of the slider next to it
+    slider_color : str Unicode color code (eg. '#C13535'), optional
+        color of the slider
+    color : str Unicode color code (eg. '#C13535'), optional
+        color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView').tag(sync=True)
-    _model_name = Unicode('IntSliderModel').tag(sync=True)
+    _model_name = Unicode('FloatSliderModel').tag(sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     _range = Bool(False, help="Display a range selector").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
+    readout_precision = Int(5, help="Number of significant digits in readout.").tag(sync=True)
     slider_color = Color(None, allow_none=True).tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 
@@ -143,18 +147,20 @@ class FloatProgress(_BoundedFloat):
     Parameters
     -----------
     value : float
-	    position within the range of the progress bar
+        position within the range of the progress bar
     min : float
-	    minimal position of the slider
+        minimal position of the slider
     max : float
-	    maximal position of the slider
+        maximal position of the slider
     step : float
-	    step of the progress bar
+        step of the progress bar
     description : str
-	    name of the progress bar
+        name of the progress bar
+    orientation : {'horizontal', 'vertical'}, optional
+        default is 'horizontal', orientation of the progress bar
     bar_style: {'success', 'info', 'warning', 'danger', ''}, optional
-	    color of the progress bar, default is '' (blue)
-	    colors are: 'success'-green, 'info'-light blue, 'warning'-orange, 'danger'-red
+        color of the progress bar, default is '' (blue)
+        colors are: 'success'-green, 'info'-light blue, 'warning'-orange, 'danger'-red
     """
     _view_name = Unicode('ProgressView').tag(sync=True)
     _model_name = Unicode('ProgressModel').tag(sync=True)
@@ -233,32 +239,35 @@ class _BoundedFloatRange(_FloatRange):
 class FloatRangeSlider(_BoundedFloatRange):
     """ Slider/trackbar that represents a pair of floats bounded by minimum and maximum value.
 
-	Parameters
-	----------
-	value : float tuple
-	    range of the slider displayed
-	min : float
-	    minimal position of the slider
-	max : float
-	    maximal position of the slider
-	step : float
-	    step of the trackbar
-	description : str
-	    name of the slider
-	orientation : {'vertical', 'horizontal}, optional
-            default is horizontal
-	readout : {True, False}, optional
-	    default is True, display the current value of the slider next to it
-	slider_color : str Unicode color code (eg. '#C13535'), optional
-	    color of the slider
-	color : str Unicode color code (eg. '#C13535'), optional
-	    color of the value displayed (if readout == True)
+    Parameters
+    ----------
+    value : float tuple
+        range of the slider displayed
+    min : float
+        minimal position of the slider
+    max : float
+        maximal position of the slider
+    step : float
+        step of the trackbar
+    description : str
+        name of the slider
+    orientation : {'horizontal', 'vertical'}, optional
+        default is 'horizontal'
+    readout : {True, False}, optional
+        default is True, display the current value of the slider next to it
+    readout_precision : int, optional
+        default is 5, display the current value of the slider next to it
+    slider_color : str Unicode color code (eg. '#C13535'), optional
+        color of the slider
+    color : str Unicode color code (eg. '#C13535'), optional
+        color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView').tag(sync=True)
-    _model_name = Unicode('IntSliderModel').tag(sync=True)
+    _model_name = Unicode('FloatSliderModel').tag(sync=True)
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     _range = Bool(True, help="Display a range selector").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
+    readout_precision = Int(5, help="Number of significant digits in readout.").tag(sync=True)
     slider_color = Color(None, allow_none=True).tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -72,7 +72,7 @@ class FloatText(_Float):
         value displayed
     description : str
         description displayed next to the text box
-    color : str Unicode color code (eg. '#C13535'), optional
+    color : str Unicode color code (eg. '#C13535')
         color of the value displayed
     """
     _view_name = Unicode('FloatTextView').tag(sync=True)
@@ -95,7 +95,7 @@ class BoundedFloatText(_BoundedFloat):
         maximal value of the range of possible values displayed
     description : str
         description displayed next to the textbox
-    color : str Unicode color code (eg. '#C13535'), optional
+    color : str Unicode color code (eg. '#C13535')
         color of the value displayed
     """
     _view_name = Unicode('FloatTextView').tag(sync=True)
@@ -118,15 +118,16 @@ class FloatSlider(_BoundedFloat):
         step of the trackbar
     description : str
         name of the slider
-    orientation : {'horizontal', 'vertical'}, optional
+    orientation : {'horizontal', 'vertical'}
         default is 'horizontal', orientation of the slider
-    readout : {True, False}, optional
+    readout : {True, False}
         default is True, display the current value of the slider next to it
-    readout_precision : int, optional
-        default is True, display the current value of the slider next to it
-    slider_color : str Unicode color code (eg. '#C13535'), optional
+    readout_format : str
+        default is '.2f', specifier for the format function used to represent
+        slider value as a string in the readout.
+    slider_color : str Unicode color code (eg. '#C13535')
         color of the slider
-    color : str Unicode color code (eg. '#C13535'), optional
+    color : str Unicode color code (eg. '#C13535')
         color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView').tag(sync=True)
@@ -135,7 +136,7 @@ class FloatSlider(_BoundedFloat):
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     _range = Bool(False, help="Display a range selector").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
-    readout_precision = Int(5, help="Number of significant digits in readout.").tag(sync=True)
+    readout_format = Unicode('.2f', help="Format for the readout").tag(sync=True)
     slider_color = Color(None, allow_none=True).tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 
@@ -156,9 +157,9 @@ class FloatProgress(_BoundedFloat):
         step of the progress bar
     description : str
         name of the progress bar
-    orientation : {'horizontal', 'vertical'}, optional
+    orientation : {'horizontal', 'vertical'}
         default is 'horizontal', orientation of the progress bar
-    bar_style: {'success', 'info', 'warning', 'danger', ''}, optional
+    bar_style: {'success', 'info', 'warning', 'danger', ''}
         color of the progress bar, default is '' (blue)
         colors are: 'success'-green, 'info'-light blue, 'warning'-orange, 'danger'-red
     """
@@ -251,15 +252,13 @@ class FloatRangeSlider(_BoundedFloatRange):
         step of the trackbar
     description : str
         name of the slider
-    orientation : {'horizontal', 'vertical'}, optional
+    orientation : {'horizontal', 'vertical'}
         default is 'horizontal'
-    readout : {True, False}, optional
+    readout : {True, False}
         default is True, display the current value of the slider next to it
-    readout_precision : int, optional
-        default is 5, display the current value of the slider next to it
-    slider_color : str Unicode color code (eg. '#C13535'), optional
+    slider_color : str Unicode color code (eg. '#C13535')
         color of the slider
-    color : str Unicode color code (eg. '#C13535'), optional
+    color : str Unicode color code (eg. '#C13535')
         color of the value displayed (if readout == True)
     """
     _view_name = Unicode('FloatSliderView').tag(sync=True)
@@ -268,6 +267,5 @@ class FloatRangeSlider(_BoundedFloatRange):
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     _range = Bool(True, help="Display a range selector").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
-    readout_precision = Int(5, help="Number of significant digits in readout.").tag(sync=True)
     slider_color = Color(None, allow_none=True).tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -150,6 +150,7 @@ class IntSlider(_BoundedInt):
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     _range = Bool(False, help="Display a range selector").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
+    readout_format = Unicode('d', help="Format for the readout").tag(sync=True)
     slider_color = Color(None, allow_none=True).tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 

--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -575,14 +575,24 @@ ul.widget-dropdown-droplist {
     }
 
     .widget-readout {
+        /* Horizontal Readout */
         padding-left   : 4px;
         padding-top    : 5px;
+        height         : 32px;
         text-align     : center;
         vertical-align : text-top;
         min-width      : 7em;
         max-width      : 7em;
+        margin-left    : 3px;
+        overflow       : hidden;
+        white-space    : nowrap;
+    }
 
-        word-wrap: break-word;
+    .widget-readout.overflow {
+        /* Overflowing Readout */
+        -webkit-box-shadow: 0px 0px 0px 1px rgba(77,0,0,0.15);
+        -moz-box-shadow: 0px 0px 0px 1px rgba(77,0,0,0.15);
+        box-shadow: 0px 0px 0px 1px rgba(77,0,0,0.15);
     }
 }
 
@@ -603,12 +613,21 @@ ul.widget-dropdown-droplist {
     }
 
     .widget-readout {
-        /* Vertical Label */
-        padding-top : 5px;
+        /* Vertical Readout */
+        padding-top    : 5px;
+        white-space    : nowrap;
         text-align     : center;
         vertical-align : text-top;
+        margin-top     : 4px;
+        overflow       : hidden;
     }
 
+    .widget-readout.overflow {
+        /* Overflowing Readout */
+        -webkit-box-shadow: 0px 0px 0px 1px rgba(77,0,0,0.15);
+        -moz-box-shadow: 0px 0px 0px 1px rgba(77,0,0,0.15);
+        box-shadow: 0px 0px 0px 1px rgba(77,0,0,0.15);
+    }
 }
 
 

--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -579,8 +579,8 @@ ul.widget-dropdown-droplist {
         padding-top    : 5px;
         text-align     : center;
         vertical-align : text-top;
-        min-width      : 4em;
-        max-width      : 4em;
+        min-width      : 7em;
+        max-width      : 7em;
 
         word-wrap: break-word;
     }

--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -63,8 +63,10 @@
   "dependencies": {
     "backbone": "1.2.0",
     "bootstrap": "^3.3.5",
+    "d3-format": "^0.5.1",
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
+    "lolex": "^1.4.0",
     "phosphor-tabs": "^1.0.0-rc.2",
     "phosphor-widget": "^1.0.0-rc.1",
     "scriptjs": "^2.5.8",

--- a/jupyter-js-widgets/src/widget_float.js
+++ b/jupyter-js-widgets/src/widget_float.js
@@ -5,6 +5,7 @@
 var _ = require('underscore');
 var widget = require('./widget');
 var int_widgets = require('./widget_int');
+var d3format = require('d3-format').format;
 
 
 var FloatModel = widget.DOMWidgetModel.extend({
@@ -34,7 +35,7 @@ var FloatSliderModel = BoundedFloatModel.extend({
         orientation: "horizontal",
         _range: false,
         readout: true,
-        readout_precision: 5,
+        readout_format: '.2f',
         slider_color: null,
         continuous_update: true
     }),
@@ -57,23 +58,6 @@ var FloatSliderView = IntSliderView.extend({
          */
         return x;
     },
-
-    /**
-     * Write value to a string
-     * @param  {number|number[]} value
-     * @return {string}
-     */
-    valueToString: function(value) {
-        if (this.model.get('_range')) {
-            var that = this;
-            return value.map(function(v) {
-                return v.toPrecision(that.model.get('readout_precision'));
-            }).join("-");
-        } else {
-            return value.toPrecision(this.model.get('readout_precision'));
-        }
-    },
-
 });
 
 

--- a/jupyter-js-widgets/src/widget_float.js
+++ b/jupyter-js-widgets/src/widget_float.js
@@ -2,8 +2,44 @@
 // Distributed under the terms of the Modified BSD License.
 'use strict';
 
+var _ = require('underscore');
 var widget = require('./widget');
 var int_widgets = require('./widget_int');
+
+
+var FloatModel = widget.DOMWidgetModel.extend({
+    defaults: _.extend({}, widget.DOMWidgetModel.prototype.defaults, {
+        _model_name: "FloatModel",
+        value: 0,
+        disabled: false,
+        description: ""
+    }),
+});
+
+
+var BoundedFloatModel = FloatModel.extend({
+    defaults: _.extend({}, FloatModel.prototype.defaults, {
+        _model_name: "BoundedFloatModel",
+        step: 1.0,
+        max: 100.0,
+        min: 0.0
+    }),
+});
+
+
+var FloatSliderModel = BoundedFloatModel.extend({
+    defaults: _.extend({}, BoundedFloatModel.prototype.defaults, {
+        _model_name: "FloatSliderModel",
+        _view_name: "FloatSliderView",
+        orientation: "horizontal",
+        _range: false,
+        readout: true,
+        readout_precision: 5,
+        slider_color: null,
+        continuous_update: true
+    }),
+});
+
 
 var IntSliderView = int_widgets.IntSliderView;
 var IntTextView = int_widgets.IntTextView;
@@ -21,6 +57,31 @@ var FloatSliderView = IntSliderView.extend({
          */
         return x;
     },
+
+    /**
+     * Write value to a string
+     * @param  {number|number[]} value
+     * @return {string}
+     */
+    valueToString: function(value) {
+        if (this.model.get('_range')) {
+            var that = this;
+            return value.map(function(v) {
+                return v.toPrecision(that.model.get('readout_precision'));
+            }).join("-");
+        } else {
+            return value.toPrecision(this.model.get('readout_precision'));
+        }
+    },
+
+});
+
+
+var FloatTextModel = FloatModel.extend({
+    defaults: _.extend({}, FloatModel.prototype.defaults, {
+        _model_name: "FloatTextModel",
+        _view_name: "FloatTextView"
+    }),
 });
 
 var FloatTextView = IntTextView.extend({
@@ -28,6 +89,8 @@ var FloatTextView = IntTextView.extend({
 });
 
 module.exports = {
+    FloatSliderModel: FloatSliderModel,
+    FloatTextModel: FloatTextModel,
     FloatSliderView: FloatSliderView,
     FloatTextView: FloatTextView
 };

--- a/jupyter-js-widgets/src/widget_float.js
+++ b/jupyter-js-widgets/src/widget_float.js
@@ -39,6 +39,16 @@ var FloatSliderModel = BoundedFloatModel.extend({
         slider_color: null,
         continuous_update: true
     }),
+
+    initialize: function () {
+        FloatSliderModel.__super__.initialize.apply(this, arguments);
+        this.on('change:readout_format', this.update_readout_format, this);
+        this.update_readout_format();
+    },
+
+    update_readout_format: function() {
+        this.readout_formatter = d3format(this.get('readout_format'));
+    }
 });
 
 
@@ -68,9 +78,11 @@ var FloatTextModel = FloatModel.extend({
     }),
 });
 
+
 var FloatTextView = IntTextView.extend({
     _parse_value: parseFloat
 });
+
 
 module.exports = {
     FloatSliderModel: FloatSliderModel,

--- a/jupyter-js-widgets/src/widget_int.js
+++ b/jupyter-js-widgets/src/widget_int.js
@@ -322,10 +322,10 @@ var IntSliderView = widget.DOMWidgetView.extend({
         var actual_value;
         if (this.model.get('_range')) {
             actual_value = ui.values.map(this._validate_slide_value);
-            this.readout.textContent = actual_value.join('-');
+            this.readout.textContent = this.valueToString(actual_value);
         } else {
             actual_value = this._validate_slide_value(ui.value);
-            this.readout.textContent = actual_value;
+            this.readout.textContent = this.valueToString(actual_value);
         }
 
         // Only persist the value while sliding if the continuous_update

--- a/jupyter-js-widgets/src/widget_int.js
+++ b/jupyter-js-widgets/src/widget_int.js
@@ -38,7 +38,17 @@ var IntSliderModel = BoundedIntModel.extend({
         readout_format: 'd',
         slider_color: null,
         continuous_update: true
-    })
+    }),
+
+    initialize: function () {
+        IntSliderModel.__super__.initialize.apply(this, arguments);
+        this.on('change:readout_format', this.update_readout_format, this);
+        this.update_readout_format();
+    },
+
+    update_readout_format: function() {
+        this.readout_formatter = d3format(this.get('readout_format'));
+    }
 });
 
 var IntSliderView = widget.DOMWidgetView.extend({
@@ -231,7 +241,7 @@ var IntSliderView = widget.DOMWidgetView.extend({
      * @return {string}
      */
     valueToString: function(value) {
-        var format = d3format(this.model.get('readout_format'));
+        var format = this.model.readout_formatter;
         if (this.model.get('_range')) {
             return value.map(function (v) {
                 return format(v);


### PR DESCRIPTION
Fixes #526.

This adds a `readout_precision` integer trait attribute to Float Slider and Float Range Slider.

This forced them to have a custom model compared to the Int versions to account for the js-side default value for that attribute.

Also fixed some docs typos.