### PR TITLE
fix requirement.txt for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 jupyter_client
 sphinx>=1.4.6
 sphinx_rtd_theme==0.1.10-alpha
-nbsphinx==git+https://github.com/SylvainCorlay/nbsphinx.git@widgets-all-the-things
+git+https://github.com/SylvainCorlay/nbsphinx.git@widgets-all-the-things#egg=nbsphinx
 jupyter_sphinx
 recommonmark==0.4.0
 ipykernel


### PR DESCRIPTION
cc @SylvainCorlay

without this, I get the following error:

Collecting nbsphinx==git+https://github.com/SylvainCorlay/nbsphinx.git@widgets-all-the-things#egg=nbsphinx (from -r requirements.txt (line 4))
  Could not find a version that satisfies the requirement nbsphinx==git+https://github.com/SylvainCorlay/nbsphinx.git@widgets-all-the-things#egg=nbsphinx (from -r requirements.txt
 (line 4)) (from versions: 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.2.10, 0.2.11)
No matching distribution found for nbsphinx==git+https://github.com/SylvainCorlay/nbsphinx.git@widgets-all-the-things#egg=nbsphinx (from -r requirements.txt (line 4))
(nb) 18:48@docs(save-styling-widgets-nb)$ fg