### PR TITLE
[WIP] Troubleshoot javascript doc build

### DIFF
--- a/docs/build-local.sh
+++ b/docs/build-local.sh
@@ -1,4 +1,4 @@
-cd ../../jupyter-js-widgets
+cd ../jupyter-js-widgets
 npm install
 cd ../docs
 npm install

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,8 @@ dependencies:
 - jinja2
 - tornado
 - nbformat
-- ipywidgets==5.2.2
+- jupyter_client
+- ipywidgets>=5.2
 - notebook>=4.2.1
 - pip:
   - sphinx==1.4.5

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,7 @@
 name: ipywidget_docs
 channels:
 - conda-forge
+- defaults
 dependencies:
 - python=3.5
 - sphinx_rtd_theme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,8 +7,8 @@ dependencies:
 - jinja2
 - tornado
 - nbformat
-- ipywidgets
-- notebook>=4.2
+- ipywidgets==5.2.2
+- notebook>=4.2.1
 - pip:
   - sphinx==1.4.5
   - nbsphinx==0.2.7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 jupyter_client
-sphinx==1.3.6
+sphinx==1.4.5
 jupyter_sphinx_theme==0.0.6

--- a/docs/source/_static/index.js
+++ b/docs/source/_static/index.js
@@ -1,4 +1,4 @@
-require("../../../jupyter-js-widgets/lib/embed-webpack");
+require("jupyter-js-widgets/lib/embed-webpack");
 
 window.onload = function() {
   // TODO: See if md parsing conf can do this, or extension (compile time)

--- a/docs/source/_static/index.js
+++ b/docs/source/_static/index.js
@@ -1,4 +1,4 @@
-require("jupyter-js-widgets/src/embed-webpack");
+require("../../../jupyter-js-widgets/lib/embed-webpack");
 
 window.onload = function() {
   // TODO: See if md parsing conf can do this, or extension (compile time)


### PR DESCRIPTION
Investigating #681 

@SylvainCorlay Noticing that the `build_local.sh` is not being found in the rtd build.

This happens in this command of my [test RTD build](http://readthedocs.org/projects/test-widgets/builds/4218775/)
``python /home/docs/checkouts/readthedocs.org/user_builds/test-widgets/conda/doc-js/bin/sphinx-build -T -E -b readthedocs -d _build/doctrees-readthedocs -D language=en . _build/html``