### PR TITLE
Specify version semver range in new_model

### DIFF
--- a/jupyter-js-widgets/src/widget_controller.ts
+++ b/jupyter-js-widgets/src/widget_controller.ts
@@ -269,6 +269,7 @@ class ControllerModel extends DOMWidgetModel {
         return this.widget_manager.new_widget({
              model_name: 'ControllerButtonModel',
              model_module: 'jupyter-js-widgets',
+             model_module_version: this.get('_model_module_version'),
              widget_class: 'Jupyter.ControllerButton',
         }).then(function(model) {
              model.set('description', index);
@@ -283,6 +284,7 @@ class ControllerModel extends DOMWidgetModel {
         return this.widget_manager.new_widget({
              model_name: 'ControllerAxisModel',
              model_module: 'jupyter-js-widgets',
+             model_module_version: this.get('_model_module_version'),
              widget_class: 'Jupyter.ControllerAxis',
         }).then(function(model) {
              model.set('description', index);


### PR DESCRIPTION
@jasongrout 

The change in `widget_controller.ts` passes the current module semver to the `new_widget` options, which is required for instantiating widgets from the js side in jupyterlab. I made a similar change in bqplot.

Additionally, in the jupyterlab widget manager's `loadClass` method, we could transform unspecified semver ranges into `*`.