### PR TITLE
Support for deprecated styling attributes

### DIFF
--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -15,38 +15,58 @@ class DOMWidget(Widget):
 
     _model_name = Unicode('DOMWidgetModel').tag(sync=True)
 
-    visible = Bool(True, allow_none=True, help="Whether the widget is visible.  False collapses the empty space, while None preserves the empty space.").tag(sync=True)  # TODO: Deprecated in ipywidgets 5.0
+    visible = Bool(True, allow_none=True, help="Whether the widget is visible.  False collapses the empty space, while None preserves the empty space.").tag(sync=True)
     _dom_classes = Tuple(help="DOM classes applied to widget.$el.").tag(sync=True)
 
     layout = Instance(Layout, allow_none=True).tag(sync=True, **widget_serialization)
     def _layout_default(self):
         return Layout()
 
-    width = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    height = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    padding = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    margin = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
+    # width, height, padding, margin border properties rebinding to the layout attribute.
+    # These direct-access properties are deprecated in 5.x and removed in 6.x.
+
+    @property
+    def width(self): # Removed in ipywidgets 6.0
+        return self.layout.width
+
+    @width.setter
+    def width(self, value): # Removed in ipywidgets 6.0
+        self.layout.width = value
+
+    @property
+    def height(self): # Removed in ipywidgets 6.0
+        return self.layout.height
+
+    @height.setter
+    def height(self, value): # Removed in ipywidgets 6.0
+        self.layout.height = value
+
+    @property
+    def padding(self): # Removed in ipywidgets 6.0
+        return self.layout.padding
+
+    @padding.setter
+    def padding(self, value): # Removed in ipywidgets 6.0
+        self.layout.padding = value
+
+    @property
+    def margin(self): # Removed in ipywidgets 6.0
+        return self.layout.margin
+
+    @margin.setter
+    def margin(self, value): # Removed in ipywidgets 6.0
+        self.layout.margin = value
+
+    @property
+    def border(self): # Removed in ipywidgets 6.0
+        return self.layout.border
+
+    @border.setter
+    def border(self, value): # Removed in ipywidgets 6.0
+        self.layout.border = value
 
     color = Color(None, allow_none=True).tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
     background_color = Color(None, allow_none=True).tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    border_color = Color(None, allow_none=True).tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-
-    border_width = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    border_radius = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
-    border_style = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_border-style.asp # TODO: Deprecated in ipywidgets 5.0
-        'none',
-        'hidden',
-        'dotted',
-        'dashed',
-        'solid',
-        'double',
-        'groove',
-        'ridge',
-        'inset',
-        'outset',
-        'initial',
-        'inherit', ''],
-        default_value='').tag(sync=True)
 
     font_style = CaselessStrEnum(values=[ # http://www.w3schools.com/cssref/pr_font_font-style.asp # TODO: Deprecated in ipywidgets 5.0
         'normal',
@@ -61,7 +81,7 @@ class DOMWidget(Widget):
         'bolder',
         'lighter',
         'initial',
-        'inherit', ''] + list(map(str, range(100,1000,100))),
+        'inherit', ''] + list(map(str, range(100, 1000, 100))),
         default_value='').tag(sync=True)
     font_size = CUnicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
     font_family = Unicode().tag(sync=True) # TODO: Deprecated in ipywidgets 5.0
@@ -70,19 +90,9 @@ class DOMWidget(Widget):
         super(DOMWidget, self).__init__(*pargs, **kwargs)
 
         # Deprecation added in 5.0.  TODO: Remove me and corresponging traits.
-        self._deprecate_traits(['width', 'height', 'padding', 'margin', 'color',
-        'background_color', 'border_color', 'border_width', 'border_radius',
-        'border_style', 'font_style', 'font_weight', 'font_size', 'font_family',
-        'visible'])
+        self._deprecate_traits(['color', 'background_color', 
+        'font_style', 'font_weight', 'font_size', 'font_family'])
 
