### PR TITLE
only filter stored snapshots

### DIFF
--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -595,11 +595,18 @@ WidgetManager.prototype.deleteSnapshots = function() {
 
         // Remove the outputs with isWidgetSnapshot: true.
         if (cell.output_area) {
-            // filter out outputs that are snapshots
-            // only touch the data, not the page.
+            // Filter out outputs that are snapshots
+            // Only touch the data, not the page
             cell.output_area.outputs = cell.output_area.outputs.filter(function (output) {
                 return !(output.metadata && output.metadata.isWidgetSnapShot);
             });
+
+            // Remove the corresponding elements from the page
+            cell.output_area.element
+              .find('img.jupyter-widget')
+              .each(function (index, el) {
+                el.remove();
+              });
         }
     }).bind(this));
 };

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -595,12 +595,11 @@ WidgetManager.prototype.deleteSnapshots = function() {
 
         // Remove the outputs with isWidgetSnapshot: true.
         if (cell.output_area) {
-            var outputState = cell.output_area.toJSON();
-            outputState = outputState.filter((function(output) {
-                return !(output.metadata && output.metadata.isWidgetSnapshot);
-            }).bind(this));
-            cell.output_area.clear_output();
-            cell.output_area.fromJSON(outputState);
+            // filter out outputs that are snapshots
+            // only touch the data, not the page.
+            cell.output_area.outputs = cell.output_area.outputs.filter(function (output) {
+                return !(output.metadata && output.metadata.isWidgetSnapShot);
+            });
         }
     }).bind(this));
 };


### PR DESCRIPTION
don't re-render outputs on the page

This should fix the problem of js outputs being re-executed on save.

I was a bit surprised that I didn't have to remove the snapshots from the page, but I don't seem to, because they don't seem to be there when this is called.

cc @SylvainCorlay and @jdfreder for review, in case there's something else needed here.

closes #554