### PR TITLE
Bug fix: hard code jquery-ui version that includes smooth theme.

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -72,7 +72,7 @@
     "bootstrap": "^3.3.5",
     "d3-format": "^0.5.1",
     "jquery": "^2.1.4",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "1.10.4",
     "jupyter-js-services": "^0.15.1",
     "lolex": "^1.4.0",
     "phosphor": "^0.5.0",


### PR DESCRIPTION
The `jquery-ui` version in the current `package.json` was `^1.10.5`, which is a version that does not exist. This causes `npm` to instead download `jquery-ui@1.12.0`:
```
$ npm install --save jquery-ui@^1.10.5
temp@ /Users/af/Desktop/temp
└── jquery-ui@1.12.0
```

That version does not come bundled with themes.

The last version of `jquery-ui` that includes the `smoothness` theme which the webpack bundle needs for building is `jquery-ui@1.10.4`, so this PR hard codes that version.

cc: @jasongrout @SylvainCorlay