### PR TITLE
Downgrade lodash, since the current version causes build errors.

### DIFF
--- a/jupyterlab_widgets/package.json
+++ b/jupyterlab_widgets/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@jupyterlab/extension-builder": "^0.8.1",
+    "@types/lodash": "4.14.40",
     "rimraf": "^2.4.2",
     "typedoc": "^0.5.0",
     "typescript": "^2.0.10"


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12773

We get errors like this when compiling now:

```
node_modules/@types/lodash/modules.d.ts(8,24): error TS2339: Property 'ary' does not exist on type 'UnderscoreStatic'.
node_modules/@types/lodash/modules.d.ts(20,29): error TS2339: Property 'assignIn' does not exist on type 'UnderscoreStatic'.
```
and many more. Deleting the `/// <reference path="modules.d.ts" />` line in @types/lodash/index.d.ts makes everything compile again.