### PR TITLE
pass data to comm open message

### DIFF
--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -142,7 +142,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
    */
    _create_comm(target_name: string, model_id: string, data?: any): Promise<any> {
     let comm = this._context.kernel.connectToComm(target_name, model_id);
-    comm.open(); // should we open it???
+    comm.open(data);
     return Promise.resolve(new shims.services.Comm(comm));
   }
 


### PR DESCRIPTION
In the lab extension widget manager, we failed to pass data in the comm open messaged which caused some issues when creating widgets from the front end.