### PR TITLE
add check to allow inconsistent index to unexpand all Accordion pages

### DIFF
--- a/jupyter-js-widgets/src/widget_selectioncontainer.js
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.js
@@ -106,11 +106,15 @@ var AccordionView = widget.DOMWidgetView.extend({
      * @param  {number} index
      */
     expandTab: function(index) {
-        var page = this.containers[index].children('.collapse');
+        /* to be able to disable all pages we must be sure
+           that the index exists before proceed */
+        if (index in this.containers) {
+            var page = this.containers[index].children('.collapse');
 
-        if (!page.hasClass('in')) {
-            page.addClass('in');
-            $(this.el.children[index]).children('.panel-heading').children('accordion-toggle').trigger('click');
+            if (!page.hasClass('in')) {
+                page.addClass('in');
+                $(this.el.children[index]).children('.panel-heading').children('accordion-toggle').trigger('click');
+            }
         }
     },
 


### PR DESCRIPTION
Already now you can set an out of range `selected_index` to implode all Accordion pages but in javascript console a lot of errors appear.
This PR fix the problem.
P.S.
Your `Please review the guidelines for contributing to this repository.` has a broken link.