### PR TITLE
Fix bootstrap's css pollution and missing styling from lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ docs/man/*.gz
 docs/source/api/generated
 docs/gh-pages
 jupyter-js-widgets/src/components
-jupyter-js-widgets/css/
 jupyter-js-widgets/lib/
 jupyter-js-widgets/docs/
 node_modules

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1323,34 +1323,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Media"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 197,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget": "36a8197e3af44921aa7e8525e3c5a2b8"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "widgets.Media(\n",
-    "    video=True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Controller"
    ]
   },

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -518,7 +518,7 @@
    },
    "outputs": [],
    "source": [
-    "item_layout = Layout(height='100px')\n",
+    "item_layout = Layout(height='100px', min_width='40px')\n",
     "items = [Button(layout=item_layout, button_style='warning') for i in range(40)]\n",
     "box_layout = Layout(overflow_x='scroll',\n",
     "                    border='3px solid black',\n",

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -271,7 +271,8 @@
 .widget-hbox .widget-readout {
     /* Horizontal Readout */
     text-align: center;
-    width: var(--jp-widgets-inline-width-tiny);
+    max-width: var(--jp-widgets-inline-width-short);
+    min-width: var(--jp-widgets-inline-width-tiny);
     margin-left: 4px;
 }
 
@@ -338,10 +339,14 @@
     width: var(--jp-widgets-inline-width);
 }
 
-.widget-text input, .widget-textarea input {
+.widget-text input[type="text"], .widget-textarea input {
     outline: none !important;
     width: inherit;
     margin-left: 4px;
+}
+
+.widget-text input[type="text"] {
+    height: auto;
 }
 
 .widget-text input:focus, .widget-textarea input:focus {
@@ -743,6 +748,11 @@ ul.widget-dropdown-droplist.mod-active {
 }
 
 /* Tab Widget */
+
+.jupyter-widgets .p-TabBar {
+    overflow-x: visible;
+    overflow-y: visible;
+}
 
 .jupyter-widgets.widget-tab .p-TabBar.p-mod-horizontal > .p-TabBar-content {
     align-items: flex-end;

--- a/widgetsnbextension/src/widgetarea.js
+++ b/widgetsnbextension/src/widgetarea.js
@@ -95,6 +95,7 @@ WidgetArea.prototype._create_elements = function() {
 
     var widget_subarea = document.createElement('div');
     widget_subarea.classList.add('widget-subarea');
+    widget_subarea.classList.add('jp-Output-result');
     widget_area.appendChild(widget_subarea);
 
     this.widget_subarea = widget_subarea;


### PR DESCRIPTION
- Fixes appearance of tabs in legacy notebook.
- add the `jp-Output-result` class to the legacy widget subarea so that the same css applies.
- prevent some bootstrap css pollution in the legacy notebook case which was breaking the text inputs.
