### PR TITLE
Allow arbitrary options to be passed to model.save by client

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -411,9 +411,11 @@ class WidgetModel extends Backbone.Model {
      *
      * This invokes a Backbone.Sync.
      */
-    save_changes(callbacks?) {
+    save_changes(callbacks?, options={}) {
         if (this.comm_live) {
-            let options: any = {patch: true}
+            _.defaults(options, {
+                patch: true
+            });
             if (callbacks) {
                 options.callbacks = callbacks;
             }


### PR DESCRIPTION
Small change to allow additional options to be passed to backbone's `model.save` method.  This would allow, e.g. passing `success`/`failure` callbacks so that code can be executed after save successfully completes.  