### PR TITLE
Define jupyter-js-widgets module

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -82,7 +82,6 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^0.34.2",
-    "jupyter-widgets-schema": "^0.1.1",
     "@types/backbone": "^1.3.33",
     "@types/semver": "^5.3.30",
     "ajv": "^4.9.0",
@@ -91,7 +90,9 @@
     "font-awesome": "^4.5.0",
     "jquery": "^3.1.1",
     "jquery-ui": "^1.12.1",
+    "jupyter-widgets-schema": "^0.1.1",
     "lolex": "^1.4.0",
+    "mathjax": "^2.7.0",
     "phosphor": "^0.7.0",
     "scriptjs": "^2.5.8",
     "semver": "^5.1.0",

--- a/jupyter-js-widgets/src-embed/embed-webpack.ts
+++ b/jupyter-js-widgets/src-embed/embed-webpack.ts
@@ -22,9 +22,9 @@ var Ajv = require('ajv');
 var widget_state_schema = require('jupyter-widgets-schema').v1.state;
 var widget_view_schema = require('jupyter-widgets-schema').v1.view;
 
-
 // Magic global widget rendering function:
-import * as widgets from './index';
+import * as widgets from '../../jupyter-js-widgets/src/index';
+import * as embed from './embed-manager';
 
 // `LoadInlineWidget` is the main function called on load of the web page.
 // All it does is inserting a <script> tag for requirejs in the case it is not
@@ -80,7 +80,7 @@ function renderManager(element, tag) {
     if (!valid) {
         console.log(model_validate.errors);
     }
-    var manager = new widgets.EmbedManager();
+    var manager = new embed.EmbedManager();
     manager.set_state(widgetStateObject.state, {}).then(function(models) {
         var tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-view+json"]');
         for (var i=0; i!=tags.length; ++i) {

--- a/jupyter-js-widgets/src/utils.ts
+++ b/jupyter-js-widgets/src/utils.ts
@@ -138,6 +138,7 @@ function reject(message, log) {
     };
 }
 
+var MathJax = require('mathjax');
 
 /**
  * Apply MathJax rendering to an element, and optionally set its text.
@@ -155,7 +156,7 @@ function typeset(element: HTMLElement, text: string): void {
         element.textContent = text;
     }
     if (typeof MathJax !== "undefined") {
-      MathJax.Hub.Queue(['Typeset', MathJax.Hub, element]);
+        MathJax.Hub.Queue(['Typeset', MathJax.Hub, element]);
     }
 }
 


### PR DESCRIPTION
@jasongrout 

- the move of the embedder from src  to src-embed introduced a bug. (We were not defining the `jupyter-js-widgets` amd module. This fixes it.
- See also the change re: MathJax. 