### PR TITLE
CSS fixes

### DIFF
--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -56,7 +56,7 @@ class VBox(Box):
 
     @default('layout')
     def _default_layout(self):
-        return Layout(display='flex', flex_flow='column', align_items='strech')
+        return Layout(display='flex', flex_flow='column')
 
 
 @register('Jupyter.HBox')
@@ -65,7 +65,7 @@ class HBox(Box):
 
     @default('layout')
     def _default_layout(self):
-        return Layout(display='flex', align_items='strech')
+        return Layout(display='flex')
 
 
 @register('Jupyter.Proxy')

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -359,6 +359,9 @@
     color: var(--jp-ui-font-color1);
     font-size: var(--jp-widgets-font-size);
     padding: var(--jp-widgets-input-padding);
+    flex-grow: 1;
+    min-width: 0; /* This makes it possible for the flexbox to shrink this input */
+    flex-shrink: 1;
 }
 
 .widget-text input:focus, .widget-textarea textarea:focus {
@@ -547,6 +550,7 @@
 }
 
 .widget-hprogress .progress {
+    flex-grow: 1;
     height: var(--jp-widgets-progress-thickness);
     margin-top: auto;
     margin-bottom: auto;
@@ -581,7 +585,7 @@
 
 .widget-dropdown-toggle {
     float: right;
-    min-width: var(--jp-widgets-inline-width-short);
+    min-width: var(--jp-widgets-inline-width-tiny);
     max-width: var(--jp-widgets-inline-width);
     display: flex;
     flex-grow: 1;
@@ -695,6 +699,7 @@ ul.widget-dropdown-droplist.mod-active {
     min-width: var(--jp-widgets-inline-width-short);
     max-width: var(--jp-widgets-inline-width);
     font-size: var(--jp-widgets-font-size);
+    flex-grow: 1;
 }
 
 .widget-select select option:checked {
@@ -716,6 +721,7 @@ ul.widget-dropdown-droplist.mod-active {
     background-color: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
     font-size: var(--jp-widgets-font-size);
+    flex-grow: 1;
 }
 
 .widget-select-multiple select option:checked {
@@ -744,13 +750,8 @@ ul.widget-dropdown-droplist.mod-active {
 
 .widget-radio {
     min-width: var(--jp-widgets-inline-width);
+    width: var(--jp-widgets-inline-width);
     line-height: var(--jp-widgets-inline-height);
-}
-
-.widget-radio-box {
-    float: right;
-    min-width: var(--jp-widgets-inline-width-short);
-    max-width: var(--jp-widgets-inline-width);
 }
 
 .widget-radio-box {
@@ -758,6 +759,7 @@ ul.widget-dropdown-droplist.mod-active {
     flex-direction: column;
     align-items: stretch;
     box-sizing: border-box;
+    flex-grow: 1;
 }
 
 .widget-radio-box label {
@@ -776,9 +778,15 @@ ul.widget-dropdown-droplist.mod-active {
 /* Color Picker Styling */
 
 .widget-colorpicker {
-    min-width: var(--jp-widgets-inline-width);
+    width: var(--jp-widgets-inline-width);
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
+}
+
+.widget-colorpicker > .widget-colorpicker-input {
+    flex-grow: 1;
+    flex-shrink: 1;
+    min-width: var(--jp-widgets-inline-width-tiny);
 }
 
 .widget-colorpicker input[type="color"] {
@@ -789,6 +797,9 @@ ul.widget-dropdown-droplist.mod-active {
     color: var(--jp-ui-font-color1);
     border: var(--jp-widgets-border-width) solid var(--jp-border-color1);
     border-left: none;
+    flex-grow: 0;
+    flex-shrink: 0;
+    box-sizing: border-box;
     align-self: stretch;
 }
 
@@ -801,6 +812,9 @@ ul.widget-dropdown-droplist.mod-active {
     border: var(--jp-widgets-border-width) solid var(--jp-border-color1);
     font-size: var(--jp-widgets-font-size);
     padding: var(--jp-widgets-input-padding);
+    min-width: 0; /* This makes it possible for the flexbox to shrink this input */
+    flex-shrink: 1;
+    box-sizing: border-box;
 }
 
 /* Play Widget */

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -341,26 +341,24 @@
 
 /* Widget Text and TextArea Stying */
 
-.widget-text {
-    /* Textbox */
+.widget-textarea, .widget-text {
     width: var(--jp-widgets-inline-width);
+}
+
+.widget-text input[type="text"] {
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
 }
 
-.widget-textarea {
-    width: var(--jp-widgets-inline-width);
-    line-height: var(--jp-widgets-inline-height);
-}
-
 .widget-text input[type="text"], .widget-textarea textarea {
+    box-sizing: border-box;
     border: var(--jp-border-width) solid var(--jp-border-color1);
     background-color: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
     font-size: var(--jp-widgets-font-size);
     padding: var(--jp-widgets-input-padding);
     flex-grow: 1;
-    min-width: 0; /* This makes it possible for the flexbox to shrink this input */
+    min-width: var(--jp-widget-inline-short); /* This makes it possible for the flexbox to shrink this input */
     flex-shrink: 1;
 }
 

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -944,5 +944,5 @@ ul.widget-dropdown-droplist.mod-active {
 }
 
 .widget-html {
-    line-height: var(--jp-widgets-inline-height);
+    font-size: var(--jp-widgets-font-size);
 }

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -117,9 +117,10 @@
      box-shadow: none;
 }
 
-.jupyter-button:hover, .jupyter-button:focus, .jupyter-button:active {
+/*.jupyter-button:hover, .jupyter-button:focus, .jupyter-button:active {
     outline: none !important;
 }
+*/
 
 /* Button "Default" Styling */
 
@@ -359,7 +360,7 @@
 }
 
 .widget-text input[type="text"], .widget-textarea input {
-    outline: none !important;
+    /*outline: none !important;*/
     width: inherit;
     margin-left: 4px;
 }
@@ -399,7 +400,7 @@
 
 .widget-slider .ui-slider-handle {
     /* Slider Handle */
-    outline: none !important;
+    outline: none !important; /* focused slider handles are colored - see below */
     position: absolute;
     background-color: var(--jp-layout-color2);
     border: var(--jp-widgets-slider-border-width) solid var(--jp-border-color2);
@@ -691,7 +692,7 @@ ul.widget-dropdown-droplist.mod-active {
     border: var(--jp-border-width) solid var(--jp-border-color1);
     -webkit-appearance: menulist;
     border-radius: 0;
-    outline: none;
+    /*outline: none;*/
     background-color: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
     min-width: var(--jp-widgets-inline-width-short);
@@ -798,7 +799,7 @@ ul.widget-dropdown-droplist.mod-active {
 
 .widget-colorpicker input[type="text"] {
     flex-grow: 1;
-    outline: none !important;
+    /*outline: none !important;*/
     background: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
     border: var(--jp-widgets-border-width) solid var(--jp-border-color1);

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -111,7 +111,7 @@
 }
 
 .jupyter-button:empty:before {
-    content: "\00a0"
+    content: "\200b"; /* zero-width space */
 }
 
 .jupyter-button:active, .jupyter-button.mod-active {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -57,7 +57,7 @@
     /* Horizontal widgets */
     display: flex;
     flex-direction: row;
-    align-items: stretch;
+    align-items: baseline;
 }
 
 .widget-vbox {
@@ -72,7 +72,7 @@
     box-sizing: border-box;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
-    align-items: flex-start;
+    align-items: baseline;
 }
 
 /* General Button Styling */
@@ -301,6 +301,8 @@
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
     font-size: large;
+    flex-grow: 1;
+    align-self: center;
 }
 
 /* Widget Valid Styling */
@@ -474,6 +476,7 @@
     width: var(--jp-widgets-inline-width-short);
     margin-left: calc(var(--jp-widgets-slider-handle-thickness) / 2 - 2 * var(--jp-widgets-slider-border-width));
     margin-right: calc(var(--jp-widgets-slider-handle-thickness) / 2 - 2 * var(--jp-widgets-slider-border-width));
+    align-self: stretch;
 }
 
 .widget-hslider .ui-slider {
@@ -796,6 +799,7 @@ ul.widget-dropdown-droplist.mod-active {
     color: var(--jp-ui-font-color1);
     border: var(--jp-widgets-border-width) solid var(--jp-border-color1);
     border-left: none;
+    align-self: stretch;
 }
 
 .widget-colorpicker input[type="text"] {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -16,8 +16,9 @@
     --jp-widgets-inline-width: 300px;
     --jp-widgets-inline-width-short: calc(var(--jp-widgets-inline-width) / 2 - var(--jp-widgets-margin));
     --jp-widgets-inline-width-tiny: calc(var(--jp-widgets-inline-width-short) / 2 - var(--jp-widgets-margin));
-    --jp-widgets-inline-label-width: 100px;
     --jp-widgets-inline-margin: 4px; /* margin between inline elements */
+    --jp-widgets-inline-label-min-width: 80px;
+    --jp-widgets-inline-label-max-width: calc(var(--jp-widgets-inline-width) - var(--jp-widgets-inline-margin) - var(--jp-widgets-inline-width-short));
     --jp-widgets-border-width: var(--jp-border-width);
     --jp-widgets-tall-height: 200px;
     --jp-widgets-horizontal-tab-height: 24px;
@@ -228,8 +229,10 @@
 .widget-hbox .widget-label {
     /* Horizontal Widget Label */
     text-align: right;
-    width: var(--jp-widgets-inline-label-width);
     margin-right: var(--jp-widgets-inline-margin);
+    max-width: var(--jp-widgets-inline-label-max-width);
+    min-width: var(--jp-widgets-inline-label-min-width);
+    flex-shrink: 0;
 }
 
 .widget-vbox .widget-label {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -16,6 +16,7 @@
     --jp-widgets-inline-width: 300px;
     --jp-widgets-inline-width-short: calc(var(--jp-widgets-inline-width) / 2 - var(--jp-widgets-margin));
     --jp-widgets-inline-width-tiny: calc(var(--jp-widgets-inline-width-short) / 2 - var(--jp-widgets-margin));
+    --jp-widgets-inline-label-width: 100px;
     --jp-widgets-border-width: var(--jp-border-width);
     --jp-widgets-tall-height: 200px;
     --jp-widgets-horizontal-tab-height: 24px;
@@ -228,15 +229,7 @@
     text-align: right;
     margin-right: 4px;
     vertical-align: text-top;
-
-    /* When labels are short, the min-width takes over,
-     * and labeled horizontal widgets are aligned.
-     *
-     * When labels are longer, the actual widget is shifted to the right.
-     * There is a maximum length for a label.
-     */
-    min-width: 80px;
-    max-width: 160px;
+    width: var(--jp-widgets-inline-label-width);
 }
 
 .widget-vbox .widget-label {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -217,8 +217,8 @@
     /* Label */
     font-size: var(--jp-widgets-font-size);
     overflow: hidden;
-    text-overflow  : ellipsis;
-    white-space    : nowrap;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     line-height: var(--jp-widgets-inline-height);
 }
 
@@ -581,7 +581,7 @@
 /* Dropdown Widget Styling */
 
 .widget-dropdown {
-    height : var(--jp-widgets-inline-height);
+    height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
     min-width: var(--jp-widgets-inline-width);
 }

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -313,10 +313,16 @@
 .widget-valid i:before {
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
-    font-family: FontAwesome;
-    font-style: normal;
     margin-right: 4px;
     margin-left: 4px;
+
+    /* from the fa class in FontAwesome: https://github.com/FortAwesome/Font-Awesome/blob/49100c7c3a7b58d50baa71efef11af41a66b03d3/css/font-awesome.css#L14 */
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 .widget-valid.mod-valid i:before {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -17,6 +17,7 @@
     --jp-widgets-inline-width-short: calc(var(--jp-widgets-inline-width) / 2 - var(--jp-widgets-margin));
     --jp-widgets-inline-width-tiny: calc(var(--jp-widgets-inline-width-short) / 2 - var(--jp-widgets-margin));
     --jp-widgets-inline-label-width: 100px;
+    --jp-widgets-inline-margin: 4px; /* margin between inline elements */
     --jp-widgets-border-width: var(--jp-border-width);
     --jp-widgets-tall-height: 200px;
     --jp-widgets-horizontal-tab-height: 24px;
@@ -107,7 +108,7 @@
 }
 
 .jupyter-button i.fa {
-    padding-right: 4px;
+    margin-right: var(--jp-widgets-inline-margin);
 }
 
 .jupyter-button:empty:before {
@@ -227,8 +228,8 @@
 .widget-hbox .widget-label {
     /* Horizontal Widget Label */
     text-align: right;
-    margin-right: 4px;
     width: var(--jp-widgets-inline-label-width);
+    margin-right: var(--jp-widgets-inline-margin);
 }
 
 .widget-vbox .widget-label {
@@ -243,7 +244,7 @@
     font-size: var(--jp-widgets-font-size);
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
-    margin-left: 4px;
+    margin-left: var(--jp-widgets-inline-margin);
     overflow: hidden;
     white-space: nowrap;
     text-align: center;
@@ -275,12 +276,12 @@
     text-align: center;
     max-width: var(--jp-widgets-inline-width-short);
     min-width: var(--jp-widgets-inline-width-tiny);
-    margin-left: 4px;
+    margin-left: var(--jp-widgets-inline-margin);
 }
 
 .widget-vbox .widget-readout {
     /* Vertical Readout */
-    margin-top: 4px;
+    margin-top: var(--jp-widgets-inline-margin);
 }
 
 /* Widget Checkbox Styling */
@@ -293,7 +294,7 @@
 }
 
 .widget-checkbox input[type="checkbox"] {
-    margin: 0px 4px 0px 4px;
+    margin: 0px var(--jp-widgets-inline-margin) 0px var(--jp-widgets-inline-margin);
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
     font-size: large;
@@ -311,8 +312,8 @@
 .widget-valid i:before {
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
-    margin-right: 4px;
-    margin-left: 4px;
+    margin-right: var(--jp-widgets-inline-margin);
+    margin-left: var(--jp-widgets-inline-margin);
 
     /* from the fa class in FontAwesome: https://github.com/FortAwesome/Font-Awesome/blob/49100c7c3a7b58d50baa71efef11af41a66b03d3/css/font-awesome.css#L14 */
     display: inline-block;
@@ -909,7 +910,7 @@ ul.widget-dropdown-droplist.mod-active {
 }
 
 .widget-accordion > .accordion-page > .accordion-header {
-    padding: 4px;
+    padding: var(--jp-widgets-input-padding);
     cursor: pointer;
     color: var(--jp-ui-font-color2);
     background-color: var(--jp-layout-color2);

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -228,14 +228,12 @@
     /* Horizontal Widget Label */
     text-align: right;
     margin-right: 4px;
-    vertical-align: text-top;
     width: var(--jp-widgets-inline-label-width);
 }
 
 .widget-vbox .widget-label {
     /* Vertical Widget Label */
     text-align: center;
-    vertical-align: text-bottom;
 }
 
 /* Widget Readout Styling */

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -456,7 +456,7 @@
 /* Horizontal Slider */
 
 .widget-hslider {
-    min-width: var(--jp-widgets-inline-width);
+    width: var(--jp-widgets-inline-width);
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
 }
@@ -552,10 +552,10 @@
     /* Progress Bar */
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
+    width: var(--jp-widgets-inline-width);
 }
 
 .widget-hprogress .progress {
-    width: var(--jp-widgets-inline-width);
     height: var(--jp-widgets-progress-thickness);
     margin-top: auto;
     margin-bottom: auto;

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -84,7 +84,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     text-align: center;
-    font-size: var(--jp-ui-font-size1);
+    font-size: var(--jp-widgets-font-size);
     cursor: pointer;
 
     height: var(--jp-widgets-inline-height);
@@ -349,12 +349,11 @@
 }
 
 .widget-textarea {
+    width: var(--jp-widgets-inline-width);
     line-height: var(--jp-widgets-inline-height);
 }
 
-.widget-textarea textarea {
-    /* TextAreaView */
-    width: var(--jp-widgets-inline-width);
+.widget-text input[type="text"], .widget-textarea textarea {
     border: var(--jp-border-width) solid var(--jp-border-color1);
     background-color: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
@@ -362,22 +361,7 @@
     padding: var(--jp-widgets-input-padding);
 }
 
-.widget-text input[type="text"], .widget-textarea input {
-    /*outline: none !important;*/
-    width: inherit;
-    margin-left: 4px;
-}
-
-.widget-text input[type="text"] {
-    height: auto;
-    border: var(--jp-border-width) solid var(--jp-border-color1);
-    background-color: var(--jp-layout-color1);
-    color: var(--jp-ui-font-color1);
-    font-size: var(--jp-widgets-font-size);
-    padding: var(--jp-widgets-input-padding);
-}
-
-.widget-text input:focus, .widget-textarea input:focus {
+.widget-text input:focus, .widget-textarea textarea:focus {
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2),
                         0 3px 1px -2px rgba(0, 0, 0, 0.14),
                         0 1px 5px 0 rgba(0, 0, 0, 0.12);
@@ -603,6 +587,15 @@
     flex-grow: 1;
     margin: 0;
     padding: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: center;
+    cursor: pointer;
+    height: var(--jp-widgets-inline-height);
+    line-height: var(--jp-widgets-inline-height);
+
+    /* TODO: figure out why the outline isn't working... */
     box-shadow: none;
     border: var(--jp-border-width) solid var(--jp-border-color1);
     color: var(--jp-ui-font-color1);
@@ -771,16 +764,13 @@ ul.widget-dropdown-droplist.mod-active {
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
     font-size: var(--jp-widgets-font-size);
-    margin: 0 2px 0 2px;
-    width: 100%;
 }
 
 .widget-radio-box input {
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
-    margin: 0 2px 0 2px;
-    vertical-align: top;
-    float: right;
+    margin: 0 var(--jp-widgets-input-padding) 0 var(--jp-widgets-input-padding);
+    float: left;
 }
 
 /* Color Picker Styling */
@@ -793,8 +783,8 @@ ul.widget-dropdown-droplist.mod-active {
 
 .widget-colorpicker input[type="color"] {
     width: var(--jp-widgets-inline-height);
-    height: auto;
-    padding: 0;
+    height: var(--jp-widgets-inline-height);
+    padding: 0 2px; /* make the color square actually square on Chrome on OS X */
     background: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
     border: var(--jp-widgets-border-width) solid var(--jp-border-color1);
@@ -805,6 +795,7 @@ ul.widget-dropdown-droplist.mod-active {
 .widget-colorpicker input[type="text"] {
     flex-grow: 1;
     /*outline: none !important;*/
+    height: var(--jp-widgets-inline-height);
     background: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
     border: var(--jp-widgets-border-width) solid var(--jp-border-color1);

--- a/jupyter-js-widgets/src/widget_color.ts
+++ b/jupyter-js-widgets/src/widget_color.ts
@@ -29,7 +29,7 @@ class ColorPickerView extends LabeledDOMWidgetView {
         this.el.classList.add('widget-colorpicker');
 
         this._color_container = document.createElement('div');
-        this._color_container.className = 'widget-hbox';
+        this._color_container.className = 'widget-hbox widget-colorpicker-input';
         this.el.appendChild(this._color_container);
 
         this._textbox = document.createElement('input');

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -388,7 +388,6 @@ class IntTextView extends LabeledDOMWidgetView {
 
         this.textbox = document.createElement('input');
         this.textbox.setAttribute('type', 'text');
-        this.textbox.className = 'form-control';
         this.el.appendChild(this.textbox);
 
         this.update(); // Set defaults.

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -64,7 +64,7 @@ class DropdownView extends LabeledDOMWidgetView {
         this.el.classList.add('widget-dropdown');
 
         this.toggle = document.createElement('div');
-        this.toggle.className = 'widget-dropdown-toggle jupyter-button';
+        this.toggle.className = 'widget-dropdown-toggle';
         this.toggle.tabIndex = 0;
         this.el.appendChild(this.toggle);
 
@@ -617,7 +617,7 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
                     icon.className = 'fa fa-' + icons[index];
                 }
                 button.setAttribute('type', 'button');
-                button.className = 'jupyter-button widget-toggle-button';
+                button.className = 'widget-toggle-button';
                 if (previous_bstyle) {
                     button.classList.add(previous_bstyle);
                 }

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -617,7 +617,7 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
                     icon.className = 'fa fa-' + icons[index];
                 }
                 button.setAttribute('type', 'button');
-                button.className = 'widget-toggle-button';
+                button.className = 'widget-toggle-button jupyter-button';
                 if (previous_bstyle) {
                     button.classList.add(previous_bstyle);
                 }

--- a/jupyter-js-widgets/src/widget_string.ts
+++ b/jupyter-js-widgets/src/widget_string.ts
@@ -110,7 +110,6 @@ class TextareaView extends LabeledDOMWidgetView {
 
         this.textbox = document.createElement('textarea');
         this.textbox.setAttribute('rows', '5');
-        this.textbox.classList.add('form-control');
         this.el.appendChild(this.textbox);
 
         this.update(); // Set defaults.
@@ -228,7 +227,6 @@ class TextView extends LabeledDOMWidgetView {
 
         this.textbox = document.createElement('input');
         this.textbox.setAttribute('type', 'text');
-        this.textbox.className = 'form-control';
         this.el.appendChild(this.textbox);
 
         this.update(); // Set defaults.


### PR DESCRIPTION
Many fixes to CSS, including:

* Better abstraction of values to variables
* Better alignment of widths
* Better alignment of baselines so text is straight across rows of controls
* Get rid of Bootstrap styling in classic notebook for consistency

and various other fixes.

CC @ellisonbg, @cameronoelsen @SylvainCorlay 

I think this fixes #904.

See #904 for before. Here is after in Jupyter Notebook:

<img width="1292" alt="screen shot 2016-11-23 at 9 43 42 pm" src="https://cloud.githubusercontent.com/assets/192614/20585215/72d900f2-b1c7-11e6-9cde-78d897ae68c7.png">

and in JupyterLab:

<img width="1484" alt="screen shot 2016-11-23 at 9 50 27 pm" src="https://cloud.githubusercontent.com/assets/192614/20585224/800da44e-b1c7-11e6-8e1e-53e42ae0a5d3.png">
