### PR TITLE
Refactor lab extension

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -469,14 +469,11 @@ class Widget(LoggingConfigurable):
         if self._view_name is not None:
             validated = Widget._version_validated
 
-            # Before the user tries to display a widget.  Validate that the
+            # Before the user tries to display a widget, validate that the
             # widget front-end is what is expected.
             if validated is None:
                 loud_error('Widget Javascript not detected.  It may not be '
-                           'installed properly. Did you enable the '
-                           'widgetsnbextension? If not, then run "jupyter '
-                           'nbextension enable --py --sys-prefix '
-                           'widgetsnbextension"')
+                           'installed or enabled properly.')
             elif not validated:
                 loud_error('The installed widget Javascript is the wrong version.')
 
@@ -489,7 +486,7 @@ class Widget(LoggingConfigurable):
             # http://tools.ietf.org/html/rfc6838
             # and the currently registered mimetypes at
             # http://www.iana.org/assignments/media-types/media-types.xhtml.
-            # We don't have a 'text/plain' entry so that the display message will be
+            # We don't have a 'text/plain' entry, so this display message will be
             # will be invisible in the current notebook.
             data = {'application/vnd.jupyter.widget': self._model_id}
             display(data, raw=True)

--- a/jupyter-js-widgets/less/widgets.less
+++ b/jupyter-js-widgets/less/widgets.less
@@ -549,6 +549,14 @@ ul.widget-dropdown-droplist {
         flex-grow: 1;
         margin-top: auto;
         margin-bottom: auto;
+
+        overflow: hidden;
+        height: 18px;
+        background-color: #f5f5f5;
+        border-radius: 2px;
+        -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+
     }
 
     .progress-bar {
@@ -558,6 +566,17 @@ ul.widget-dropdown-droplist {
         -ms-transition     : none;
         -o-transition      : none;
         transition         : none;
+
+        float: left;
+        width: 0%;
+        height: 100%;
+        font-size: 12px;
+        line-height: 18px;
+        color: #fff;
+        text-align: center;
+        background-color: #337ab7;
+        -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);;
     }
 }
 
@@ -572,6 +591,13 @@ ul.widget-dropdown-droplist {
         margin-left: auto;
         margin-right: auto;
         margin-bottom: 0;
+
+        overflow: hidden;
+        height: 18px;
+        background-color: #f5f5f5;
+        border-radius: 2px;
+        -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
     }
 
     .progress-bar {
@@ -581,6 +607,17 @@ ul.widget-dropdown-droplist {
         -ms-transition     : none;
         -o-transition      : none;
         transition         : none;
+
+        float: left;
+        width: 0%;
+        height: 100%;
+        font-size: 12px;
+        line-height: 18px;
+        color: #fff;
+        text-align: center;
+        background-color: #337ab7;
+        -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);;
     }
 }
 

