### PR TITLE
Set the value to a tick without the % operator

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -63,8 +63,8 @@ def _get_min_max_value(min, max, value=None, step=None):
         raise ValueError('unable to infer range, value from: ({0}, {1}, {2})'.format(min, max, value))
     if step is not None:
         # ensure value is on a step
-        r = (value - min) % step
-        value = value - r
+        tick = int((value - min) / step)
+        value = min + tick * step
     return min, max, value
 
 def _widget_abbrev_single_value(o):


### PR DESCRIPTION
Use slightly different logic in `_get_min_max_value` to ensure that the `value` is on a tick: compute the tick number as integer and then compute the value from that. This avoids the `%` operator, whose semantics might differ from what `_get_min_max_value` expects for certain numeric types, in particular in SageMath. Using `int(x/y)` unambiguously means: round `x/y` down to the nearest integer.