### PR TITLE
Add a max-width to the label widget to make it fit the widget grid

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -232,6 +232,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     line-height: var(--jp-widgets-inline-height);
+    max-width: var(--jp-widgets-inline-width);
 }
 
 .widget-inline-hbox .widget-label {


### PR DESCRIPTION
This also prevents a label from being arbitrarily long. In that case, I think people should use an HTML widget, which wraps the text.