### PR TITLE
Align-items with stretch by default in HBox and VBox

### DIFF
--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -83,6 +83,7 @@ def VBox(*pargs, **kwargs):
     box = Box(*pargs, **kwargs)
     box.layout.display = 'flex'
     box.layout.flex_flow = 'column'
+    box.layout.align_items = 'stretch'
     return box
 
 
@@ -90,6 +91,7 @@ def HBox(*pargs, **kwargs):
     """Displays multiple widgets horizontally using the flexible box model."""
     box = Box(*pargs, **kwargs)
     box.layout.display = 'flex'
+    box.layout.align_items = 'stretch'
     return box
 
 


### PR DESCRIPTION
As discussed with @jasongrout this is probably the behavior expected when people use the `Box` widget with the `HBox` and `VBox` functions, especially when nesting them...