### PR TITLE
Add interactive_output function

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -16,6 +16,6 @@ from .widget_selection import RadioButtons, ToggleButtons, Dropdown, Select, Sel
 from .widget_selectioncontainer import Tab, Accordion
 from .widget_string import HTML, Label, Text, Textarea
 from .widget_controller import Controller
-from .interaction import interact, interactive, fixed, interact_manual
+from .interaction import interact, interactive, fixed, interact_manual, interactive_output
 from .widget_link import jslink, jsdlink
 from .widget_layout import Layout

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -30,6 +30,24 @@ from collections import Iterable, Mapping
 
 empty = Parameter.empty
 
+def interactive_output(f, controls):
+    """Connect widget controls to a function.
+
+    This function does not generate a user interface for the widgets (unlike `interact`).
+    This enables customisation of the widget user interface layout.
+    The user interface layout must be defined and displayed manually.
+    """
+
+    out = Output()
+    def observer(change):
+        out.clear_output()
+        kwargs = {k:v.value for k,v in controls.items()}
+        with out:
+            f(**kwargs)
+    for k,w in controls.items():
+        w.observe(observer, 'value')
+    observer(None)
+    return out
 
 def _matches(o, pattern):
     """Match a pattern of types in a sequence."""


### PR DESCRIPTION
Allows separation of widget definition and UI, as per #910.
Supersedes https://github.com/ipython/ipywidgets/pull/930.

Please feel free to edit the docstring.

