### PR TITLE
Add sys-prefix by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install the current version of ipywidgets using pip or conda.
 
 ```
 pip install ipywidgets
-jupyter nbextension enable --py widgetsnbextension
+jupyter nbextension enable --py --sys-prefix widgetsnbextension
 ```
 
 - With conda:


### PR DESCRIPTION
sys-prefix should always be the default.

Actually, this is something we should change when we adopt the conf.d approach.