### PR TITLE
Change most functions in interaction.py to methods of interactive

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -1,5 +1,6 @@
 from .widget import Widget, CallbackDispatcher, register, widget_serialization, handle_version_comm_opened
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 
 from .trait_types import Color, EventfulDict, EventfulList
 

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -18,7 +18,7 @@ except ImportError:
     from inspect import getargspec as check_argspec # py2
 
 from IPython.core.getipython import get_ipython
-from . import (Widget, Text,
+from . import (ValueWidget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
     Box, Button, DOMWidget, Output)
 from IPython.display import display, clear_output
@@ -130,7 +130,7 @@ def _widget_abbrev(o):
 
 def _widget_from_abbrev(abbrev, default=empty):
     """Build a Widget instance given an abbreviation or Widget."""
-    if isinstance(abbrev, Widget) or isinstance(abbrev, fixed):
+    if isinstance(abbrev, ValueWidget) or isinstance(abbrev, fixed):
         return abbrev
 
     widget = _widget_abbrev(abbrev)
@@ -190,6 +190,7 @@ def _widgets_from_abbreviations(seq):
     result = []
     for name, abbrev, default in seq:
         widget = _widget_from_abbrev(abbrev, default)
+        assert isinstance(widget, ValueWidget) or isinstance(widget, fixed)
         if not widget.description:
             widget.description = name
         widget._kwarg = name

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -136,8 +136,8 @@ class interactive(Box):
 
         # If we are only to run the function on demand, add a button to request this.
         if self.manual:
-            manual_button = Button(description="Run %s" % f.__name__)
-            c.append(manual_button)
+            self.manual_button = Button(description="Run %s" % f.__name__)
+            c.append(self.manual_button)
 
         self.out = Output()
         c.append(self.out)
@@ -148,7 +148,7 @@ class interactive(Box):
         # Otherwise, it is triggered for every trait change received
         # On-demand running also suppresses running the function with the initial parameters
         if self.manual:
-            manual_button.on_click(self.call_f)
+            self.manual_button.on_click(self.call_f)
 
             # Also register input handlers on text areas, so the user can hit return to
             # invoke execution.
@@ -165,7 +165,7 @@ class interactive(Box):
     def call_f(self, *args):
         self.kwargs = {}
         if self.manual:
-            manual_button.disabled = True
+            self.manual_button.disabled = True
         try:
             for widget in self.kwargs_widgets:
                 value = widget.value
@@ -184,7 +184,7 @@ class interactive(Box):
                 ip.showtraceback()
         finally:
             if self.manual:
-                manual_button.disabled = False
+                self.manual_button.disabled = False
 
     # Find abbreviations
     def signature(self):

--- a/ipywidgets/widgets/valuewidget.py
+++ b/ipywidgets/widgets/valuewidget.py
@@ -1,0 +1,10 @@
+"""Contains the ValueWidget class"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from .widget import Widget
+
+
+class ValueWidget(Widget):
+    """Widget that can be used for the input of an interactive function"""

--- a/ipywidgets/widgets/widget_bool.py
+++ b/ipywidgets/widgets/widget_bool.py
@@ -7,11 +7,12 @@ Represents a boolean using a widget.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import register
 from traitlets import Unicode, Bool, CaselessStrEnum
 
 
-class _Bool(DOMWidget):
+class _Bool(DOMWidget, ValueWidget):
     """A base class for creating widgets that represent booleans."""
     value = Bool(False, help="Bool value").tag(sync=True)
     description = Unicode('', help="Description of the boolean (label).").tag(sync=True)

--- a/ipywidgets/widgets/widget_color.py
+++ b/ipywidgets/widgets/widget_color.py
@@ -7,13 +7,14 @@ Represents an HTML Color .
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import register
 from .trait_types import Color
 from traitlets import Unicode, Bool
 
 
 @register('Jupyter.ColorPicker')
-class ColorPicker(DOMWidget):
+class ColorPicker(DOMWidget, ValueWidget):
     value = Color('black').tag(sync=True)
     concise = Bool().tag(sync=True)
     description = Unicode().tag(sync=True)

--- a/ipywidgets/widgets/widget_controller.py
+++ b/ipywidgets/widgets/widget_controller.py
@@ -6,13 +6,14 @@ Represents a Gamepad or Joystick controller.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import Widget, register, widget_serialization
+from .valuewidget import ValueWidget
+from .widget import register, widget_serialization
 from .domwidget import DOMWidget
 from traitlets import Bool, Int, Float, Unicode, List, Instance
 
 
 @register('Jupyter.ControllerButton')
-class Button(Widget):
+class Button(ValueWidget):
     """Represents a gamepad or joystick button."""
     value = Float(min=0.0, max=1.0, read_only=True).tag(sync=True)
     pressed = Bool(read_only=True).tag(sync=True)
@@ -24,7 +25,7 @@ class Button(Widget):
 
 
 @register('Jupyter.ControllerAxis')
-class Axis(Widget):
+class Axis(ValueWidget):
     """Represents a gamepad or joystick axis."""
     value = Float(min=-1.0, max=1.0, read_only=True).tag(sync=True)
 

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -7,13 +7,14 @@ Represents an unbounded float using a widget.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import register
 from .trait_types import Color
 from traitlets import (Unicode, CFloat, Bool, Int, CaselessStrEnum,
                        Tuple, TraitError, validate)
 
 
-class _Float(DOMWidget):
+class _Float(DOMWidget, ValueWidget):
     value = CFloat(0.0, help="Float value").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     description = Unicode(help="Description of the value this widget represents").tag(sync=True)

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -9,12 +9,13 @@ Represents an image in the frontend using a widget.
 import base64
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import register
 from traitlets import Unicode, CUnicode, Bytes, observe
 
 
 @register('Jupyter.Image')
-class Image(DOMWidget):
+class Image(DOMWidget, ValueWidget):
     """Displays an image as a widget.
 
     The `value` of this widget accepts a byte string.  The byte string is the

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -7,6 +7,7 @@ Represents an unbounded int using a widget.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import register
 from .trait_types import Color
 from traitlets import (Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError,
@@ -61,7 +62,7 @@ def _bounded_int_doc(cls):
     return cls
 
 
-class _Int(DOMWidget):
+class _Int(DOMWidget, ValueWidget):
     """Base class for widgets that represent an integer."""
     value = CInt(0, help="Int value").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -8,6 +8,7 @@ Represents an enumeration using a widget.
 from collections import Mapping
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import register
 from traitlets import (Unicode, Bool, Any, Dict, TraitError, CaselessStrEnum,
                        Tuple, List, Union, observe, validate)
@@ -21,7 +22,7 @@ def _label_to_value(k, obj):
     return obj._options_dict[k]
 
 
-class _Selection(DOMWidget):
+class _Selection(DOMWidget, ValueWidget):
     """Base class for Selection widgets
 
     ``options`` can be specified as a list or dict. If given as a list,

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -7,12 +7,13 @@ Represents a unicode string using a widget.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
+from .valuewidget import ValueWidget
 from .widget import CallbackDispatcher, register
 from traitlets import Unicode, Bool
 from warnings import warn
 
 
-class _String(DOMWidget):
+class _String(DOMWidget, ValueWidget):
     """Base class used to create widgets that represent a string."""
 
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)


### PR DESCRIPTION
In order to allow users to override certain behaviours of `interactive`, change most functions from `interaction.py` to become methods of the class `interactive`. In the process, some functions are renamed and the two functions `_widget_from_abbrev` and `_widget_abbrev` have been merged to one method `widget_from_abbrev`.

Depends on #725.

Needed for https://github.com/OpenDreamKit/OpenDreamKit/issues/94