### PR TITLE
CUnicode -> Unicode

### DIFF
--- a/ipywidgets/widgets/widget_layout.py
+++ b/ipywidgets/widgets/widget_layout.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from .widget import Widget, register
-from traitlets import Unicode, CUnicode
+from traitlets import Unicode
 
 
 class Layout(Widget):
@@ -28,28 +28,28 @@ class Layout(Widget):
     _model_name = Unicode('LayoutModel').tag(sync=True)
 
     # Keys
-    align_content = CUnicode().tag(sync=True)
-    align_items = CUnicode().tag(sync=True)
-    align_self = CUnicode().tag(sync=True)
-    bottom = CUnicode().tag(sync=True)
-    border = CUnicode().tag(sync=True)
-    display = CUnicode().tag(sync=True)
-    flex = CUnicode().tag(sync=True)
-    flex_flow = CUnicode().tag(sync=True)
-    height = CUnicode().tag(sync=True)
-    justify_content = CUnicode().tag(sync=True)
-    left = CUnicode().tag(sync=True)
-    margin = CUnicode().tag(sync=True)
-    max_height = CUnicode().tag(sync=True)
-    max_width = CUnicode().tag(sync=True)
-    min_height = CUnicode().tag(sync=True)
-    min_width = CUnicode().tag(sync=True)
-    overflow = CUnicode().tag(sync=True)
-    overflow_x = CUnicode().tag(sync=True)
-    overflow_y = CUnicode().tag(sync=True)
-    order = CUnicode().tag(sync=True)
-    padding = CUnicode().tag(sync=True)
-    right = CUnicode().tag(sync=True)
-    top = CUnicode().tag(sync=True)
-    visibility = CUnicode().tag(sync=True)
-    width = CUnicode().tag(sync=True)
+    align_content = Unicode().tag(sync=True)
+    align_items = Unicode().tag(sync=True)
+    align_self = Unicode().tag(sync=True)
+    bottom = Unicode().tag(sync=True)
+    border = Unicode().tag(sync=True)
+    display = Unicode().tag(sync=True)
+    flex = Unicode().tag(sync=True)
+    flex_flow = Unicode().tag(sync=True)
+    height = Unicode().tag(sync=True)
+    justify_content = Unicode().tag(sync=True)
+    left = Unicode().tag(sync=True)
+    margin = Unicode().tag(sync=True)
+    max_height = Unicode().tag(sync=True)
+    max_width = Unicode().tag(sync=True)
+    min_height = Unicode().tag(sync=True)
+    min_width = Unicode().tag(sync=True)
+    overflow = Unicode().tag(sync=True)
+    overflow_x = Unicode().tag(sync=True)
+    overflow_y = Unicode().tag(sync=True)
+    order = Unicode().tag(sync=True)
+    padding = Unicode().tag(sync=True)
+    right = Unicode().tag(sync=True)
+    top = Unicode().tag(sync=True)
+    visibility = Unicode().tag(sync=True)
+    width = Unicode().tag(sync=True)


### PR DESCRIPTION
It is a common mistake for users to try to set `width` or `height` to an integer value which is not a valid value for the property. This makes it clearer that a string is expected.