### PR TITLE
Add no wrapping and overflow indication to descriptions and buttons

### DIFF
--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -229,10 +229,11 @@
     color: #333333;
     cursor: pointer;
     display: inline-block;
-    overflow: hidden;
     text-align: center;
     vertical-align: middle;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     i.fa {
         padding-right: 3px;
@@ -644,7 +645,9 @@ ul.widget-dropdown-droplist {
         padding-top    : 5px;
         text-align     : right;
         vertical-align : text-top;
-        overflow: 'hidden';
+        white-space    : nowrap;
+        overflow       : hidden;
+        text-overflow  : ellipsis;
     }
 
     .widget-readout {
@@ -683,7 +686,9 @@ ul.widget-dropdown-droplist {
         padding-bottom : 5px;
         text-align     : center;
         vertical-align : text-bottom;
+        white-space    : nowrap;
         overflow       : hidden;
+        text-overflow  : ellipsis;
     }
 
     .widget-readout {


### PR DESCRIPTION
This enforces the design constraint that widget descriptions and buttons have a single line of text.