### PR TITLE
Don't write empty widget state to metadata

### DIFF
--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -200,16 +200,21 @@ WidgetManager.set_state_callbacks(function() {
     }
     return Promise.resolve({});
 }, function(state) {
-    // Only persist the views of the widget
-    var stateToSave = _.mapObject(state, function(widgetState) {
-        return _.pick(widgetState, 'views');
+    var stateToSave = {};
+    _.mapObject(state, function(widgetState, key) {
+        // don't persist widget state with no views
+        if (widgetState.views.length === 0) return;
+        // Only persist the views of the widget
+        stateToSave[key] = _.pick(widgetState, 'views');
     });
+
     // check if there are any views to persist
     if (Object.keys(stateToSave).length === 0) {
         // no widget state, don't save empty widget state in metadata
         delete Jupyter.notebook.metadata.widgets;
         return;
     }
+
     Jupyter.notebook.metadata.widgets = {
         state: stateToSave,
         // Persisted widget state version

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -200,15 +200,20 @@ WidgetManager.set_state_callbacks(function() {
     }
     return Promise.resolve({});
 }, function(state) {
+    // Only persist the views of the widget
+    var stateToSave = _.mapObject(state, function(widgetState) {
+        return _.pick(widgetState, 'views');
+    });
+    // check if there are any views to persist
+    if (Object.keys(stateToSave).length === 0) {
+        // no widget state, don't save empty widget state in metadata
+        delete Jupyter.notebook.metadata.widgets;
+        return;
+    }
     Jupyter.notebook.metadata.widgets = {
-
+        state: stateToSave,
         // Persisted widget state version
         version: version,
-
-        // Only persist the views of the widget
-        state: _.mapObject(state, function(widgetState) {
-            return _.pick(widgetState, 'views');
-        })
     };
 });
 


### PR DESCRIPTION
This is two related changes, the first of which I'm pretty sure is the right thing to do, but I'm less sure about the second:

1. Don't save empty widget state dicts in metadata if there's no state to save.
2. Exclude widgets with no views from the metadata, since no information is persisted for these widgets when there are no views attached to them.

closes #636