### PR TITLE
Enable assignment of a dictionary to the layout attribute

### DIFF
--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -3,10 +3,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import Unicode, Instance, Bool, Tuple, default
+from traitlets import Unicode, Bool, Tuple, default
 from .widget import Widget, widget_serialization
 from .trait_types import Color
-from .widget_layout import Layout
+from .widget_layout import Layout, LayoutTraitType
 
 
 class DOMWidget(Widget):
@@ -14,7 +14,7 @@ class DOMWidget(Widget):
 
     _model_name = Unicode('DOMWidgetModel').tag(sync=True)
     _dom_classes = Tuple(help="DOM classes applied to widget.$el.").tag(sync=True)
-    layout = Instance(Layout).tag(sync=True, **widget_serialization)
+    layout = LayoutTraitType().tag(sync=True, **widget_serialization)
 
     @default('layout')
     def _default_layout(self):

--- a/ipywidgets/widgets/widget_layout.py
+++ b/ipywidgets/widgets/widget_layout.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from .widget import Widget, register
-from traitlets import Unicode
+from traitlets import Unicode, Instance
 
 
 class Layout(Widget):
@@ -53,3 +53,13 @@ class Layout(Widget):
     top = Unicode(None, allow_none=True).tag(sync=True)
     visibility = Unicode(None, allow_none=True).tag(sync=True)
     width = Unicode(None, allow_none=True).tag(sync=True)
+
+class LayoutTraitType(Instance):
+
+    klass = Layout
+
+    def validate(self, obj, value):
+        if isinstance(value, dict):
+            return super(LayoutTraitType, self).validate(obj, Layout(**value))
+        else:
+            return super(LayoutTraitType, self).validate(obj, value)


### PR DESCRIPTION
This enables things like

```python
Button(layout={'width': '500px'})
```

```python
b = Button()
button.layout = {'width': '500px'}
```

@jasongrout 