### PR TITLE
Prevent duplicate embedding

### DIFF
--- a/jupyter-js-widgets/src-embed/embed-webpack.ts
+++ b/jupyter-js-widgets/src-embed/embed-webpack.ts
@@ -109,4 +109,8 @@ function renderManager(element, tag) {
     });
 }
 
-window.addEventListener('load', loadInlineWidgets);
+// Prevent the embedder to be defined twice.
+if (!(window as any)._jupyter_widget_embedder) {
+    (window as any)._jupyter_widget_embedder = true;
+    window.addEventListener('load', loadInlineWidgets);
+}


### PR DESCRIPTION
This is easily tested by repeating the `index.built.js` script tag in the `web4` example.