### PR TITLE
Remove box shadow on dropdown toggle

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -594,6 +594,7 @@
     flex-grow: 1;
     margin: 0;
     padding: 0;
+    box-shadow: none;
     border: var(--jp-border-width) solid var(--jp-border-color1);
     color: var(--jp-ui-font-color1);
     background-color: var(--jp-layout-color1);


### PR DESCRIPTION
The box shadow makes it look weird when the droplist is visible.

**Before:**
<img width="399" alt="screen shot 2016-11-06 at 8 36 28 pm" src="https://cloud.githubusercontent.com/assets/2397974/20040918/c357fffc-a460-11e6-9bc3-f0fa45c84cdf.png">


**After:**
<img width="404" alt="screen shot 2016-11-06 at 8 30 32 pm" src="https://cloud.githubusercontent.com/assets/2397974/20040901/616001be-a460-11e6-8098-c5a66d727483.png">
