### PR TITLE
Serialize widget state to metadata on save of the notebook

### DIFF
--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -201,9 +201,11 @@ WidgetManager.set_state_callbacks(function() {
     return Promise.resolve({});
 }, function(state) {
     Jupyter.notebook.metadata.widgets = {
-        state: state,
-        // Persisted widget state version
-        version: version,
+        'application/vnd.jupyter.widget-state+json' : {
+            version_major: 1,
+            version_minor: 0,
+            state: state
+        }
     };
 });
 


### PR DESCRIPTION
This will be required to

 - render widgets in sphinx documentation with nbsphinx.
 - render widgets in nbviewer.