### PR TITLE
In JLab, handle the case where a widget model is not found.

### DIFF
--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -171,6 +171,7 @@ abstract class ManagerBase<T> {
      * Get a promise for a model by model id.
      */
     get_model(model_id: string): Promise<Backbone.Model> {
+        // Perhaps we should return a Promise.reject if the model is not found.
         return this._models[model_id];
     };
 

--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -261,11 +261,19 @@ class WidgetRenderer implements RenderMime.IRenderer, IDisposable {
   render(options: RenderMime.IRendererOptions<string>): Widget {
     // data is a model id
     let w = new Panel();
-    this._manager.get_model(options.source).then((model: any) => {
-      return this._manager.display_model(void 0, model, void 0);
-    }).then((view: Widget) => {
-      w.addWidget(view);
-    });
+    let model = this._manager.get_model(options.source);
+    if (model) {
+      model.then((model: any) => {
+        return this._manager.display_model(void 0, model, void 0);
+      }).then((view: Widget) => {
+        w.addWidget(view);
+      });
+    } else {
+      // Model doesn't exist
+      let error = document.createElement('p');
+      error.textContent = 'Widget not found.';
+      w.addWidget(new Widget({node: error}));
+    }
     return w;
   }
 


### PR DESCRIPTION
This comes up when opening a notebook where widgets were already displayed and saved. Really, we should make the rendering system smarter, so that we can give up, and the rendering system will continue to try to find a new renderer.