### PR TITLE
Make jupyterlab depend on an explicit version of jupyter-js-widgets.

### DIFF
--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "jupyter-js-widgets": "file:../jupyter-js-widgets",
+    "jupyter-js-widgets": "^2.0.0-dev.20",
     "jupyterlab": "^0.3.0",
     "phosphor": "^0.6.1"
   },


### PR DESCRIPTION
If another package depends on jupyterlab_widgets, it will need to pull down an explicit jupyter-js-widgets dependency version, not a relative path to jupyter-js-widgets.