### PR TITLE
Add a get_interact_value() method to customize the value passed to interactive functions

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -168,7 +168,7 @@ class interactive(Box):
             self.manual_button.disabled = True
         try:
             for widget in self.kwargs_widgets:
-                value = widget.value
+                value = widget.get_interact_value()
                 self.kwargs[widget._kwarg] = value
             with self.out:
                 if self.clear_output:

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -716,3 +716,16 @@ def test_interact_noinspect():
         description='a',
         value=a,
     )
+
+
+def test_get_interact_value():
+    from ipywidgets.widgets import ValueWidget
+    from traitlets import Unicode
+    class TheAnswer(ValueWidget):
+        description = Unicode()
+        def get_interact_value(self):
+            return 42
+    w = TheAnswer()
+    c = interactive(lambda v: v, v=w)
+    c.call_f()
+    nt.assert_equal(c.result, 42)

--- a/ipywidgets/widgets/valuewidget.py
+++ b/ipywidgets/widgets/valuewidget.py
@@ -8,3 +8,10 @@ from .widget import Widget
 
 class ValueWidget(Widget):
     """Widget that can be used for the input of an interactive function"""
+
+    def get_interact_value(self):
+        """Return the value for this widget which should be passed to
+        interactive functions. Custom widgets can change this method
+        to process the raw value ``self.value``.
+        """
+        return self.value


### PR DESCRIPTION
Let `W` be a widget. If that is used for an interactive (`@interact`) function, the function receives `W.value`. I propose to allow to customize this by adding a method `W.get_value()` to return the value pased to the interactive function. By default, this is just `W.value` but custom widgets could change this.

This solves the same problem as #724 but perhaps with a cleaner API.

Context: this is to support analogous functionality from [SageNB](https://github.com/sagemath/sagenb) to help with https://github.com/OpenDreamKit/OpenDreamKit/issues/94.