### PR TITLE
widgetsnbextension is not zip_safe

### DIFF
--- a/widgetsnbextension/setup.py
+++ b/widgetsnbextension/setup.py
@@ -208,6 +208,7 @@ setup_args = dict(
                 'widgetsnbextension/static/extension.js.map'
         ]),
     ],
+    zip_safe=False,
     include_package_data = True,
 )
 


### PR DESCRIPTION
Prevents installation of zipped-up eggs, for which the nbextension install will fail

cc @nthiery who encountered this.