### PR TITLE
A widget must be attached to the DOM before it is typeset.

### DIFF
--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -759,7 +759,7 @@ var DOMWidgetViewMixin = {
     },
 
     typeset: function(element, text){
-        utils.typeset(element, text);
+        this.displayed.then(function() {utils.typeset(element, text);});
     }
 };
 


### PR DESCRIPTION
MathJax needs this so it can measure things related to the font size, etc.

Fixes #550