### PR TITLE
Improve build on RTD

### DIFF
--- a/docs/build-rtd.sh
+++ b/docs/build-rtd.sh
@@ -4,4 +4,7 @@ nvm install 5
 nvm use 5
 nvm alias default 5
 npm install -g npm
-bash build-local.sh
+cd ../../jupyter-js-widgets
+npm install
+cd ../docs
+npm install

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,7 @@
 name: ipywidget_docs
 channels:
 - conda-forge
+- defaults
 dependencies:
 - python=3.5
 - sphinx_rtd_theme
@@ -9,8 +10,10 @@ dependencies:
 - nbformat
 - ipywidgets
 - notebook>=4.2
+- sphinx>=1.4.6
+- ipykernel
 - pip:
-  - sphinx==1.4.5
-  - nbsphinx==0.2.7
+  - nbsphinx==0.2.9
   - sphinx_rtd_theme==0.1.10-alpha
   - python-dateutil
+  - recommonmark==0.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
 jupyter_client
-sphinx==1.3.6
+sphinx>=1.4.6
 sphinx_rtd_theme==0.1.10-alpha
+nbsphinx==0.2.9
+recommonmark==0.4.0
+ipykernel

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,32 +2,37 @@
 # -*- coding: utf-8 -*-
 #
 
-import sphinx_rtd_theme
 import os
 import subprocess
 import sys
+import sphinx_rtd_theme
+import recommonmark.parser
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-def bash(fileName):
+# -- path -------------------------------------------------------
+
+from os.path import dirname
+docs = dirname(dirname(__file__))
+root = dirname(docs)
+sys.path.insert(0, root)
+
+
+# -- bash utility function --------------------------------------
+def bash(filename):
     """Runs a bash script in the local directory"""
     sys.stdout.flush()
-    subprocess.call("bash {}".format(fileName), shell=True)
+    subprocess.call("bash {}".format(filename), shell=True)
 
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-source_suffix = ['.rst', '.ipynb']
 
-# Conf.py import settings
-source_parsers = {}
+# -- source files and parsers -----------------------------------
 
-def init_theme():
-    from recommonmark.parser import CommonMarkParser
-    source_parsers['.md'] = CommonMarkParser
-    source_suffix.append('.md')
+source_suffix = ['.rst', '.md', '.ipynb']
+source_parsers = {
+    '.md': recommonmark.parser.CommonMarkParser,
+}
 
-html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# -- Sphinx extensions and configuration ------------------------
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -38,46 +43,79 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
 ]
 
-init_theme()
+intersphinx_mapping = {
+    'ipython': ('http://ipython.org/ipython-doc/dev/', None),
+    'nbconvert': ('http://nbconvert.readthedocs.io/en/latest/', None),
+    'nbformat': ('http://nbformat.readthedocs.io/en/latest/', None),
+    'jupyter': ('http://jupyter.readthedocs.io/en/latest/', None),
+}
+
+nbsphinx_allow_errors = True   # exception ipstruct.py ipython_genutils
+
+# -- RTD and local build instructions -----------------------
+
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if on_rtd:
     print('On RTD, installing node and building...')
     bash('../build-rtd.sh')
 else:
-    print('Not on RTD, building...')
+    print('Local build not on RTD, building...')
+
+    # set theme; see end of file for theme options
+    html_theme = "sphinx_rtd_theme"
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     bash('../build-local.sh')
+
 print('Done bulding')
+
+
+# -- General information -------
 
 _release = {}
 exec(compile(open('../../ipywidgets/_version.py').read(), '../../ipywidgets/_version.py', 'exec'), _release)
+version = '.'.join(map(str, _release['version_info'][:2]))
+release = _release['__version__']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-master_doc = 'index'
 
-# General information about the project.
+master_doc = 'index'
 project = 'ipywidgets and jupyter-js-widgets'
 copyright = '2016, Jupyter Team, https://jupyter.org'
 author = 'Jupyter Team'
 
-version = '.'.join(map(str, _release['version_info'][:2]))
-release = _release['__version__']
 language = None
-exclude_patterns = []
+exclude_patterns = ['_build', '**.ipynb_checkpoints', 'examples/Imag*']
 pygments_style = 'sphinx'
 todo_include_todos = False
+
+
+# -- html --------------------------
+
+html_static_path = ['_static']
 htmlhelp_basename = 'ipywidgetsdoc'
 
-latex_elements = { }
+
+# -- latex -------------------------
+
+latex_elements = {}
 latex_documents = [
   (master_doc, 'ipywidgets.tex', 'ipywidgets Documentation',
    'https://jupyter.org', 'manual'),
 ]
+
+
+# -- tex ---------------------------
+
 texinfo_documents = [
   (master_doc, 'ipywidgets', 'ipywidgets Documentation',
    author, 'ipywidgets', 'One line description of project.',
    'Miscellaneous'),
 ]
