### PR TITLE
Check bounds before collapsing or expanding accordions

### DIFF
--- a/jupyter-js-widgets/src/widget_selectioncontainer.js
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.js
@@ -84,8 +84,12 @@ var AccordionView = widget.DOMWidgetView.extend({
             var new_index = this.model.get('selected_index');
             /* old_index can be out of bounds, this check avoids raising
                a javascript error. */
-            this.collapseTab(old_index);
-            this.expandTab(new_index);
+            if (0 <= old_index && old_index < this.containers.length) {
+                this.collapseTab(old_index);
+            }
+            if (0 <= new_index && new_index < this.containers.length) {
+                this.expandTab(new_index);
+            }
         }
     },
 


### PR DESCRIPTION
This pull request restores some bounds checking that was dropped in 2c5ba893bc968d874ffa6603dd7185c8278807bd. At the time the bounds checking was added it appeared that the javascript errors raised without bounds checking were harmless...they clutter up the debugging console, but nothing worse.

In versions of ipywidgets 4.1 and 5, though, setting the  `selected_index` property to some outside of the bounds (e.g. `-1`, which has the nice effect of closing all of the accordions) in nested accordion widgets leads to titles not being set in the nested accordions.

Normally I'd attach a screen shot of things not working, but my ipywidgets install is currently messed up. I'll upload a notebook to a gist in a couple of minutes which demonstrated the problem.