### PR TITLE
changing package.json for windows

### DIFF
--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run clean && webpack",
     "clean": "rimraf widgetsnbextension/static",
-    "update": "rimraf node_modules/jupyter-js-widgets; npm install file:../jupyter-js-widgets; npm run build",
+    "update": "rimraf node_modules/jupyter-js-widgets && npm install file:../jupyter-js-widgets && npm run build",
     "prepublish": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
The `;` is not valid in Windows. I also see that for other commands in here and in `jupyter-js-widgets` we `&&` where we are only executing the subsequent commands if the previous one succeeds.