### PR TITLE
Clarify that kernel synchronization only works when we have a live kernel

### DIFF
--- a/docs/source/examples/Widget Events.ipynb
+++ b/docs/source/examples/Widget Events.ipynb
@@ -281,9 +281,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Linking traitlets attributes from the server side\n",
+    "### Linking traitlets attributes in the kernel\n",
     "\n",
-    "The first method is to use the `link` and `dlink` functions from the `traitlets` module. "
+    "The first method is to use the `link` and `dlink` functions from the `traitlets` module. This only works if we are interacting with a live kernel."
    ]
   },
   {
@@ -411,7 +411,7 @@
    "source": [
     "When synchronizing traitlets attributes, you may experience a lag because of the latency due to the roundtrip to the server side. You can also directly link widget attributes in the browser using the link widgets, in either a unidirectional or a bidirectional fashion.\n",
     "\n",
-    "Besides, pure-javascript links persist when embedding widgets in html web pages without a backend."
+    "Javascript links persist when embedding widgets in html web pages without a kernel."
    ]
   },
   {


### PR DESCRIPTION
Fixes #988.