### PR TITLE
Make HBox and VBox use classes instead of explicitly setting the styles.

### DIFF
--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -53,19 +53,15 @@ class Box(DOMWidget):
 @register('Jupyter.VBox')
 class VBox(Box):
     """Displays multiple widgets vertically using the flexible box model."""
-
-    @default('layout')
-    def _default_layout(self):
-        return Layout(display='flex', flex_flow='column')
+    _model_name = Unicode('VBoxModel').tag(sync=True)
+    _view_name = Unicode('VBoxView').tag(sync=True)
 
 
 @register('Jupyter.HBox')
 class HBox(Box):
     """Displays multiple widgets horizontally using the flexible box model."""
-
-    @default('layout')
-    def _default_layout(self):
-        return Layout(display='flex')
+    _model_name = Unicode('HBoxModel').tag(sync=True)
+    _view_name = Unicode('HBoxView').tag(sync=True)
 
 
 @register('Jupyter.Proxy')

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -36,14 +36,11 @@
     --jp-widgets-menu-item-height: 24px;
 }
 
-.p-Widget.jupyter-widgets {
-    overflow: visible;
-}
-
 .jupyter-widgets {
     margin: var(--jp-widgets-margin);
     box-sizing: border-box;
     color: var(--jp-content-font-color1);
+    overflow: visible;
 }
 
 .jp-Output-result > .jupyter-widgets {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -53,14 +53,14 @@
 
 /* vbox and hbox */
 
-.widget-hbox {
+.widget-inline-hbox {
     /* Horizontal widgets */
     display: flex;
     flex-direction: row;
     align-items: baseline;
 }
 
-.widget-vbox {
+.widget-inline-vbox {
     /* Vertical Widgets */
     display: flex;
     flex-direction: column;
@@ -72,7 +72,20 @@
     box-sizing: border-box;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
-    align-items: baseline;
+}
+
+.widget-hbox {
+    /* Horizontal widgets */
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+}
+
+.widget-vbox {
+    /* Vertical Widgets */
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
 }
 
 /* General Button Styling */

--- a/jupyter-js-widgets/src/widget_box.ts
+++ b/jupyter-js-widgets/src/widget_box.ts
@@ -86,6 +86,26 @@ class BoxModel extends DOMWidgetModel {
 }
 
 export
+class HBoxModel extends BoxModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _view_name: 'HBoxView',
+            _model_name: 'HBoxModel',
+        });
+    }
+}
+
+export
+class VBoxModel extends BoxModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _view_name: 'VBoxView',
+            _model_name: 'VBoxModel',
+        });
+    }
+}
+
+export
 class ProxyModel extends DOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
@@ -231,6 +251,7 @@ class BoxView extends DOMWidgetView {
      * Called when view is rendered.
      */
     render() {
+        super.render();
         this.children_views.update(this.model.get('children'));
         this.update_overflow_x();
         this.update_overflow_y();
@@ -294,4 +315,26 @@ class BoxView extends DOMWidgetView {
     }
     children_views: any;
     pWidget: JupyterPhosphorPanelWidget;
+}
+
+export
+class HBoxView extends BoxView {
+    /**
+     * Public constructor
+     */
+    initialize(parameters) {
+        super.initialize(parameters);
+        this.pWidget.addClass('widget-hbox');
+    }
+}
+
+export
+class VBoxView extends BoxView {
+    /**
+     * Public constructor
+     */
+    initialize(parameters) {
+        super.initialize(parameters);
+        this.pWidget.addClass('widget-vbox');
+    }
 }

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -60,7 +60,7 @@ class DropdownView extends LabeledDOMWidgetView {
         super.render();
 
         this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-hbox');
+        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-dropdown');
 
         this.toggle = document.createElement('div');
@@ -455,7 +455,7 @@ class RadioButtonsView extends LabeledDOMWidgetView {
         super.render();
 
         this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-hbox');
+        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-radio');
 
         this.container = document.createElement('div');
@@ -561,7 +561,7 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
         super.render();
 
         this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-hbox');
+        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-toggle-buttons');
 
         this.buttongroup = document.createElement('div');
@@ -730,7 +730,7 @@ class SelectView extends LabeledDOMWidgetView {
         super.render();
 
         this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-hbox');
+        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-select');
 
         this.listbox = document.createElement('select');
@@ -836,7 +836,7 @@ class SelectionSliderView extends LabeledDOMWidgetView {
         super.render();
 
         this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-hbox');
+        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-hslider');
         this.el.classList.add('widget-slider');
 
@@ -903,14 +903,14 @@ class SelectionSliderView extends LabeledDOMWidgetView {
             // Use the right CSS classes for vertical & horizontal sliders
             if (orientation === 'vertical') {
                 this.el.classList.remove('widget-hslider');
-                this.el.classList.remove('widget-hbox');
+                this.el.classList.remove('widget-inline-hbox');
                 this.el.classList.add('widget-vslider');
-                this.el.classList.add('widget-vbox');
+                this.el.classList.add('widget-inline-vbox');
             } else {
                 this.el.classList.remove('widget-vslider');
-                this.el.classList.remove('widget-vbox');
+                this.el.classList.remove('widget-inline-vbox');
                 this.el.classList.add('widget-hslider');
-                this.el.classList.add('widget-hbox');
+                this.el.classList.add('widget-inline-hbox');
             }
 
             var readout = this.model.get('readout');


### PR DESCRIPTION
We run into problems when we set the element style of phosphor widgets - phosphor hides widgets by adding a css class, so if we set the display style of an element explicitly, it overrides phosphor hiding the element. This means that the element behaves badly in tabs, etc.