### PR TITLE
Improve dev install instructions

### DIFF
--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -18,9 +18,8 @@ available in the PATH used with sudo.
 1. Navigate into the cloned repo and install
 
         cd ipywidgets
-        bash dev-install.sh --user
+        bash dev-install.sh --sys-prefix
 
-(If you do not want a user install, remove the `--user`)
 
 After you've made changes to `jupyter-js-widgets` if you want to test those
 changes, run the following, empty your browsers cache, and refresh the page.


### PR DESCRIPTION
Default to sys-prefix even in dev installs otherwise, other python installs also get the dev version of the js.