--- a/jupyterlab_widgets/README.md
+++ b/jupyterlab_widgets/README.md
@@ -9,10 +9,12 @@ Package Install
 **Prerequisites**
 - [node](http://nodejs.org/)
 - [python](https://www.continuum.io/downloads)
+- Jupyter Notebook 4.2+
 
 ```bash
-npm install --save jupyter-js-widgets-labextension
-conda install notebook  # notebook 4.2+ required
+pip install jupyterlab_widgets
+jupyter labextension install --sys-prefix --py jupyterlab_widgets
+jupyter labextension enable --sys-prefix --py jupyterlab_widgets
 ```
 
 
@@ -21,22 +23,28 @@ Source Build
 
 **Prerequisites**
 - [git](http://git-scm.com/)
-- [node 0.12+](http://nodejs.org/)
+- [node](http://nodejs.org/)
 - [python](https://www.continuum.io/downloads)
+- Jupyter Notebook 4.2+
 
 ```bash
 git clone https://github.com/ipython/ipywidgets.git
 cd ipywidgets/labextension
 npm install
 npm run build
-conda install notebook  # notebook 4.2+ required
+pip install -e .
+jupyter labextension install --sys-prefix --py jupyterlab_widgets
+jupyter labextension enable --sys-prefix --py jupyterlab_widgets
 ```
 
+If you are not on Windows, use the `--symlink` option in the `labextension install`
+step so that you don't have to install during rebuilds.
 
 **Rebuild**
 ```bash
 npm run clean
 npm run build
+jupyter labextension install --sys-prefix --py jupyterlab_widgets # if you didn't use --symlink above
 ```
 
 Build Docs

--- a/jupyterlab_widgets/README.md
+++ b/jupyterlab_widgets/README.md
@@ -41,6 +41,9 @@ If you are not on Windows, use the `--symlink` option in the `labextension insta
 step so that you don't have to install during rebuilds.
 
 **Rebuild**
+
+If you want to pull in changes to `jupyter-js-widgets`, first run `npm run update` to update the version of `jupyter-js-widgets` in the node_modules directory.
+
 ```bash
 npm run clean
 npm run build

--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "jupyter-js-widgets": "^2.0.2",
+    "jupyter-js-widgets": "^2.0.3",
     "jupyterlab": "^0.5.1",
     "phosphor": "^0.6.1"
   },

--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -20,6 +20,7 @@
     "build:src": "tsc --project src",
     "build:extension": "node scripts/buildExtension.js",
     "build": "npm run build:src && npm run build:extension",
+    "update": "rimraf node_modules/jupyter-js-widgets; npm install file:../jupyter-js-widgets; npm run build",
     "docs": "typedoc --mode file --module commonjs --excludeNotExported --target es5 --moduleResolution node --out docs/ src",
     "prepublish": "npm run build"
   },

--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "jupyter-js-widgets": "^2.0.3",
-    "jupyterlab": "^0.5.1",
+    "jupyterlab": "^0.6.0",
     "phosphor": "^0.6.1"
   },
   "devDependencies": {

--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -34,6 +34,14 @@ import {
 } from 'phosphor/lib/algorithm/json';
 
 import {
+  NotebookPanel
+} from 'jupyterlab/lib/notebook/notebook/panel';
+
+import {
+  INotebookModel
+} from 'jupyterlab/lib/notebook/notebook/model';
+
+import {
   IRenderMime, RenderMime
 } from 'jupyterlab/lib/rendermime';
 
@@ -44,10 +52,6 @@ import {
 import {
   OutputModel, OutputView
 } from './output';
-
-import 'jquery-ui/themes/base/all.css';
-
-import 'jupyter-js-widgets/css/widgets.min.css';
 
 import {
   SemVerCache
@@ -300,3 +304,10 @@ class WidgetRenderer implements RenderMime.IRenderer, IDisposable {
   public mimetypes = ['application/vnd.jupyter.widget'];
   private _manager: WidgetManager;
 }
+
+
+export
+const IIPyWidgetExtension = new Token<IIPyWidgetExtension>('jupyter.extensions.widgetManager');
+
+export
+interface IIPyWidgetExtension extends DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {};

--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -61,6 +61,18 @@ import {
 (widgets as any)['OutputView'] = OutputView;
 
 /**
+ * The token identifying the JupyterLab plugin.
+ */
+export
+const INBWidgetExtension = new Token<INBWidgetExtension>('jupyter.extensions.nbWidgetManager');
+
+/**
+ * The type of the provided value of the plugin in JupyterLab.
+ */
+export
+type INBWidgetExtension = DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>;
+
+/**
  * The class name added to an BackboneViewWrapper widget.
  */
 const BACKBONEVIEWWRAPPER_CLASS = 'jp-BackboneViewWrapper';
@@ -304,10 +316,3 @@ class WidgetRenderer implements RenderMime.IRenderer, IDisposable {
   public mimetypes = ['application/vnd.jupyter.widget'];
   private _manager: WidgetManager;
 }
-
-
-export
-const IIPyWidgetExtension = new Token<IIPyWidgetExtension>('jupyter.extensions.widgetManager');
-
-export
-interface IIPyWidgetExtension extends DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {};

--- a/jupyterlab_widgets/src/plugin.ts
+++ b/jupyterlab_widgets/src/plugin.ts
@@ -30,32 +30,17 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  WidgetManager, WidgetRenderer
+  WidgetManager, WidgetRenderer, IIPyWidgetExtension
 } from './index';
 
 const WIDGET_MIMETYPE = 'application/vnd.jupyter.widget';
 
-export
-const IIPyWidgetExtension = new Token<IIPyWidgetExtension>('jupyter.extensions.widgetManager');
+
+import 'jquery-ui/themes/base/all.css';
+import 'jupyter-js-widgets/css/widgets.min.css';
 
 export
-interface IIPyWidgetExtension extends IPyWidgetExtension {};
-
-/**
- * The widget manager provider.
- */
-const widgetManagerProvider: JupyterLabPlugin<IIPyWidgetExtension> = {
-  id: 'jupyter.extensions.widgetManager',
-  provides: IIPyWidgetExtension,
-  requires: [IDocumentRegistry],
-  activate: activateWidgetExtension,
-  autoStart: true
-};
-
-export default widgetManagerProvider;
-
-export
-class IPyWidgetExtension implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+class IPyWidgetExtension implements IIPyWidgetExtension {
   /**
    * Create a new extension object.
    */
@@ -82,6 +67,21 @@ class IPyWidgetExtension implements DocumentRegistry.IWidgetExtension<NotebookPa
   }
   private _registry: WidgetManager.IWidgetData[] = [];
 }
+
+
+
+/**
+ * The widget manager provider.
+ */
+const widgetManagerProvider: JupyterLabPlugin<IIPyWidgetExtension> = {
+  id: 'jupyter.extensions.widgetManager',
+  provides: IIPyWidgetExtension,
+  requires: [IDocumentRegistry],
+  activate: activateWidgetExtension,
+  autoStart: true
+};
+
+export default widgetManagerProvider;
 
 
 /**

--- a/jupyterlab_widgets/src/plugin.ts
+++ b/jupyterlab_widgets/src/plugin.ts
@@ -30,7 +30,7 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  WidgetManager, WidgetRenderer, IIPyWidgetExtension
+  WidgetManager, WidgetRenderer, INBWidgetExtension
 } from './index';
 
 const WIDGET_MIMETYPE = 'application/vnd.jupyter.widget';
@@ -40,7 +40,7 @@ import 'jquery-ui/themes/base/all.css';
 import 'jupyter-js-widgets/css/widgets.min.css';
 
 export
-class IPyWidgetExtension implements IIPyWidgetExtension {
+class NBWidgetExtension implements INBWidgetExtension {
   /**
    * Create a new extension object.
    */
@@ -73,9 +73,9 @@ class IPyWidgetExtension implements IIPyWidgetExtension {
 /**
  * The widget manager provider.
  */
-const widgetManagerProvider: JupyterLabPlugin<IIPyWidgetExtension> = {
+const widgetManagerProvider: JupyterLabPlugin<INBWidgetExtension> = {
   id: 'jupyter.extensions.widgetManager',
-  provides: IIPyWidgetExtension,
+  provides: INBWidgetExtension,
   requires: [IDocumentRegistry],
   activate: activateWidgetExtension,
   autoStart: true
@@ -88,7 +88,7 @@ export default widgetManagerProvider;
  * Activate the widget extension.
  */
 function activateWidgetExtension(app: JupyterLab, registry: IDocumentRegistry) {
-  let extension = new IPyWidgetExtension();
+  let extension = new NBWidgetExtension();
   registry.addWidgetExtension('Notebook', extension);
   return extension;
 }

--- a/jupyterlab_widgets/src/tsconfig.json
+++ b/jupyterlab_widgets/src/tsconfig.json
@@ -8,5 +8,6 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "../lib"
-  }
+  },
+  "exclude": ["typedoc.d.ts"]
 }

--- a/jupyterlab_widgets/src/typedoc.d.ts
+++ b/jupyterlab_widgets/src/typedoc.d.ts
@@ -1,0 +1,7 @@
+/*
+ * TODO: remove the below typings after typedoc understands the lib compiler option
+ * and the @types typing resolution.
+ */
+/// <reference path="../node_modules/typescript/lib/lib.dom.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es5.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>


### PR DESCRIPTION
Make it so that we export the token/interface from the main package, and the CSS is only imported in the plugin. This ensures that downstream plugins don’t include the CSS (which they shouldn’t) and only import from the main package instead of a module deep in our package (which they should).