### PR TITLE
Validate json schema for widget state

### DIFF
--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -48,7 +48,7 @@ This HTML snippet is composed of multiple `<script>` tags:
                 "type": "object",
                 "additionalProperties": true,
                 "additionalProperties" : {
-                    "type": "object"
+                    "type": "object",
                     "properties": {
                         "model_name": {
                             "description" : "Name of the JavaScript class holding the model implementation",
@@ -73,6 +73,7 @@ This HTML snippet is composed of multiple `<script>` tags:
                 }
             }
         },
+        "required": [ "version_major", "version_minor", "state" ],
         "additionalProperties": false
     }
     ```
@@ -91,11 +92,23 @@ This HTML snippet is composed of multiple `<script>` tags:
         "description": "Jupyter Interactive Widget View JSON schema.",
         "type": "object",
         "properties" : {
-            "model_id" : {
+            "version_major" : {
+                "description": "Format version (major)",
+                "type": "number",
+                "minimum": 1,
+                "maximum": 1
+            },
+            "version_minor" : {
+                "description": "Format version (minor)",
+                "type": "number"
+            },
+            "model_id": {
                 "description": "Unique identifier of the widget model to be displayed",
                 "type": "string"
-            }
-        }
+            },
+            "required": [ "model_id" ]
+        },
+        "additionalProperties": false
     }
     ```
 

--- a/ipywidgets/state.schema.json
+++ b/ipywidgets/state.schema.json
@@ -43,5 +43,6 @@
             }
         }
     },
+    "required": [ "version_major", "version_minor", "state" ],
     "additionalProperties": false
 }

--- a/ipywidgets/view.schema.json
+++ b/ipywidgets/view.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Jupyter Interactive Widget View JSON schema.",
+    "type": "object",
+    "properties" : {
+        "version_major" : {
+            "description": "Format version (major)",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 1
+        },
+        "version_minor" : {
+            "description": "Format version (minor)",
+            "type": "number"
+        },
+        "model_id": {
+            "description": "Unique identifier of the widget model to be displayed",
+            "type": "string"
+        },
+        "required": [ "model_id" ]
+    },
+    "additionalProperties": false
+}

--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -82,8 +82,10 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^0.34.2",
+    "jupyter-widget-schema": "file:../jupyter-widget-schema/",
     "@types/backbone": "^1.3.33",
     "@types/semver": "^5.3.30",
+    "ajv": "^4.9.0",
     "backbone": "1.2.0",
     "d3-format": "^0.5.1",
     "font-awesome": "^4.5.0",

