### PR TITLE
Remove deprecated code

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -5,7 +5,7 @@ from .trait_types import Color, EventfulDict, EventfulList
 
 from .widget_bool import Checkbox, ToggleButton, Valid
 from .widget_button import Button
-from .widget_box import Box, FlexBox, Proxy, PlaceProxy, HBox, VBox
+from .widget_box import Box, Proxy, PlaceProxy, HBox, VBox
 from .widget_float import FloatText, BoundedFloatText, FloatSlider, FloatProgress, FloatRangeSlider
 from .widget_image import Image
 from .widget_int import IntText, BoundedIntText, IntSlider, IntProgress, IntRangeSlider
@@ -13,7 +13,7 @@ from .widget_color import ColorPicker
 from .widget_output import Output
 from .widget_selection import RadioButtons, ToggleButtons, Dropdown, Select, SelectionSlider, SelectMultiple
 from .widget_selectioncontainer import Tab, Accordion
-from .widget_string import HTML, Label, Latex, Text, Textarea
+from .widget_string import HTML, Label, Text, Textarea
 from .widget_controller import Controller
 from .interaction import interact, interactive, fixed, interact_manual
 from .widget_link import jslink, jsdlink

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -3,86 +3,23 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import Unicode, Dict, Instance, Bool, List, \
-    CaselessStrEnum, Tuple, CUnicode, Int, Set, observe
+from traitlets import Unicode, Instance, Bool, Tuple
 from .widget import Widget, widget_serialization
 from .trait_types import Color
 from .widget_layout import Layout
-from warnings import warn # TODO: Remove when traitlet deprection is removed post 5.0
+
 
 class DOMWidget(Widget):
     """Widget that can be inserted into the DOM"""
 
     _model_name = Unicode('DOMWidgetModel').tag(sync=True)
 
-    visible = Bool(True, allow_none=True, help="Whether the widget is visible.  False collapses the empty space, while None preserves the empty space.").tag(sync=True)  # TODO: Deprecated in ipywidgets 5.0
+    visible = Bool(True, allow_none=True, help="Whether the widget is visible.  False collapses the empty space, while None preserves the empty space.").tag(sync=True)
     _dom_classes = Tuple(help="DOM classes applied to widget.$el.").tag(sync=True)
 
     layout = Instance(Layout, allow_none=True).tag(sync=True, **widget_serialization)
     def _layout_default(self):
         return Layout()
