### PR TITLE
widget-subarea do not shrink correctly

### DIFF
--- a/widgetsnbextension/css/outputarea.css
+++ b/widgetsnbextension/css/outputarea.css
@@ -29,6 +29,7 @@
 }
 
 .widget-area .widget-subarea {
+    min-width: 0px;
     padding: 0.4em 0 0.4em 0;
     display: flex;
     flex: 2;


### PR DESCRIPTION
I'm developing a nbExtension, and I found out that when my elements are big enough, and window's width is thin, widget-subarea do not shrink at all, so my elements overflow from widget area. Setting min width of sub area to 0px fix this issue.