### PR TITLE
In _get_min_max_value(), allow all arguments to be given

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -41,30 +41,36 @@ def _matches(o, pattern):
 
 def _get_min_max_value(min, max, value=None, step=None):
     """Return min, max, value given input values with possible None."""
+    # Either min and max need to be given, or value needs to be given
     if value is None:
-        if not max > min:
-            raise ValueError('max must be greater than min: (min={0}, max={1})'.format(min, max))
+        if min is None or max is None:
+            raise ValueError('unable to infer range, value from: ({0}, {1}, {2})'.format(min, max, value))
         diff = max - min
         value = min + (diff / 2)
         # Ensure that value has the same type as diff
         if not isinstance(value, type(diff)):
             value = min + (diff // 2)
-    elif min is None and max is None:
+    else:  # value is not None
         if not isinstance(value, Real):
             raise TypeError('expected a real number, got: %r' % value)
+        # Infer min/max from value
         if value == 0:
             # This gives (0, 1) of the correct type
-            min, max = (value, value + 1)
+            vrange = (value, value + 1)
         elif value > 0:
-            min, max = (-value, 3*value)
+            vrange = (-value, 3*value)
         else:
-            min, max = (3*value, -value)
-    else:
-        raise ValueError('unable to infer range, value from: ({0}, {1}, {2})'.format(min, max, value))
+            vrange = (3*value, -value)
+        if min is None:
+            min = vrange[0]
+        if max is None:
+            max = vrange[1]
     if step is not None:
         # ensure value is on a step
         tick = int((value - min) / step)
         value = min + tick * step
+    if not min <= value <= max:
+        raise ValueError('value must be between min and max (min={0}, value={1}, max={2})'.format(min, value, max))
     return min, max, value
 
 def _yield_abbreviations_for_parameter(param, kwargs):


### PR DESCRIPTION
In the function `_get_min_max_value()`, allow all arguments (all 3 of `min`, `max`, `value`) to be given.

In the current implementation, if `value` is given, then it is required that `min` and `max` are `None`. This makes little sense. This PR does not change any existing behaviour, but it allows for future improvements.