-
-    width = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    height = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    padding = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    margin = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-
-    color = Color(None, allow_none=True).tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    background_color = Color(None, allow_none=True).tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    border_color = Color(None, allow_none=True).tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-
-    border_width = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    border_radius = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    border_style = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_border-style.asp # TODO: Deprecated in ipywidgets 5.0
-        'none',
-        'hidden',
-        'dotted',
-        'dashed',
-        'solid',
-        'double',
-        'groove',
-        'ridge',
-        'inset',
-        'outset',
-        'initial',
-        'inherit', ''],
-        default_value='').tag(sync=True)
-
-    font_style = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_font_font-style.asp # TODO: Deprecated in ipywidgets 5.0
-        'normal',
-        'italic',
-        'oblique',
-        'initial',
-        'inherit', ''],
-        default_value='').tag(sync=True)
-    font_weight = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_font_weight.asp # TODO: Deprecated in ipywidgets 5.0
-        'normal',
-        'bold',
-        'bolder',
-        'lighter',
-        'initial',
-        'inherit', ''] + list(map(str, range(100,1000,100))),
-        default_value='').tag(sync=True)
-    font_size = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    font_family = Unicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-
-    def __init__(self, *pargs, **kwargs):
-        super(DOMWidget, self).__init__(*pargs, **kwargs)
-
-        # Deprecation added in 5.0.  TODO: Remove me and corresponging traits.
-        self._deprecate_traits(['width', 'height', 'padding', 'margin', 'color',
-        'background_color', 'border_color', 'border_width', 'border_radius',
-        'border_style', 'font_style', 'font_weight', 'font_size', 'font_family',
-        'visible'])
-
-    @observe('border_width', 'border_style', 'border_color')
-    def _update_border(self, change):
-        name, new = change['name'], change['new']
-        if new is not None and new != '':
-            if name != 'border_width' and not self.border_width:
-                self.border_width = 1
-            if name != 'border_style' and self.border_style == '':
-                self.border_style = 'solid'
 
     def add_class(self, className):
         """
@@ -103,8 +40,3 @@ class DOMWidget(Widget):
         if className in self._dom_classes:
             self._dom_classes = [c for c in self._dom_classes if c != className]
         return self
-
-    def _deprecate_traits(self, traits): # TODO: Deprecation added in 5.0.  Remove me and corresponging traits.
-        def traitWarn(change):
-            warn("%s deprecated" % change['name'], DeprecationWarning)
-        self.observe(traitWarn, names=traits)

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -93,24 +93,3 @@ def HBox(*pargs, **kwargs):
     box.layout.display = 'flex'
     box.layout.align_items = 'stretch'
     return box
-
-
-@register('Jupyter.FlexBox')
-class FlexBox(Box): # TODO: Deprecated in 5.0 (entire class)
-    """Displays multiple widgets using the flexible box model."""
-    _view_name = Unicode('FlexBoxView').tag(sync=True)
-    _model_name = Unicode('FlexBoxModel').tag(sync=True)
-    orientation = CaselessStrEnum(values=['vertical', 'horizontal'], default_value='vertical').tag(sync=True)
-    flex = Int(help="""Specify the flexible-ness of the model.""").tag(sync=True)
-    def _flex_changed(self, name, old, new):
-        new = min(max(0, new), 2)
-        if self.flex != new:
-            self.flex = new
-
-    _locations = ['start', 'center', 'end', 'baseline', 'stretch']
-    pack = CaselessStrEnum(values=_locations, default_value='start').tag(sync=True)
-    align = CaselessStrEnum(values=_locations, default_value='start').tag( sync=True)
-
-    def __init__(self, *pargs, **kwargs):
-        warn('FlexBox is deprecated in ipywidgets 5.0.  Use Box and Box.layout instead.', DeprecationWarning)
-        super(FlexBox, self).__init__(*pargs, **kwargs)

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -49,13 +49,6 @@ class Label(_String):
     _model_name = Unicode('LabelModel').tag(sync=True)
 
 
-class Latex(Label):
-
-    def __init__(self, *args, **kwargs):
-        warn('The Latex widget is deprecated. Use Label instead')
-        super(Latex, self).__init__(*args, **kwargs)
-
-
 @register('Jupyter.Textarea')
 class Textarea(_String):
     """Multiline text area widget."""

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -535,23 +535,6 @@ var DOMWidgetModel = WidgetModel.extend({
         layout: undefined,
         visible: true,
         _dom_classes: [],
-
-        // Deprecated attributes
-        color: null,
-        height: '',
-        border_radius: '',
-        border_width: '',
-        background_color: null,
-        font_style: '',
-        width: '',
-        font_family: '',
-        border_color: null,
-        padding: '',
-        font_weight: '',
-        icon: '',
-        border_style: '',
-        font_size: '',
-        margin: ''
     }),
 }, {
     serializers: _.extend({
@@ -567,54 +550,12 @@ var DOMWidgetViewMixin = {
         WidgetViewMixin.initialize.apply(this, [parameters]);
         this.id = utils.uuid();
 
-        this.listenTo(this.model, 'change:visible', this.update_visible, this); // TODO: Deprecated in 5.0
+        this.listenTo(this.model, 'change:visible', this.update_visible, this);
 
         this.listenTo(this.model, 'change:_dom_classes', function(model, new_classes) {
             var old_classes = model.previous('_dom_classes');
             this.update_classes(old_classes, new_classes);
         }, this);
-
-        this.listenTo(this.model, 'change:color', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('color', value); }, this);
-
-        this.listenTo(this.model, 'change:background_color', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('background', value); }, this);
-
-        this.listenTo(this.model, 'change:width', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('width', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:height', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('height', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:border_color', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-color', value); }, this);
-
-        this.listenTo(this.model, 'change:border_width', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-width', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:border_style', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-style', value); }, this);
-
-        this.listenTo(this.model, 'change:font_style', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-style', value); }, this);
-
-        this.listenTo(this.model, 'change:font_weight', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-weight', value); }, this);
-
-        this.listenTo(this.model, 'change:font_size', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-size', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:font_family', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-family', value); }, this);
-
-        this.listenTo(this.model, 'change:padding', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('padding', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:margin', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('margin', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:border_radius', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-radius', this._default_px(value)); }, this);
 
         this.layoutPromise = Promise.resolve();
         this.listenTo(this.model, 'change:layout', function(model, value) {
@@ -622,24 +563,8 @@ var DOMWidgetViewMixin = {
         });
 
         this.displayed.then(_.bind(function() {
-            this.update_visible(this.model, this.model.get('visible')); // TODO: Deprecated in 5.0
+            this.update_visible(this.model, this.model.get('visible'));
             this.update_classes([], this.model.get('_dom_classes'));
-
-            this.update_attr('color', this.model.get('color')); // TODO: Deprecated in 5.0
-            this.update_attr('background', this.model.get('background_color')); // TODO: Deprecated in 5.0
-            this.update_attr('width', this._default_px(this.model.get('width'))); // TODO: Deprecated in 5.0
-            this.update_attr('height', this._default_px(this.model.get('height'))); // TODO: Deprecated in 5.0
-            this.update_attr('border-color', this.model.get('border_color')); // TODO: Deprecated in 5.0
-            this.update_attr('border-width', this._default_px(this.model.get('border_width'))); // TODO: Deprecated in 5.0
-            this.update_attr('border-style', this.model.get('border_style')); // TODO: Deprecated in 5.0
-            this.update_attr('font-style', this.model.get('font_style')); // TODO: Deprecated in 5.0
-            this.update_attr('font-weight', this.model.get('font_weight')); // TODO: Deprecated in 5.0
-            this.update_attr('font-size', this._default_px(this.model.get('font_size'))); // TODO: Deprecated in 5.0
-            this.update_attr('font-family', this.model.get('font_family')); // TODO: Deprecated in 5.0
-            this.update_attr('padding', this._default_px(this.model.get('padding'))); // TODO: Deprecated in 5.0
-            this.update_attr('margin', this._default_px(this.model.get('margin'))); // TODO: Deprecated in 5.0
-            this.update_attr('border-radius', this._default_px(this.model.get('border_radius'))); // TODO: Deprecated in 5.0
-
             this.setLayout(this.model.get('layout'));
         }, this));
     },
@@ -653,7 +578,6 @@ var DOMWidgetViewMixin = {
                 }
 
                 return that.create_child_view(layout).then(function(view) {
-
                     // Trigger the displayed event of the child view.
                     return that.displayed.then(function() {
                         view.trigger('displayed', that);
@@ -664,24 +588,7 @@ var DOMWidgetViewMixin = {
         }
     },
 
-    _default_px: function(value) { // TODO: Deprecated in 5.0
-        /**
-         * Makes browser interpret a numerical string as a pixel value.
-         */
-        if (value && /^\d+\.?(\d+)?$/.test(value.trim())) {
-            return value.trim() + 'px';
-        }
-        return value;
-    },
-
-    update_attr: function(name, value) { // TODO: Deprecated in 5.0
-        /**
-         * Set a css attr of the widget view.
-         */
-        this.el.style[name] = value;
-    },
-
-    update_visible: function(model, value) { // TODO: Deprecated in 5.0
+    update_visible: function(model, value) {
         /**
          * Update visibility
          */


### PR DESCRIPTION
- All the top-level styling attributes that were deprecated in 5.0
- The `Latex` widget, that was replaced with `Label`.