-    @observe('border_width', 'border_style', 'border_color')
-    def _update_border(self, change):
-        name, new = change['name'], change['new']
-        if new is not None and new != '':
-            if name != 'border_width' and not self.border_width:
-                self.border_width = 1
-            if name != 'border_style' and self.border_style == '':
-                self.border_style = 'solid'
 
     def add_class(self, className):
         """
@@ -104,7 +114,7 @@ class DOMWidget(Widget):
             self._dom_classes = [c for c in self._dom_classes if c != className]
         return self
 
-    def _deprecate_traits(self, traits): # TODO: Deprecation added in 5.0.  Remove me and corresponging traits.
+    def _deprecate_traits(self, traits): # Removed in ipywidgets 6.0.
         def traitWarn(change):
             warn("%s deprecated" % change['name'], DeprecationWarning)
         self.observe(traitWarn, names=traits)

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -535,20 +535,11 @@ var DOMWidgetModel = WidgetModel.extend({
 
         // Deprecated attributes
         color: null,
-        height: "",
-        border_radius: "",
-        border_width: "",
         background_color: null,
         font_style: "",
-        width: "",
         font_family: "",
-        border_color: null,
-        padding: "",
         font_weight: "",
-        icon: "",
-        border_style: "",
         font_size: "",
-        margin: ""
     }),
 }, {
     serializers: _.extend({
@@ -564,54 +555,12 @@ var DOMWidgetViewMixin = {
         WidgetViewMixin.initialize.apply(this, [parameters]);
         this.id = utils.uuid();
 
-        this.listenTo(this.model, 'change:visible', this.update_visible, this); // TODO: Deprecated in 5.0
+        this.listenTo(this.model, 'change:visible', this.update_visible, this);
 
         this.listenTo(this.model, 'change:_dom_classes', function(model, new_classes) {
             var old_classes = model.previous('_dom_classes');
             this.update_classes(old_classes, new_classes);
         }, this);
-
-        this.listenTo(this.model, 'change:color', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('color', value); }, this);
-
-        this.listenTo(this.model, 'change:background_color', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('background', value); }, this);
-
-        this.listenTo(this.model, 'change:width', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('width', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:height', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('height', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:border_color', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-color', value); }, this);
-
-        this.listenTo(this.model, 'change:border_width', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-width', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:border_style', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-style', value); }, this);
-
-        this.listenTo(this.model, 'change:font_style', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-style', value); }, this);
-
-        this.listenTo(this.model, 'change:font_weight', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-weight', value); }, this);
-
-        this.listenTo(this.model, 'change:font_size', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-size', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:font_family', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('font-family', value); }, this);
-
-        this.listenTo(this.model, 'change:padding', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('padding', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:margin', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('margin', this._default_px(value)); }, this);
-
-        this.listenTo(this.model, 'change:border_radius', function (model, value) { // TODO: Deprecated in 5.0
-            this.update_attr('border-radius', this._default_px(value)); }, this);
 
         this.layoutPromise = Promise.resolve();
         this.listenTo(this.model, "change:layout", function(model, value) {
@@ -619,24 +568,8 @@ var DOMWidgetViewMixin = {
         });
 
         this.displayed.then(_.bind(function() {
-            this.update_visible(this.model, this.model.get("visible")); // TODO: Deprecated in 5.0
+            this.update_visible(this.model, this.model.get("visible"));
             this.update_classes([], this.model.get('_dom_classes'));
-
-            this.update_attr('color', this.model.get('color')); // TODO: Deprecated in 5.0
-            this.update_attr('background', this.model.get('background_color')); // TODO: Deprecated in 5.0
-            this.update_attr('width', this._default_px(this.model.get('width'))); // TODO: Deprecated in 5.0
-            this.update_attr('height', this._default_px(this.model.get('height'))); // TODO: Deprecated in 5.0
-            this.update_attr('border-color', this.model.get('border_color')); // TODO: Deprecated in 5.0
-            this.update_attr('border-width', this._default_px(this.model.get('border_width'))); // TODO: Deprecated in 5.0
-            this.update_attr('border-style', this.model.get('border_style')); // TODO: Deprecated in 5.0
-            this.update_attr('font-style', this.model.get('font_style')); // TODO: Deprecated in 5.0
-            this.update_attr('font-weight', this.model.get('font_weight')); // TODO: Deprecated in 5.0
-            this.update_attr('font-size', this._default_px(this.model.get('font_size'))); // TODO: Deprecated in 5.0
-            this.update_attr('font-family', this.model.get('font_family')); // TODO: Deprecated in 5.0
-            this.update_attr('padding', this._default_px(this.model.get('padding'))); // TODO: Deprecated in 5.0
-            this.update_attr('margin', this._default_px(this.model.get('margin'))); // TODO: Deprecated in 5.0
-            this.update_attr('border-radius', this._default_px(this.model.get('border_radius'))); // TODO: Deprecated in 5.0
-
             this.setLayout(this.model.get('layout'));
         }, this));
     },
@@ -661,24 +594,7 @@ var DOMWidgetViewMixin = {
         }
     },
 
-    _default_px: function(value) { // TODO: Deprecated in 5.0
-        /**
-         * Makes browser interpret a numerical string as a pixel value.
-         */
-        if (value && /^\d+\.?(\d+)?$/.test(value.trim())) {
-            return value.trim() + 'px';
-        }
-        return value;
-    },
-
-    update_attr: function(name, value) { // TODO: Deprecated in 5.0
-        /**
-         * Set a css attr of the widget view.
-         */
-        this.el.style[name] = value;
-    },
-
-    update_visible: function(model, value) { // TODO: Deprecated in 5.0
+    update_visible: function(model, value) {
         /**
          * Update visibility
          */


### PR DESCRIPTION
Fixes #598. This is a 5.x PR only since it fixes a behavior that is actually deprecated and removed in 6.0.

The problem was that both `layout` and the deprecated top-level attributes were setting the same css attributes. Which ever does it the last was the one being applied.

What I did instead was to remove the js-side handling of the top-level attributes that existed in `layout` and rebind them to layouts via properties. However, I could only do this for top-level attributes that were not css shorthands for layout attributes, so the behavior.

