### PR TITLE
Avoid conversion using type(value)

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -52,8 +52,8 @@ def _get_min_max_value(min, max, value=None, step=None):
         if not isinstance(value, Real):
             raise TypeError('expected a real number, got: %r' % value)
         if not value:
-            t = type(value)
-            min, max = (t(0), t(1))
+            # This gives (0, 1) of the correct type
+            min, max = (value, value + 1)
         elif value > 0:
             min, max = (-value, 3*value)
         else:

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -51,7 +51,7 @@ def _get_min_max_value(min, max, value=None, step=None):
     elif min is None and max is None:
         if not isinstance(value, Real):
             raise TypeError('expected a real number, got: %r' % value)
-        if not value:
+        if value == 0:
             # This gives (0, 1) of the correct type
             min, max = (value, value + 1)
         elif value > 0:


### PR DESCRIPTION
We should not assume that the following works to convert `1` to the same "type" as `value`:
```
t = type(value)
x = t(1)
```
In particular, this would break for many SageMath types.

As alternative, doing arithmetic with the given value does work for SageMath types and all standard Python types.