### PR TITLE
Move test setup() to tests/__init__.py

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -155,21 +155,30 @@ class interactive(Box):
         # Otherwise, it is triggered for every trait change received
         # On-demand running also suppresses running the function with the initial parameters
         if self.manual:
-            self.manual_button.on_click(self.call_f)
+            self.manual_button.on_click(self.update)
 
             # Also register input handlers on text areas, so the user can hit return to
             # invoke execution.
             for w in self.kwargs_widgets:
                 if isinstance(w, Text):
-                    w.on_submit(self.call_f)
+                    w.on_submit(self.update)
         else:
             for widget in self.kwargs_widgets:
-                widget.observe(self.call_f, names='value')
+                widget.observe(self.update, names='value')
 
-            self.on_displayed(lambda _: self.call_f(dict(name=None, old=None, new=None)))
+            self.on_displayed(lambda _: self.update(dict(name=None, old=None, new=None)))
 
     # Callback function
-    def call_f(self, *args):
+    def update(self, *args):
+        """
+        Call the interact function and update the output widget with
+        the result of the function call.
+
+        Parameters
+        ----------
+        *args : ignored
+            Required for this method to be used as traitlets callback.
+        """
         self.kwargs = {}
         if self.manual:
             self.manual_button.disabled = True

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -166,7 +166,7 @@ class interactive(Box):
             for widget in self.kwargs_widgets:
                 widget.observe(self.update, names='value')
 
-            self.on_displayed(lambda _: self.update(dict(name=None, old=None, new=None)))
+            self.on_displayed(self.update)
 
     # Callback function
     def update(self, *args):

--- a/ipywidgets/widgets/tests/__init__.py
+++ b/ipywidgets/widgets/tests/__init__.py
@@ -1,0 +1,32 @@
+from ipykernel.comm import Comm
+from ipywidgets import Widget
+
+class DummyComm(Comm):
+    comm_id = 'a-b-c-d'
+
+    def open(self, *args, **kwargs):
+        pass
+
+    def send(self, *args, **kwargs):
+        pass
+
+    def close(self, *args, **kwargs):
+        pass
+
+_widget_attrs = {}
+undefined = object()
+
+def setup_test_comm():
+    _widget_attrs['_comm_default'] = getattr(Widget, '_comm_default', undefined)
+    Widget._comm_default = lambda self: DummyComm()
+    _widget_attrs['_ipython_display_'] = Widget._ipython_display_
+    def raise_not_implemented(*args, **kwargs):
+        raise NotImplementedError()
+    Widget._ipython_display_ = raise_not_implemented
+
+def teardown_test_comm():
+    for attr, value in _widget_attrs.items():
+        if value is undefined:
+            delattr(Widget, attr)
+        else:
+            setattr(Widget, attr, value)

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -608,10 +608,10 @@ def test_interact_manual_nocall():
 
 def test_interact_call():
     w = interact.widget(f)
-    w.call_f()
+    w.update()
 
     w = interact_manual.widget(f)
-    w.call_f()
+    w.update()
 
 def test_interact_options():
     def f(x):
@@ -751,5 +751,5 @@ def test_get_interact_value():
             return 42
     w = TheAnswer()
     c = interactive(lambda v: v, v=w)
-    c.call_f()
+    c.update()
     nt.assert_equal(c.result, 42)

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -16,7 +16,8 @@ from ipykernel.comm import Comm
 import ipywidgets as widgets
 
 from traitlets import TraitError
-from ipywidgets import interact, interactive, Widget, interaction, Output
+from ipywidgets import (interact, interact_manual, interactive, Widget,
+    interaction, Output)
 from ipython_genutils.py3compat import annotate
 
 #-----------------------------------------------------------------------------
@@ -593,7 +594,7 @@ def test_custom_description():
     nt.assert_equal(d, {'b': 'different text'})
 
 def test_interact_manual_button():
-    c = interactive(f, __manual=True)
+    c = interact.options(manual=True).widget(f)
     w = c.children[0]
     check_widget(w, cls=widgets.Button)
 
@@ -601,9 +602,32 @@ def test_interact_manual_nocall():
     callcount = 0
     def calltest(testarg):
         callcount += 1
-    c = interactive(calltest, testarg=5, __manual=True)
+    c = interact.options(manual=True)(calltest, testarg=5).widget
     c.children[0].value = 10
     nt.assert_equal(callcount, 0)
+
+def test_interact_call():
+    w = interact.widget(f)
+    w.call_f()
+
+    w = interact_manual.widget(f)
+    w.call_f()
+
+def test_interact_options():
+    def f(x):
+        return x
+    w = interact.options(manual=False).options(manual=True)(f, x=21).widget
+    nt.assert_equal(w.manual, True)
+
+    w = interact_manual.options(manual=False).options()(x=21).widget(f)
+    nt.assert_equal(w.manual, False)
+
+    w = interact(x=21)().options(manual=True)(f).widget
+    nt.assert_equal(w.manual, True)
+
+def test_interact_options_bad():
+    with nt.assert_raises(ValueError):
+        interact.options(bad="foo")
 
 def test_int_range_logic():
     irsw = widgets.IntRangeSlider

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -12,11 +12,10 @@ except ImportError:
 
 import nose.tools as nt
 
-from ipykernel.comm import Comm
 import ipywidgets as widgets
 
 from traitlets import TraitError
-from ipywidgets import (interact, interact_manual, interactive, Widget,
+from ipywidgets import (interact, interact_manual, interactive,
     interaction, Output)
 from ipython_genutils.py3compat import annotate
 
@@ -24,40 +23,18 @@ from ipython_genutils.py3compat import annotate
 # Utility stuff
 #-----------------------------------------------------------------------------
 
-class DummyComm(Comm):
-    comm_id = 'a-b-c-d'
-
-    def open(self, *args, **kwargs):
-        pass
-
-    def send(self, *args, **kwargs):
-        pass
-
-    def close(self, *args, **kwargs):
-        pass
-
-_widget_attrs = {}
-displayed = []
-undefined = object()
+from . import setup_test_comm, teardown_test_comm
 
 def setup():
-    _widget_attrs['_comm_default'] = getattr(Widget, '_comm_default', undefined)
-    Widget._comm_default = lambda self: DummyComm()
-    _widget_attrs['_ipython_display_'] = Widget._ipython_display_
-    def raise_not_implemented(*args, **kwargs):
-        raise NotImplementedError()
-    Widget._ipython_display_ = raise_not_implemented
+    setup_test_comm()
 
 def teardown():
-    for attr, value in _widget_attrs.items():
-        if value is undefined:
-            delattr(Widget, attr)
-        else:
-            setattr(Widget, attr, value)
+    teardown_test_comm()
 
 def f(**kwargs):
     pass
 
+displayed = []
 def clear_display():
     global displayed
     displayed = []


### PR DESCRIPTION
Move the implementation of a fake `Comm` for testing interacts to `ipywidgets/widgets/tests/__init__.py` to make it more easily available externally, for example for testing interact functionality in SageMath.

Continued from #771 to avoid merge conflicts.