### PR TITLE
Override RTD css for ul

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -845,6 +845,7 @@ ul.widget-dropdown-droplist.mod-active {
 
 .jupyter-widgets.widget-tab .p-TabBar.p-mod-horizontal > .p-TabBar-content {
     align-items: flex-end;
+    margin-bottom: 0;
 }
 
 .jupyter-widgets.widget-tab .widget-tab-contents {


### PR DESCRIPTION
The RTD sphinx theme has a css rule for 

`.rst-content .section ul` which is set to `margin-bottom 24px`.

This overrides it so that the phosphor tabs work well in RTD.

<img width="579" alt="screen shot 2016-12-12 at 1 31 41 pm" src="https://cloud.githubusercontent.com/assets/2397974/21099663/bb312972-c06f-11e6-9b99-d440a64dc4b7.png">


Fixes #972.