### PR TITLE
Add building docs locally instructions to docs

### DIFF
--- a/docs/source/dev_docs.md
+++ b/docs/source/dev_docs.md
@@ -1,0 +1,38 @@
+Building the Documentation
+==========================
+
+To build the documentation you'll need `Sphinx <http://www.sphinx-doc.org/>`_, `pandoc <http://pandoc.org/>`_
+and a few other packages.
+
+To install (and activate) a `conda environment`_ named ``notebook_docs``
+containing all the necessary packages (except pandoc), use::
+
+    conda env create -f docs/environment.yml
+    source activate notebook_docs  # Linux and OS X
+    activate notebook_docs         # Windows
+
+.. _conda environment:
+    http://conda.pydata.org/docs/using/envs.html#use-environment-from-file
+
+If you want to install the necessary packages with ``pip`` instead, use
+(omitting --user if working in a virtual environment)::
+
+    pip install -r docs/doc-requirements.txt --user
+
+Once you have installed the required packages, you can build the docs with::
+
+    cd docs
+    make html
+
+After that, the generated HTML files will be available at
+``build/html/index.html``. You may view the docs in your browser.
+
+You can automatically check if all hyperlinks are still valid::
+
+    make linkcheck
+
+Windows users can find ``make.bat`` in the ``docs`` folder.
+
+You should also have a look at the `Project Jupyter Documentation Guide`__.
+
+__ https://jupyter.readthedocs.io/en/latest/contrib_docs/index.html

--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -70,3 +70,18 @@ permissions on npm and pip related install directories are correct.
         the `conda` directory
 
     - Try reinstalling ipywidgets
+    
+Releasing new versions
+----------------------
+
+See [dev_release.md](dev_release.md) for a details on how to release new versions of ipywidgets to PyPI and jupyter-js-widgets on npm. 
+
+Testing
+-------
+
+See [dev_testing.md](dev_testing.md) for a details on how to run Python and Javascript tests. 
+
+Building documentation
+----------------------
+
+See [dev_docs.md](dev_docs.md) for a details on how to build the docs. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,4 +27,5 @@ Contents
 
     dev_install.md
     dev_testing.md
+    dev_docs.md
     dev_release.md


### PR DESCRIPTION
There was no documentation for this so I referenced the docs from [notebook](https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst#building-the-documentation).