### PR TITLE
try default msg_throttle = 1

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -161,7 +161,7 @@ class Widget(LoggingConfigurable):
         to use to represent the widget.""").tag(sync=True)
     comm = Instance('ipykernel.comm.Comm', allow_none=True)
 
-    msg_throttle = Int(3, help="""Maximum number of msgs the front-end can send before receiving an idle msg from the back-end.""").tag(sync=True)
+    msg_throttle = Int(1, help="""Maximum number of msgs the front-end can send before receiving an idle msg from the back-end.""").tag(sync=True)
 
     keys = List()
     def _keys_default(self):

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -40,7 +40,7 @@ var WidgetModel = Backbone.Model.extend({
         _model_name: "WidgetModel",
         _view_module: "jupyter-js-widgets",
         _view_name: null,
-        msg_throttle: 3
+        msg_throttle: 1,
     },
 
     constructor: function (widget_manager, model_id, comm, attributes) {


### PR DESCRIPTION
It seems to offer a smoother experience than 3, which causes jerks as a slider moves across values