### PR TITLE
Simplify typeset function.

### DIFF
--- a/jupyter-js-widgets/src/utils.js
+++ b/jupyter-js-widgets/src/utils.js
@@ -156,29 +156,10 @@ function reject(message, log) {
  * text: option string
  */
 function typeset(element, text) {
-    if (arguments.length > 1) {
-        if (element.length) {
-            for (var i = 0; i < element.length; ++i) {
-                var el = element[i];
-                el.textContent = text;
-            }
-        } else {
-            element.textContent = text;
-        }
+    element.textContent = text;
+    if (window.MathJax) {
+      MathJax.Hub.Queue(['Typeset', MathJax.Hub, element]);
     }
-    if (!window.MathJax) {
-      return;
-    }
-    var output = [];
-    if (element.length) {
-        for (var i = 0; i < element.length; ++i) {
-            var el = element[i];
-            output.push(MathJax.Hub.Queue(['Typeset', MathJax.Hub, el]));
-        }
-    } else {
-        output.push(MathJax.Hub.Queue(['Typeset', MathJax.Hub, element]));
-    }
-    return output;
 }
 
 /**

--- a/jupyter-js-widgets/src/utils.js
+++ b/jupyter-js-widgets/src/utils.js
@@ -143,20 +143,19 @@ function reject(message, log) {
 }
 
 /**
- * Apply MathJax rendering to an element, and optionally set its text
+ * Apply MathJax rendering to an element, and optionally set its text.
  *
  * If MathJax is not available, make no changes.
  *
- * Returns the output any number of typeset elements as an array or undefined if
- * MathJax was not available.
- *
  * Parameters
  * ----------
- * element: Node, NodeList, or jQuery selection
- * text: option string
+ * element: Node
+ * text: optional string
  */
 function typeset(element, text) {
-    element.textContent = text;
+    if (text) {
+        element.textContent = text;
+    }
     if (window.MathJax) {
       MathJax.Hub.Queue(['Typeset', MathJax.Hub, element]);
     }

--- a/jupyter-js-widgets/src/utils.js
+++ b/jupyter-js-widgets/src/utils.js
@@ -153,7 +153,7 @@ function reject(message, log) {
  * text: optional string
  */
 function typeset(element, text) {
-    if (text) {
+    if (text !== void 0) {
         element.textContent = text;
     }
     if (window.MathJax) {

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -759,7 +759,7 @@ var DOMWidgetViewMixin = {
     },
 
     typeset: function(element, text){
-        utils.typeset.apply(null, arguments);
+        utils.typeset(element, text);
     }
 };
 


### PR DESCRIPTION
The `typeset` function can be dramatically simplified because we do not pass element collections to it. It was implemented to support collections because it was ported over from a `jQuery` implementation and `jQuery` objects are collections by default. But it is not necessary in the current codebase.

cf. https://github.com/ipython/ipywidgets/issues/544

cc: @jasongrout @SylvainCorlay 