### PR TITLE
Removed a comment associated with already removed tests.

### DIFF
--- a/jupyter-js-widgets/src/widget_selectioncontainer.js
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.js
@@ -80,8 +80,6 @@ var AccordionView = widget.DOMWidgetView.extend({
         if (options === undefined || options.updated_view != this) {
             var old_index = this.model.previous('selected_index');
             var new_index = this.model.get('selected_index');
-            /* old_index can be out of bounds, this check avoids raising
-               a javascript error. */
             this.collapseTab(old_index);
             this.expandTab(new_index);
         }


### PR DESCRIPTION
Looking the code to add the possibility to deselect all Accordions pages I found this error.
It was originally in c63c14e6 as:
```javascript
            if (options === undefined || options.updated_view != this) {
                var old_index = this.model.previous('selected_index');
                var new_index = this.model.get('selected_index');
                /* old_index can be out of bounds, this check avoids raising
                   a (hrmless) javascript error. */
                if (0 <= old_index && old_index < this.containers.length) {
                    this.containers[old_index].children('.panel-collapse').collapse('hide');
                }
                if (0 <= new_index && new_index < this.containers.length) {
                    this.containers[new_index].children('.panel-collapse').collapse('show');
                }
            }
```