### PR TITLE
Support an "eval" attribute to evaluate widget values in @interact

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -235,17 +235,24 @@ def interactive(__interact_f, **kwargs):
 
     # Build the callback
     def call_f(*args):
-
-        container.kwargs = {}
-        for widget in kwargs_widgets:
-            value = widget.value
-            container.kwargs[widget._kwarg] = value
         if manual:
             manual_button.disabled = True
         try:
             with out:
                 if co:
                     clear_output(wait=True)
+                container.kwargs = {}
+                for widget in kwargs_widgets:
+                    value = widget.value
+                    # If the widget has an "eval" attribute, call it on
+                    # the obtained value.
+                    try:
+                        ev = widget.eval
+                    except AttributeError:
+                        pass
+                    else:
+                        value = ev(value)
+                    container.kwargs[widget._kwarg] = value
                 container.result = f(**container.kwargs)
                 if container.result is not None:
                     display(container.result)


### PR DESCRIPTION
Let `W` be a `Text` widget (or another widget, but `Text` is a natural use case). If that is used for an interactive (`@interact`) function, the function receives the text from the input box, i.e. `W.value` as a string. I propose to support an additional evaluation step such that the interactive function could receive `f(W.value)` as argument for some callable `f`.

In the current implementation, this is done with a `W.eval` attribute. If that attribute exists, then `W.eval(W.value)` is passed to the interactive function.

The current branch deals with the internal implementation only. At this point, there is no clean user-interface for this (you have to manually set `W.eval = f` or define a custom widget type with an `eval` attribute), but that can easily be added later. I also want to avoid bikeshedding about the user-interface, I wanted feedback about the general idea first.

Context: this is to support analogous functionality from [SageNB](https://github.com/sagemath/sagenb) to help with https://github.com/OpenDreamKit/OpenDreamKit/issues/94.