### PR TITLE
Bugfixes

### DIFF
--- a/jupyter-js-widgets/examples/web/manager.js
+++ b/jupyter-js-widgets/examples/web/manager.js
@@ -29,6 +29,7 @@ WidgetManager.prototype._create_comm = function() {
     return Promise.resolve({
         on_close: () => {},
         on_msg: () => {},
-        close: () => {}
+        close: () => {},
+        send: () => {}
     });
 }

--- a/jupyter-js-widgets/examples/web2/manager.js
+++ b/jupyter-js-widgets/examples/web2/manager.js
@@ -28,6 +28,7 @@ WidgetManager.prototype._create_comm = function() {
     return Promise.resolve({
         on_close: () => {},
         on_msg: () => {},
-        close: () => {}
+        close: () => {},
+        send: () => {}
     });
 }

--- a/jupyter-js-widgets/examples/web4/index.js
+++ b/jupyter-js-widgets/examples/web4/index.js
@@ -1,1 +1,1 @@
-require('jupyter-js-widgets/src/embed-webpack');
+require('jupyter-js-widgets/lib/embed-webpack');

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -59,7 +59,7 @@ class WidgetModel extends Backbone.Model {
 
     /**
      * Test to see if the model has been synced with the server.
-     * 
+     *
      * #### Notes
      * As of backbone 1.1, backbone ignores `patch` if it thinks the
      * model has never been pushed.
@@ -258,7 +258,7 @@ class WidgetModel extends Backbone.Model {
 
     /**
      * Set a value.
-     * 
+     *
      * We just call the super method, in which val and options are optional
      */
     set(key, val?, options?) {
@@ -279,7 +279,7 @@ class WidgetModel extends Backbone.Model {
      * Handle sync to the back-end.  Called when a model.save() is called.
      *
      * Make sure a comm exists.
-     * 
+     *
      * Parameters
      * ----------
      * method : create, update, patch, delete, read
@@ -622,7 +622,7 @@ abstract class WidgetView extends NativeView<WidgetModel> {
 
     /**
      * Render a view
-     * 
+     *
      * @returns the view or a promise to the view.
      */
     render(): any {

--- a/jupyter-js-widgets/src/widget_box.ts
+++ b/jupyter-js-widgets/src/widget_box.ts
@@ -23,6 +23,7 @@ import {
 
 import * as _ from 'underscore';
 
+
 export
 namespace JupyterPhosphorPanelWidget {
     export
@@ -90,12 +91,12 @@ class ProxyModel extends DOMWidgetModel {
         return _.extend(super.defaults(), {
             _view_name: 'ProxyView',
             _model_name: 'ProxyModel',
-            child: null            
+            child: null
         })
     }
 
     static serializers = _.extend({
-        child: {deserialize: unpack_models}        
+        child: {deserialize: unpack_models}
     }, DOMWidgetModel.serializers);
 }
 
@@ -171,7 +172,7 @@ class PlaceProxyModel extends ProxyModel {
         return _.extend(super.defaults(), {
             _view_name: 'PlaceProxyView',
             _model_name: 'PlaceProxyModel',
-            selector: ''          
+            selector: ''
         })
     }
 }
@@ -205,7 +206,9 @@ class BoxView extends DOMWidgetView {
         }
 
         this.el = this.pWidget.node;
-        this.$el = $(this.el);
+        if ((window as any).jQuery) {
+            this.$el = (window as any).jQuery(this.pWidget.node);
+        }
      }
 
     /**

--- a/jupyter-js-widgets/src/widget_link.ts
+++ b/jupyter-js-widgets/src/widget_link.ts
@@ -45,8 +45,8 @@ class DirectionalLinkModel extends WidgetModel {
 
     updateBindings() {
         this.cleanup();
-        [this.sourceModel, this.sourceAttr] = this.get('source');
-        [this.targetModel, this.targetAttr] = this.get('target');
+        [this.sourceModel, this.sourceAttr] = this.get('source') || [null, null];
+        [this.targetModel, this.targetAttr] = this.get('target') || [null, null];
         if (this.sourceModel) {
             this.listenTo(this.sourceModel, 'change:' + this.sourceAttr, () => {
                 this.updateValue(this.sourceModel, this.sourceAttr, this.targetModel, this.targetAttr);
@@ -75,7 +75,7 @@ class DirectionalLinkModel extends WidgetModel {
     targetModel: WidgetModel;
     targetAttr: string;
 
-    private _updating: boolean;    
+    private _updating: boolean;
 }
 
 export

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -370,9 +370,9 @@ class DropdownView extends DOMWidgetView {
         var buttongroupRect = this.buttongroup.getBoundingClientRect();
         var availableHeightAbove = buttongroupRect.top;
         var availableHeightBelow = window.innerHeight - buttongroupRect.bottom;
-        // Account for 1px border.
-        availableHeightAbove += 1;
-        availableHeightBelow -= 1;
+        var border = parseInt(getComputedStyle(this.droplist).borderWidth, 10);
+        availableHeightAbove += border;
+        availableHeightBelow -= border;
         var width = buttongroupRect.width;
         var maxHeight = Math.floor(
             Math.max(availableHeightAbove, availableHeightBelow)
@@ -391,22 +391,19 @@ class DropdownView extends DOMWidgetView {
 
         // If the drop list fits below, render below.
         if (droplistRect.height <= availableHeightBelow) {
-            // Account for 1px border.
-            top = Math.ceil(buttongroupRect.bottom + 1);
-            this.droplist.style.top = top + 'px';
+            top = buttongroupRect.bottom + border;
+            this.droplist.style.top = Math.ceil(top) + 'px';
         // If the drop list fits above, render above.
         } else if (droplistRect.height <= availableHeightAbove) {
-            // Account for 1px border.
-            top = Math.floor(buttongroupRect.top - droplistRect.height + 1);
-            this.droplist.style.top = top + 'px';
+            top = buttongroupRect.top - droplistRect.height + border;
+            this.droplist.style.top = Math.floor(top) + 'px';
         // Otherwise, render in whichever has more space, above or below.
         } else if (availableHeightBelow >= availableHeightAbove) {
-            // Account for 1px border.
-            top = Math.ceil(buttongroupRect.bottom + 1);
-            this.droplist.style.top = top + 'px';
+            top = buttongroupRect.bottom + border;
+            this.droplist.style.top = Math.ceil(top) + 'px';
         } else {
-            // Account for 1px border.
-            top = Math.floor(buttongroupRect.top - droplistRect.height + 1);
+            top = buttongroupRect.top - droplistRect.height + border;
+            top = Math.floor(top);
             this.droplist.style.top = top + 'px';
         }
 
@@ -822,7 +819,7 @@ class SelectView extends DOMWidgetView {
      */
     _handle_change() {
         // TODO: typecasting not needed in Typescript 2.0
-        // (see https://github.com/Microsoft/TypeScript/issues/9334 and 
+        // (see https://github.com/Microsoft/TypeScript/issues/9334 and
         // https://github.com/Microsoft/TypeScript/issues/8220)
         var value = (this.listbox.options[this.listbox.selectedIndex] as HTMLOptionElement).value;
         this.model.set('selected_label', value, {updated_view: this});
@@ -1058,7 +1055,7 @@ class SelectMultipleView extends SelectView {
         for (var i = 0, len = options.length; i < len; ++i) {
             var value = options[i].getAttribute('data-value');
             // TODO: typecasting not needed in Typescript 2.0
-            // (see https://github.com/Microsoft/TypeScript/issues/9334 and 
+            // (see https://github.com/Microsoft/TypeScript/issues/9334 and
             // https://github.com/Microsoft/TypeScript/issues/8220)
             (options[i] as HTMLOptionElement).selected = _.contains(values, value);
         }

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -374,15 +374,13 @@ class DropdownView extends DOMWidgetView {
         availableHeightAbove += border;
         availableHeightBelow -= border;
         var width = buttongroupRect.width;
-        var maxHeight = Math.floor(
-            Math.max(availableHeightAbove, availableHeightBelow)
-        );
+        var maxHeight = Math.max(availableHeightAbove, availableHeightBelow);
         var top = 0;
         var left = buttongroupRect.left;
 
-        this.droplist.style.left = left + 'px';
-        this.droplist.style.maxHeight = maxHeight + 'px';
-        this.droplist.style.width = width + 'px';
+        this.droplist.style.left = Math.floor(left) + 'px';
+        this.droplist.style.maxHeight = Math.floor(maxHeight) + 'px';
+        this.droplist.style.width = Math.floor(width) + 'px';
 
         // Make drop list visible to compute its dimensions.
         this.droplist.classList.add('mod-active');
@@ -403,8 +401,7 @@ class DropdownView extends DOMWidgetView {
             this.droplist.style.top = Math.ceil(top) + 'px';
         } else {
             top = buttongroupRect.top - droplistRect.height + border;
-            top = Math.floor(top);
-            this.droplist.style.top = top + 'px';
+            this.droplist.style.top = Math.floor(top) + 'px';
         }
 
         // If a selection is active, scroll to it if necessary.


### PR DESCRIPTION
- [x] Fix broken `web` example.
- [x] Fix broken `web2` example.
- [x] Fix broken `web4` example.
- [x] Use `getComputedStyle` to calculate border width instead of hard-coding it in `widget_selection`.
- [x] Fix missing `$` (`window.jQuery`) error in `widget_box`.
- [x] Fix occasionally broken destructuring initialization in `widget_link`.
- [x] Formatting - remove trailing whitespace in `widget`.
- [x] 	Only use `floor` or `ceil` when writing to the DOM in `widget_selection`.

cc @jasongrout @SylvainCorlay 