### PR TITLE
Fix model change to default not syncing

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -309,7 +309,7 @@ class WidgetModel extends Backbone.Model {
             return false;
         }
 
-        var attrs = (method === 'patch') ? options.attrs : model.get_state(options);
+        var attrs = (method === 'patch') ? options.attrs : model.get_state(options.drop_defaults);
 
         // The state_lock lists attributes that are currently being changed
         // right now from a kernel message.


### PR DESCRIPTION
See my issue here: https://github.com/ipython/ipywidgets/issues/738

Looking at another call to `model.get_state` as an example [here](https://github.com/ipython/ipywidgets/blob/eb4dcd9956d88ae842bff7822a9c32fc038906dd/jupyter-js-widgets/src/manager-base.ts#L350), I believe this is just a simple typo where `options` was passed instead of `options.drop_defaults` [here](https://github.com/ipython/ipywidgets/blob/eb4dcd9956d88ae842bff7822a9c32fc038906dd/jupyter-js-widgets/src/widget.ts#L312).