### PR TITLE
Use phosphor attach method instead of native DOM's appendChild

### DIFF
--- a/jupyter-js-widgets/examples/web/manager.js
+++ b/jupyter-js-widgets/examples/web/manager.js
@@ -1,4 +1,5 @@
 var widgets = require('jupyter-js-widgets');
+var PhosphorWidget = require('phosphor/lib/ui/widget').Widget;
 var ManagerBase = widgets.ManagerBase;
 console.info('jupyter-js-widgets loaded successfully');
 
@@ -12,8 +13,7 @@ WidgetManager.prototype = Object.create(ManagerBase.prototype);
 WidgetManager.prototype.display_view = function(msg, view, options) {
     var that = this;
     return Promise.resolve(view).then(function(view) {
-        that.el.appendChild(view.el);
-        view.trigger('displayed');
+        PhosphorWidget.attach(view.pWidget, that.el);
         view.on('remove', function() {
             console.log('View removed', view);
         });

--- a/jupyter-js-widgets/examples/web2/manager.js
+++ b/jupyter-js-widgets/examples/web2/manager.js
@@ -1,6 +1,8 @@
 var widgets = require('jupyter-js-widgets');
-require('jupyter-js-widgets/css/widgets.built.css');
+var PhosphorWidget = require('phosphor/lib/ui/widget').Widget;
 
+require('jupyter-js-widgets/css/widgets.built.css');
+require('phosphor/styles/base.css');
 console.info('jupyter-js-widgets loaded successfully');
 
 var WidgetManager = exports.WidgetManager = function(el) {
@@ -13,8 +15,7 @@ WidgetManager.prototype = Object.create(widgets.ManagerBase.prototype);
 WidgetManager.prototype.display_view = function(msg, view, options) {
     var that = this;
     return Promise.resolve(view).then(function(view) {
-        that.el.appendChild(view.el);
-        view.trigger('displayed');
+        PhosphorWidget.attach(view.pWidget, that.el);
         view.on('remove', function() {
             console.log('View removed', view);
         });

--- a/jupyter-js-widgets/examples/web3/src/manager.ts
+++ b/jupyter-js-widgets/examples/web3/src/manager.ts
@@ -1,5 +1,8 @@
 import * as widgets from 'jupyter-js-widgets';
 import './widgets.css';
+import 'phosphor/styles/base.css';
+import * as PWidget from 'phosphor/lib/ui/widget';
+
 
 export
 class WidgetManager extends widgets.ManagerBase<HTMLElement> {
@@ -17,8 +20,7 @@ class WidgetManager extends widgets.ManagerBase<HTMLElement> {
 
     display_view(msg, view, options) {
         return Promise.resolve(view).then((view) => {
-            this.el.appendChild(view.el);
-            view.trigger('displayed');
+            PWidget.Widget.attach(view.pWidget, this.el);
             view.on('remove', function() {
                 console.log('view removed', view);
             });

--- a/jupyter-js-widgets/src-embed/embed-manager.ts
+++ b/jupyter-js-widgets/src-embed/embed-manager.ts
@@ -5,6 +5,8 @@ import {
     ManagerBase
 } from '../lib/manager-base';
 
+import * as PhosphorWidget from 'phosphor/lib/ui/widget';
+
 export
 class EmbedManager extends ManagerBase<HTMLElement> {
 
@@ -14,8 +16,7 @@ class EmbedManager extends ManagerBase<HTMLElement> {
      */
     display_view(msg, view, options) {
         return Promise.resolve(view).then(function(view) {
-            options.el.appendChild(view.el);
-            view.trigger('displayed');
+            PhosphorWidget.Widget.attach(view.pWidget, options.el);
             view.on('remove', function() {
                 console.log('View removed', view);
             });


### PR DESCRIPTION
So that the phosphor-based-widgets properly render in embedded contexts.