### PR TITLE
More prominent description of the layout limitations of the 'description' field.

### DIFF
--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -145,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may have noticed that the slider length is shorter in presence of a description. This because the description is added *inside* of the Slider total length. You **cannot** change the width of the internal description field. If you need more flexibility to layout sliders and captions, you should use a combination of `Slider` and `Label` widgets arranged in a layout."
+    "You may have noticed that the widget's length is shorter in presence of a description. This because the description is added *inside* of the widget's total length. You **cannot** change the width of the internal description field. If you need more flexibility to layout widgets and captions, you should use a combination with the `Label` widgets arranged in a layout."
    ]
   },
   {

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -138,6 +138,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Description"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may have noticed that the slider length is shorter in presence of a description. This because the description is added *inside* of the Slider total length. You **cannot** change the width of the internal description field. If you need more flexibility to layout sliders and captions, you should use a combination of `Slider` and `Label` widgets arranged in a layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "HBox([Label('A too long description'), IntSlider()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### More Styling (colors, inner-widget details)\n",
     "\n",
     "The `layout` attribute only exposes layout-related css properties for the top-level DOM element of widgets. Individual widgets may expose more styling-related properties, or none. For example, the `Button` widget has a `button_style` attribute that may take 5 different values:\n",
@@ -227,24 +252,6 @@
    "outputs": [],
    "source": [
     "Label(value='$e=mc^2$')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You may have noticed that the slider length is shorter in presence of a description. This because the description is added *inside* of the Slider total length. You **cannot** change the width of the internal description field. If you need more flexibility to layout sliders and captions, you should use a combination of `Slider` and `Label` widgets arranged in a layout."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "HBox([Label('A too long description'), IntSlider()])"
    ]
   },
   {


### PR DESCRIPTION
The `description` field of the widgets has some layout limitations, that were "buried" in the documentation. This PR moves the existing mention of the limitations to its own paragraph with its own title. It also changes the wording to reflect that not only the `slider` widget is affected.

See discussion in #714 