### PR TITLE
WIP Resize of change of layout attribute

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -15,6 +15,14 @@ import {
     Widget
 } from 'phosphor/lib/ui/widget';
 
+import {
+  sendMessage
+} from 'phosphor/lib/core/messaging';
+
+import {
+  ResizeMessage
+} from 'phosphor/lib/ui/widget';
+
 /**
  * Replace model ids with models recursively.
  */
@@ -750,12 +758,17 @@ class DOMWidgetView extends WidgetView {
             this.layoutPromise = this.layoutPromise.then((oldLayoutView) => {
                 if (oldLayoutView) {
                     oldLayoutView.unlayout();
+                    this.stopListening(oldLayout);
+                    oldLayoutView.remove();
                 }
 
                 return this.create_child_view(layout).then((view) => {
                     // Trigger the displayed event of the child view.
                     return this.displayed.then(() => {
                         view.trigger('displayed', this);
+                        this.listenTo(layout, 'change', () => {
+                            sendMessage(this.pWidget, ResizeMessage.UnknownSize);
+                        });
                         return view;
                     });
                 }).catch(utils.reject('Could not add LayoutView to DOMWidgetView', true));

--- a/jupyter-js-widgets/src/widget_box.ts
+++ b/jupyter-js-widgets/src/widget_box.ts
@@ -280,9 +280,9 @@ class BoxView extends DOMWidgetView {
             dummy.dispose();
 
             // Trigger the displayed event of the child view.
-            this.displayed.then(() => {
-                view.trigger('displayed', this);
-            });
+            //this.displayed.then(() => {
+            //    view.trigger('displayed', this);
+            //});
             return view;
         }).catch(reject('Could not add child view to box', true));
     }


### PR DESCRIPTION
@jasongrout @sccolbert comments?

Now I understand what is going on: 
- The box widget should not add children to the DOM manually but call attach.
- since onAfterAttach triggers jupyter-js-widgets'  `display` event, we should make it not trigger the displayed event.
