### PR TITLE
Migrate to typescript 2

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -62,7 +62,7 @@
     "spawn-sync": "^1.0.14",
     "style-loader": "^0.13.1",
     "typedoc": "^0.4.2",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.3",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.11"
   },

--- a/jupyter-js-widgets/src/embed-manager.ts
+++ b/jupyter-js-widgets/src/embed-manager.ts
@@ -39,7 +39,7 @@ class EmbedManager extends ManagerBase<HTMLElement> {
      * that attempts loading the module from unpkg. 
      */
     require_error(success_callback) {
-        return function(err) {
+        return function(err) : any {
             var failedId = err.requireModules && err.requireModules[0];
             if (failedId) {
                 // TODO: Get typing to work for requirejs

--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -125,7 +125,7 @@ abstract class ManagerBase<T> {
      * The default implementation just throws the original error.
      */
     require_error (success_callback) {
-        return function(err) {
+        return function(err) : any {
             throw err;
         };
     };

--- a/jupyter-js-widgets/src/utils.ts
+++ b/jupyter-js-widgets/src/utils.ts
@@ -39,7 +39,7 @@ class WrappedError extends Error {
         }
         this.error_stack.push(this);
     }
-    error_stack: this[];
+    error_stack: any[];
 }
 
 /**

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -417,7 +417,7 @@ class DropdownView extends DOMWidgetView {
     buttongroup: HTMLDivElement;
     droplabel: HTMLButtonElement;
     dropbutton: HTMLButtonElement;
-    caret: HTMLPhraseElement;
+    caret: HTMLElement;
 }
 
 export

--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -5,16 +5,16 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "jupyter-js-widgets": "^2.0.0-dev.23",
-    "jupyterlab": "^0.3.0",
+    "jupyter-js-widgets": "file:../jupyter-js-widgets",
+    "jupyterlab": "^0.4.1",
     "phosphor": "^0.6.1"
   },
   "devDependencies": {
     "jupyter-js-services": "^0.18.1",
-    "jupyterlab-extension-builder": "^0.4.0",
+    "jupyterlab-extension-builder": "^0.6.2",
     "rimraf": "^2.4.2",
     "typedoc": "^0.4.4",
-    "typescript": "^1.8.0"
+    "typescript": "^2.0.3"
   },
   "scripts": {
     "clean": "rimraf docs && rimraf lib && rimraf jupyterlab_widgets/static",

--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -30,6 +30,10 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
+
+import {
   IRenderMime, RenderMime
 } from 'jupyterlab/lib/rendermime';
 
@@ -254,7 +258,7 @@ class WidgetRenderer implements RenderMime.IRenderer, IDisposable {
   /**
    * Render a widget mimetype.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     // data is a model id
     let w = new Panel();
     this._manager.get_model(options.source).then((model: any) => {


### PR DESCRIPTION
Besides I am requiring `jupyter-js-widgets` by file path like in widgetsnbextension in the labextension.

@jasongrout 