### PR TITLE
Buffered state diff bug fix

### DIFF
--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -216,9 +216,9 @@ abstract class ManagerBase<T> {
             options_clone.comm = comm;
             let widget_model = this.new_model(options_clone, serialized_state);
             widget_model.then(model => {
-+                model.sync('create', model);
-+                return model;
-+            });
+                model.sync('create', model);
+                return model;
+            });
         }, () => {
             // Comm Promise Rejected.
             if (!options_clone.model_id) {

--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -215,7 +215,7 @@ abstract class ManagerBase<T> {
             // Comm Promise Resolved.
             options_clone.comm = comm;
             let widget_model = this.new_model(options_clone, serialized_state);
-            widget_model.then(model => {
+            return widget_model.then(model => {
                 model.sync('create', model);
                 return model;
             });

--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -214,7 +214,11 @@ abstract class ManagerBase<T> {
         return commPromise.then((comm) => {
             // Comm Promise Resolved.
             options_clone.comm = comm;
-            return this.new_model(options_clone, serialized_state);
+            let widget_model = this.new_model(options_clone, serialized_state);
+            widget_model.then(model => {
++                model.sync('create', model);
++                return model;
++            });
         }, () => {
             // Comm Promise Rejected.
             if (!options_clone.model_id) {
@@ -289,7 +293,6 @@ abstract class ManagerBase<T> {
                         comm: options.comm,
                     }
                     var widget_model = new ModelType(attributes, modelOptions);
-                    widget_model.sync('create', widget_model);
                     widget_model.once('comm:close', function () {
                         delete that._models[model_id];
                     });

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -91,7 +91,7 @@ class WidgetModel extends Backbone.Model {
         this.pending_msgs = 0;
         this.msg_buffer = null;
         this.state_lock = null;
-        // this.initialized = true;
+        this.initialized = true;
 
         this.views = {};
 
@@ -276,7 +276,7 @@ class WidgetModel extends Backbone.Model {
         // However, we don't buffer the initial state coming from the
         // backend or the default values specified in `defaults`.
         //
-        if (true) {}
+        if (this.initialized) {
             this._buffered_state_diff = _.extend(this._buffered_state_diff || {}, this.changedAttributes() || {});
         }
         return return_value;
@@ -503,6 +503,7 @@ class WidgetModel extends Backbone.Model {
     comm_live: boolean;
     model_id: string;
     msg_buffer_callbacks: any;
+    initialized: boolean;
 }
 
 export

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -91,6 +91,7 @@ class WidgetModel extends Backbone.Model {
         this.pending_msgs = 0;
         this.msg_buffer = null;
         this.state_lock = null;
+        // this.initialized = true;
 
         this.views = {};
 
@@ -275,7 +276,9 @@ class WidgetModel extends Backbone.Model {
         // However, we don't buffer the initial state coming from the
         // backend or the default values specified in `defaults`.
         //
-        this._buffered_state_diff = _.extend(this._buffered_state_diff || {}, this.changedAttributes() || {});
+        if (true) {}
+            this._buffered_state_diff = _.extend(this._buffered_state_diff || {}, this.changedAttributes() || {});
+        }
         return return_value;
     }
 

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -88,7 +88,6 @@ class WidgetModel extends Backbone.Model {
         let comm = options.comm;
 
         this.state_change = Promise.resolve();
-        this._buffered_state_diff = {};
         this.pending_msgs = 0;
         this.msg_buffer = null;
         this.state_lock = null;
@@ -276,7 +275,7 @@ class WidgetModel extends Backbone.Model {
         // However, we don't buffer the initial state coming from the
         // backend or the default values specified in `defaults`.
         //
-        this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
+        this._buffered_state_diff = _.extend(this._buffered_state_diff || {}, this.changedAttributes() || {});
         return return_value;
     }
 

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -507,7 +507,6 @@ class WidgetModel extends Backbone.Model {
     comm_live: boolean;
     model_id: string;
     msg_buffer_callbacks: any;
-    initialized: boolean;
 }
 
 export


### PR DESCRIPTION
This is on top of my PR #832. 

I think, the root issue is that in WidgetModel the attribute _buffered_state_diff is not set correctly on initialization. So when the first sync from javascript happens, the change handlers of all the attributes are notified. Also, if any of the other attributes changed, they are being overwritten by the old values which came back in the comm message.