--- a/jupyter-js-widgets/src-embed/embed-webpack.ts
+++ b/jupyter-js-widgets/src-embed/embed-webpack.ts
@@ -16,6 +16,11 @@ if (Element && !Element.prototype.matches) {
 require('font-awesome/css/font-awesome.css');
 require('../css/widgets.built.css');
 
+// Load json schema validator
+var Ajv = require('ajv');
+var widget_state_schema = require('jupyter-widget-schema').v1.state;
+
+
 // Magic global widget rendering function:
 import * as widgets from './index';
 
@@ -66,8 +71,13 @@ export function renderInlineWidgets(event) {
 // Besides, if the view script tag has an <img> sibling DOM node with class `jupyter-widget`,
 // the <img> tag is deleted.
 function renderManager(element, tag) {
-    // TODO: validate state schema
     var widgetStateObject = JSON.parse(tag.innerHTML);
+    var ajv = new Ajv(); // options can be passed, e.g. {allErrors: true}
+    var validate = ajv.compile(widget_state_schema);
+    var valid = validate(widgetStateObject);
+    if (!valid) {
+        console.log(validate.errors);
+    }
     var manager = new widgets.EmbedManager();
     manager.set_state(widgetStateObject.state, {}).then(function(models) {
         var tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-view+json"]');

--- a/jupyter-js-widgets/src-embed/embed-webpack.ts
+++ b/jupyter-js-widgets/src-embed/embed-webpack.ts
@@ -19,6 +19,7 @@ require('../css/widgets.built.css');
 // Load json schema validator
 var Ajv = require('ajv');
 var widget_state_schema = require('jupyter-widget-schema').v1.state;
+var widget_view_schema = require('jupyter-widget-schema').v1.view;
 
 
 // Magic global widget rendering function:
@@ -73,10 +74,10 @@ export function renderInlineWidgets(event) {
 function renderManager(element, tag) {
     var widgetStateObject = JSON.parse(tag.innerHTML);
     var ajv = new Ajv(); // options can be passed, e.g. {allErrors: true}
-    var validate = ajv.compile(widget_state_schema);
-    var valid = validate(widgetStateObject);
+    var model_validate = ajv.compile(widget_state_schema);
+    var valid = model_validate(widgetStateObject);
     if (!valid) {
-        console.log(validate.errors);
+        console.log(model_validate.errors);
     }
     var manager = new widgets.EmbedManager();
     manager.set_state(widgetStateObject.state, {}).then(function(models) {
@@ -84,7 +85,13 @@ function renderManager(element, tag) {
         for (var i=0; i!=tags.length; ++i) {
             // TODO: validate view schema
             let viewtag = tags[i];
-            let model_id = JSON.parse(viewtag.innerHTML).model_id;
+            let widgetViewObject = JSON.parse(viewtag.innerHTML);
+            var view_validate = ajv.compile(widget_view_schema);
+            var valid = view_validate(widgetViewObject);
+            if (!valid) {
+                console.log(view_validate.errors);
+            }
+            let model_id = widgetViewObject.model_id;
             let model = models.find(function(item) {
                 return item.id == model_id;
             });

--- a/jupyter-widget-schema/README.md
+++ b/jupyter-widget-schema/README.md
@@ -1,0 +1,16 @@
+Jupyter Widget Schema
+=====================
+
+JSON schema for the json serialization of Jupyter Interactive Widgets.
+
+Package Install
+---------------
+
+**Prerequisites**
+- [node](http://nodejs.org/)
+
+Run the following command **at the root of this repository**.
+
+```bash
+npm install --save jupyter-widget-schema
+```

--- a/jupyter-widget-schema/index.js
+++ b/jupyter-widget-schema/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     v1: {
-        state: require('./v1/state.schema.json')
+        state: require('./v1/state.schema.json'),
+        view: require('./v1/view.schema.json')
     }
 };

--- a/jupyter-widget-schema/index.js
+++ b/jupyter-widget-schema/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+    v1: {
+        state: require('./v1/state.schema.json')
+    }
+};

--- a/jupyter-widget-schema/package.json
+++ b/jupyter-widget-schema/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "jupyter-widget-schema",
+  "version": "0.0.1",
+  "description": "Schemas for the Jupyter interactive Widgets",
+  "main": "index.js",
+  "scripts": {
+    "test": "node index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ipython/ipywidgets.git"
+  },
+  "keywords": [
+    "jupyter",
+    "schemas",
+    "notebook"
+  ],
+  "author": "Project Jupyter",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/ipython/ipywidgets/issues"
+  },
+  "homepage": "https://github.com/ipython/ipywidgets#readme"
+}

--- a/jupyter-widget-schema/v1/state.schema.json
+++ b/jupyter-widget-schema/v1/state.schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Jupyter Interactive Widget State JSON schema.",
+    "type": "object",
+    "properties" : {
+        "version_major" : {
+            "description": "Format version (major)",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 1
+        },
+        "version_minor" : {
+            "description": "Format version (minor)",
+            "type": "number"
+        },
+        "state": {
+            "description": "Model State for All Widget Models",
+            "type": "object",
+            "additionalProperties": true,
+            "additionalProperties" : {
+                "type": "object",
+                "properties": {
+                    "model_name": {
+                        "description" : "Name of the JavaScript class holding the model implementation",
+                        "type": "string"
+                    },
+                    "model_module": {
+                        "description" : "Name of the JavaScript module holding the model implementation",
+                        "type": "string"
+                    },
+                    "model_module_version": {
+                        "description" : "Semver range for the JavaScript module holding the model implementation",
+                        "type": "string"
+                    },
+                    "state": {
+                        "description" : "Serialized state of the model",
+                        "type": "object",
+                        "additional_properties": true
+                    }
+                },
+                "required": [ "model_name", "model_module", "state" ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/jupyter-widget-schema/v1/state.schema.json
+++ b/jupyter-widget-schema/v1/state.schema.json
@@ -43,5 +43,6 @@
             }
         }
     },
+    "required": [ "version_major", "version_minor", "state" ],
     "additionalProperties": false
 }

--- a/jupyter-widget-schema/v1/view.schema.json
+++ b/jupyter-widget-schema/v1/view.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Jupyter Interactive Widget View JSON schema.",
+    "type": "object",
+    "properties" : {
+        "version_major" : {
+            "description": "Format version (major)",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 1
+        },
+        "version_minor" : {
+            "description": "Format version (minor)",
+            "type": "number"
+        },
+        "model_id": {
+            "description": "Unique identifier of the widget model to be displayed",
+            "type": "string"
+        },
+        "required": [ "model_id" ]
+    },
+    "additionalProperties": false
+}

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup_args = dict(
     scripts         = [],
     packages        = packages,
     package_data    = {
-        'ipywidgets': [ 'state.schema.json' ]
+        'ipywidgets': [ 'state.schema.json', 'view.schema.json' ]
     },
     description     = "IPython HTML widgets for Jupyter",
     long_description = LONG_DESCRIPTION,


### PR DESCRIPTION
This implements the js side validation of the serialized state.

This can be tested with the `web4` example.

It also adds a js package holding the schema as in https://github.com/jupyter/nbformat/issues/70#issuecomment-263970093