### PR TITLE
Buffered_state_diff bug fix backport

### DIFF
--- a/jupyter-js-widgets/src/manager-base.js
+++ b/jupyter-js-widgets/src/manager-base.js
@@ -168,7 +168,11 @@ ManagerBase.prototype.new_widget = function(options, serialized_state) {
     return commPromise.then(function(comm) {
         // Comm Promise Resolved.
         options_clone.comm = comm;
-        return that.new_model(options_clone, serialized_state);
+        var widget_model = that.new_model(options_clone, serialized_state);
+        return widget_model.then(function(model) {
+            model.sync('create', model);
+            return model;
+        });
     }, function() {
         // Comm Promise Rejected.
         if (!options_clone.model_id) {

--- a/jupyter-js-widgets/src/widget.js
+++ b/jupyter-js-widgets/src/widget.js
@@ -252,7 +252,9 @@ var WidgetModel = Backbone.Model.extend({
         // However, we don't buffer the initial state comming from the
         // backend or the default values specified in `defaults`.
         //
-        this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
+        if(this._buffered_state_diff !== null && this._buffered_state_diff !== undefined) {
+            this._buffered_state_diff = _.extend(this._buffered_state_diff, this.changedAttributes() || {});
+        }
         return return_value;
     },
 
@@ -330,12 +332,13 @@ var WidgetModel = Backbone.Model.extend({
                 // normal.
                 this.send_sync_message(attrs, callbacks);
                 this.pending_msgs++;
+                // Since the comm is a one-way communication, assume the message
+                // arrived and was processed successfully.
+                // Don't call options.success since we don't have a model back from
+                // the server. Note that this means we don't have the Backbone
+                // 'sync' event.
             }
         }
-        // Since the comm is a one-way communication, assume the message
-        // arrived.  Don't call success since we don't have a model back from the server
-        // this means we miss out on the 'sync' event.
-        this._buffered_state_diff = {};
     },
 
     send_sync_message: function(attrs, callbacks) {


### PR DESCRIPTION
Backporting the fix from #833 tp 5.x. I think this is valuable because the issue results in a irritating bug where the traits of the `widget` are being reset back to their previous values. 