### PR TITLE
Add CommManager.comms shim

### DIFF
--- a/jupyter-js-widgets/src/services-shim.ts
+++ b/jupyter-js-widgets/src/services-shim.ts
@@ -47,6 +47,7 @@ namespace shims {
              */
             new_comm(target_name: string, data: any, callbacks: any, metadata: any, comm_id: string): Comm {
                 var comm = new Comm(this.jsServicesKernel.connectToComm(target_name, comm_id));
+                this.register_comm(comm);
                 comm.open(data, callbacks, metadata);
                 return comm;
             };
@@ -61,6 +62,7 @@ namespace shims {
                 var handle = this.jsServicesKernel.registerCommTarget(target_name, function(jsServicesComm, msg) {
                     // Create the comm.
                     var comm = new Comm(jsServicesComm);
+                    this.register_comm(comm);
 
                     // Call the callback for the comm.
                     try {
@@ -85,7 +87,17 @@ namespace shims {
                 delete this.targets[target_name];
             };
 
+            /**
+         	 * Register a comm in the mapping
+             */
+            register_comm = function (comm) {
+              this.comms[comm.comm_id] = Promise.resolve(comm);
+              comm.kernel = this.kernel;
+              return comm.comm_id;
+            };
+
             targets = Object.create(null);
+			comms = Object.create(null);
             kernel: IKernel = null; 
             jsServicesKernel: IKernel = null;
         }

--- a/jupyter-js-widgets/src/services-shim.ts
+++ b/jupyter-js-widgets/src/services-shim.ts
@@ -59,7 +59,7 @@ namespace shims {
              *                         comm is made.  Signature of f(comm, msg).
              */
             register_target (target_name, f) {
-                var handle = this.jsServicesKernel.registerCommTarget(target_name, function(jsServicesComm, msg) {
+                var handle = this.jsServicesKernel.registerCommTarget(target_name, _.bind(function(jsServicesComm, msg) {
                     // Create the comm.
                     var comm = new Comm(jsServicesComm);
                     this.register_comm(comm);
@@ -73,7 +73,7 @@ namespace shims {
                         console.error(wrapped_error);
                         return;
                     }
-                });
+                }, this));
                 this.targets[target_name] = handle;
             };
 
@@ -88,7 +88,7 @@ namespace shims {
             };
 
             /**
-         	 * Register a comm in the mapping
+             * Register a comm in the mapping
              */
             register_comm = function (comm) {
               this.comms[comm.comm_id] = Promise.resolve(comm);
@@ -97,7 +97,7 @@ namespace shims {
             };
 
             targets = Object.create(null);
-			comms = Object.create(null);
+            comms = Object.create(null);
             kernel: IKernel = null; 
             jsServicesKernel: IKernel = null;
         }

--- a/jupyter-js-widgets/src/services-shim.ts
+++ b/jupyter-js-widgets/src/services-shim.ts
@@ -59,7 +59,8 @@ namespace shims {
              *                         comm is made.  Signature of f(comm, msg).
              */
             register_target (target_name, f) {
-                var handle = this.jsServicesKernel.registerCommTarget(target_name, _.bind(function(jsServicesComm, msg) {
+                var handle = this.jsServicesKernel.registerCommTarget(target_name,
+                (jsServicesComm, msg) => {
                     // Create the comm.
                     var comm = new Comm(jsServicesComm);
                     this.register_comm(comm);
@@ -73,7 +74,7 @@ namespace shims {
                         console.error(wrapped_error);
                         return;
                     }
-                }, this));
+                });
                 this.targets[target_name] = handle;
             };
 


### PR DESCRIPTION
The current jupyter-js-services shim for the CommManager, which gets used by project's like the dashboard_server does not mirror the API of the real [CommManager](https://github.com/jupyter/notebook/blob/master/notebook/static/services/kernels/comm.js) completely, which is generally no problem but I was hoping to at least expose a means to look up existing comms. bokeh 0.12.2 will use this part of the comm_manager API to register an on_msg callback on an existing Comm. In future bokeh will probably correctly set up a notebook extension and/or display plots as a widget so this should no longer be needed but for the time being it would be great if we could expose the ``comms`` on the shim. Tested with bokeh 0.12.2rc2 and the current dashboard_server master.

