### PR TITLE
Initializing buffered_state_diff correctly

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -88,7 +88,6 @@ class WidgetModel extends Backbone.Model {
         let comm = options.comm;
 
         this.state_change = Promise.resolve();
-        this._buffered_state_diff = {};
         this.pending_msgs = 0;
         this.msg_buffer = null;
         this.state_lock = null;
@@ -276,7 +275,7 @@ class WidgetModel extends Backbone.Model {
         // However, we don't buffer the initial state coming from the
         // backend or the default values specified in `defaults`.
         //
-        this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
+        this._buffered_state_diff = _.extend(this._buffered_state_diff || {}, this.changedAttributes() || {});
         return return_value;
     }
 


### PR DESCRIPTION
In widgets, we changed from over-riding `constructor` to over-riding `initialize`. But `initialize` is called after set and I think we want `_buffered_state_diff` initialized before, because in `set` we try to update the `_buffered_state_diff`. 

After a discussion with @jasongrout, we decided that this is the minimally intrusive change that we can make to have `_buffered_state_diff` initialized before `set` is called.  