### PR TITLE
Trivial fix in jquery-less widgets

### DIFF
--- a/jupyter-js-widgets/src/widget_selectioncontainer.ts
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.ts
@@ -202,7 +202,7 @@ class AccordionView extends DOMWidgetView {
         accordion_inner.appendChild(dummy);
         return this.create_child_view(model).then(function(view) {
 
-            dummy.parentNode.replaceChild(dummy, view.el);
+            dummy.parentNode.replaceChild(view.el, dummy);
 
             that.update_selected_index();
             that.update_titles();


### PR DESCRIPTION
The new node is the first argument to `replaceChild`.