### PR TITLE
2.0

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-js-widgets",
-  "version": "2.0.0-dev.23",
+  "version": "2.0.0",
   "description": "Jupyter interactive widgets",
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",

--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -1,11 +1,11 @@
 {
   "name": "jupyterlab_widgets",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The JupyterLab extension providing Jupyter widgets.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "jupyter-js-widgets": "file:../jupyter-js-widgets",
+    "jupyter-js-widgets": "^2.0.0",
     "jupyterlab": "^0.4.1",
     "phosphor": "^0.6.1"
   },


### PR DESCRIPTION
Update jupyter-js-widgets to 2.0.0, but publish it with the next tag:

```
npm publish --tag=next
```

We do this so that semver for `^2.0.0` works correctly, so we don't keep breaking things when we make a patch release of this dev version.