+
+
+# -- epub --------------------------
 
 # Bibliographic Dublin Core info.
 epub_title = project
@@ -85,16 +123,8 @@ epub_author = author
 epub_publisher = author
 epub_copyright = copyright
 
-intersphinx_mapping = {
-    'ipython': ('http://ipython.org/ipython-doc/dev/', None),
-    'nbconvert': ('http://nbconvert.readthedocs.org/en/latest/', None),
-    'nbformat': ('http://nbformat.readthedocs.org/en/latest/', None),
-    'jupyter': ('http://jupyter.readthedocs.org/en/latest/', None),
-}
-html_static_path = ['_static']
 
-# Theme options are theme-specific and customize the look and feel of a
-# theme further.
+# -- Theme options -----------------
+
+# Options are theme-specific and customize the look and feel of the theme.
 html_theme_options = {}
-
-nbsphinx_allow_errors = True

--- a/docs/source/dev_docs.rst
+++ b/docs/source/dev_docs.rst
@@ -8,8 +8,8 @@ To install (and activate) a `conda environment`_ named ``notebook_docs``
 containing all the necessary packages (except pandoc), use::
 
     conda env create -f docs/environment.yml
-    source activate notebook_docs  # Linux and OS X
-    activate notebook_docs         # Windows
+    source activate ipywidget_docs  # Linux and OS X
+    activate ipywidget_docs         # Windows
 
 .. _conda environment:
     http://conda.pydata.org/docs/using/envs.html#use-environment-from-file
@@ -17,11 +17,12 @@ containing all the necessary packages (except pandoc), use::
 If you want to install the necessary packages with ``pip`` instead, use
 (omitting --user if working in a virtual environment)::
 
-    pip install -r docs/doc-requirements.txt --user
+    pip install -r docs/requirements.txt --user
 
 Once you have installed the required packages, you can build the docs with::
 
     cd docs
+    make clean
     make html
 
 After that, the generated HTML files will be available at

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -539,7 +539,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -553,77 +553,77 @@
     "072d62154ba14f13ac51e6fe0dac936a": {
      "views": [
       {
-       "cell_index": 17
+       "cell_index": 17.0
       }
      ]
     },
     "1b2f795293ac4359b5d19f671cd1dc8d": {
      "views": [
       {
-       "cell_index": 14
+       "cell_index": 14.0
       }
      ]
     },
     "613e8b5c7e184c30a80550778b2eadcc": {
      "views": [
       {
-       "cell_index": 11
+       "cell_index": 11.0
       }
      ]
     },
     "66dbbd7aa7274e0190bc35f3c8fe9b14": {
      "views": [
       {
-       "cell_index": 5
+       "cell_index": 5.0
       }
      ]
     },
     "6829b17e477c42fd94abca8d29b45583": {
      "views": [
       {
-       "cell_index": 27
+       "cell_index": 27.0
       }
      ]
     },
     "9b5c457b6f3e4ed2b294333ddec0a239": {
      "views": [
       {
-       "cell_index": 15
+       "cell_index": 15.0
       }
      ]
     },
     "9c824a83ddcf45859eb7b47b3f729d78": {
      "views": [
       {
-       "cell_index": 7
+       "cell_index": 7.0
       }
      ]
     },
     "b8ed930fd529488c917e480c59c94c42": {
      "views": [
       {
-       "cell_index": 9
+       "cell_index": 9.0
       }
      ]
     },
     "cbd0dfcfedb14cdeb0a19cea9f1ddf1f": {
      "views": [
       {
-       "cell_index": 25
+       "cell_index": 25.0
       }
      ]
     },
     "d57ab2bb075548f995fd14eeb47a32a5": {
      "views": [
       {
-       "cell_index": 21
+       "cell_index": 21.0
       }
      ]
     },
     "e7a2f86e565849489c1c0c7ba803a82d": {
      "views": [
       {
-       "cell_index": 23
+       "cell_index": 23.0
       }
      ]
     }
@@ -632,5 +632,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,5 +27,5 @@ Contents
 
     dev_install.md
     dev_testing.md
-    dev_docs.md
+    dev_docs
     dev_release.md


### PR DESCRIPTION
- Update `environment.yml` and `requirements.txt` to align package versions
- Replace `bash build-local.sh` in `build-rtd.sh` as RTD would not execute the bash command but will execute the individual commands contained in the script.
- Updated the suffix for `dev_doc` as it is a `.rst` file not `.md`. Also updated the environment name.
- Simplified and documented `conf.py` to be more consistent with Sphinx and other Jupyter projects 
- In `conf.py` enabled support for rst, md, and ipynb since all are needed

What to iterate on
- There are a number of nbsphinx image warnings though docs build
- There are still the JavaScript errors in `Widget Styling.ipynb`
- There are some places where data type is not recognized. Perhaps not recognizing `application/vnd.jupyter.widget` as a recent change?

Rendered Docs: http://test-widgets.readthedocs.io/en/fix-build/