### PR TITLE
update_mapped_classes fixes

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -866,6 +866,12 @@ class DOMWidgetView extends WidgetView {
         this.update_classes(old_classes, new_classes, el || this.el);
     }
 
+    set_mapped_classes(class_map, trait_name, el?) {
+        var key = this.model.get(trait_name);
+        var new_classes = class_map[key] ? class_map[key] : [];
+        this.update_classes([], new_classes, el || this.el);
+    }
+
     typeset(element, text){
         this.displayed.then(function() {utils.typeset(element, text);});
     }

--- a/jupyter-js-widgets/src/widget_bool.ts
+++ b/jupyter-js-widgets/src/widget_bool.ts
@@ -108,19 +108,16 @@ class ToggleButtonView extends DOMWidgetView {
     render() {
         this.el.className = 'jupyter-widgets jupyter-button widget-toggle-button';
         this.listenTo(this.model, 'change:button_style', this.update_button_style);
-        this.update_button_style();
+        this.set_button_style();
         this.update(); // Set defaults.
     }
 
     update_button_style() {
-        var class_map = {
-            primary: ['mod-primary'],
-            success: ['mod-success'],
-            info: ['mod-info'],
-            warning: ['mod-warning'],
-            danger: ['mod-danger']
-        };
-        this.update_mapped_classes(class_map, 'button_style');
+        this.update_mapped_classes(ToggleButtonView.class_map, 'button_style');
+    }
+
+    set_button_style() {
+        this.set_mapped_classes(ToggleButtonView.class_map, 'button_style');
     }
 
     /**
@@ -192,6 +189,14 @@ class ToggleButtonView extends DOMWidgetView {
     }
 
     el: HTMLButtonElement;
+
+    static class_map = {
+        primary: ['mod-primary'],
+        success: ['mod-success'],
+        info: ['mod-info'],
+        warning: ['mod-warning'],
+        danger: ['mod-danger']
+    };
 }
 
 export

--- a/jupyter-js-widgets/src/widget_box.ts
+++ b/jupyter-js-widgets/src/widget_box.ts
@@ -253,17 +253,15 @@ class BoxView extends DOMWidgetView {
     render() {
         super.render();
         this.children_views.update(this.model.get('children'));
-        this.update_box_style();
+        this.set_box_style();
     }
 
     update_box_style() {
-        var class_map = {
-            success: ['alert', 'alert-success'],
-            info: ['alert', 'alert-info'],
-            warning: ['alert', 'alert-warning'],
-            danger: ['alert', 'alert-danger']
-        };
-        this.update_mapped_classes(class_map, 'box_style');
+        this.update_mapped_classes(BoxView.class_map, 'box_style');
+    }
+
+    set_box_style() {
+        this.set_mapped_classes(BoxView.class_map, 'box_style');
     }
 
     add_child_model(model) {
@@ -291,6 +289,13 @@ class BoxView extends DOMWidgetView {
 
     children_views: any;
     pWidget: JupyterPhosphorPanelWidget;
+
+    static class_map = {
+        success: ['alert', 'alert-success'],
+        info: ['alert', 'alert-info'],
+        warning: ['alert', 'alert-warning'],
+        danger: ['alert', 'alert-danger']
+    };
 }
 
 export

--- a/jupyter-js-widgets/src/widget_button.ts
+++ b/jupyter-js-widgets/src/widget_button.ts
@@ -34,7 +34,7 @@ class ButtonView extends DOMWidgetView {
     render() {
         this.el.className = 'jupyter-widgets jupyter-button widget-button';
         this.listenTo(this.model, 'change:button_style', this.update_button_style);
-        this.update_button_style();
+        this.set_button_style();
         this.update(); // Set defaults.
     }
 
@@ -64,14 +64,11 @@ class ButtonView extends DOMWidgetView {
     }
 
     update_button_style() {
-        var class_map = {
-            primary: ['mod-primary'],
-            success: ['mod-success'],
-            info: ['mod-info'],
-            warning: ['mod-warning'],
-            danger: ['mod-danger']
-        };
-        this.update_mapped_classes(class_map, 'button_style');
+        this.update_mapped_classes(ButtonView.class_map, 'button_style');
+    }
+
+    set_button_style() {
+        this.set_mapped_classes(ButtonView.class_map, 'button_style');
     }
 
     /**
@@ -105,4 +102,12 @@ class ButtonView extends DOMWidgetView {
     }
 
     el: HTMLButtonElement;
+
+    static class_map = {
+        primary: ['mod-primary'],
+        success: ['mod-success'],
+        info: ['mod-info'],
+        warning: ['mod-warning'],
+        danger: ['mod-danger']
+    };
 }

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -515,12 +515,17 @@ class ProgressModel extends BoundedIntModel {
 
 export
 class ProgressView extends LabeledDOMWidgetView {
+    initialize(parameters) {
+        super.initialize(parameters);
+        this.listenTo(this.model, 'change:bar_style', this.update_bar_style);
+        this.pWidget.addClass('jupyter-widgets');
+    }
+
     render() {
         super.render();
         var orientation = this.model.get('orientation');
-        var className = orientation === 'horizontal' ? 'widget-hprogress'
-            : 'widget-vprogress';
-        this.el.classList.add('jupyter-widgets');
+        var className = orientation === 'horizontal' ?
+            'widget-hprogress' : 'widget-vprogress';
         this.el.classList.add(className);
 
         this.progress = document.createElement('div');
@@ -537,9 +542,7 @@ class ProgressView extends LabeledDOMWidgetView {
 
         // Set defaults.
         this.update();
-
-        this.listenTo(this.model, 'change:bar_style', this.update_bar_style);
-        this.update_bar_style();
+        this.set_bar_style();
     }
 
     update() {
@@ -577,17 +580,22 @@ class ProgressView extends LabeledDOMWidgetView {
     }
 
     update_bar_style() {
-        var class_map = {
-            success: ['progress-bar-success'],
-            info: ['progress-bar-info'],
-            warning: ['progress-bar-warning'],
-            danger: ['progress-bar-danger']
-        };
-        this.update_mapped_classes(class_map, 'bar_style', this.bar);
+        this.update_mapped_classes(ProgressView.class_map, 'bar_style', this.bar);
+    }
+
+    set_bar_style() {
+        this.set_mapped_classes(ProgressView.class_map, 'bar_style', this.bar);
     }
 
     progress: HTMLDivElement;
     bar: HTMLDivElement;
+
+    static class_map = {
+        success: ['progress-bar-success'],
+        info: ['progress-bar-info'],
+        warning: ['progress-bar-warning'],
+        danger: ['progress-bar-danger']
+    };
 }
 
 export

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -45,10 +45,15 @@ class DropdownModel extends SelectionModel {
 export
 class DropdownView extends LabeledDOMWidgetView {
     initialize(options) {
+        super.initialize(options);
+
         this.onKeydown = this._handle_keydown.bind(this);
         this.onDismiss = this._handle_dismiss.bind(this);
         this.onHover = this._handle_hover.bind(this);
-        super.initialize(options);
+        this.listenTo(this.model, 'change:button_style', this.update_button_style);
+
+        this.pWidget.addClass('jupyter-widgets');
+        this.pWidget.addClass('widget-dropdown');
     }
 
     remove() {
@@ -58,10 +63,7 @@ class DropdownView extends LabeledDOMWidgetView {
 
     render() {
         super.render();
-
-        this.el.classList.add('jupyter-widgets');
         this.el.classList.add('widget-inline-hbox');
-        this.el.classList.add('widget-dropdown');
 
         this.toggle = document.createElement('div');
         this.toggle.className = 'widget-dropdown-toggle';
@@ -84,14 +86,12 @@ class DropdownView extends LabeledDOMWidgetView {
         // container they were instantiated in.
         this.droplist = document.createElement('ul');
         this.droplist.className = 'widget-dropdown-droplist';
-        document.body.appendChild(this.droplist);
         this.droplist.addEventListener('click', this._handle_click.bind(this));
-
-        this.listenTo(this.model, 'change:button_style', this.update_button_style);
-        this.update_button_style();
+        document.body.appendChild(this.droplist);
 
         // Set defaults.
         this.update();
+        this.set_button_style();
     }
 
     /**
@@ -138,14 +138,11 @@ class DropdownView extends LabeledDOMWidgetView {
     }
 
     update_button_style() {
-        var class_map = {
-            primary: ['mod-primary'],
-            success: ['mod-success'],
-            info: ['mod-info'],
-            warning: ['mod-warning'],
-            danger: ['mod-danger']
-        };
-        this.update_mapped_classes(class_map, 'button_style', this.toggle);
+        this.update_mapped_classes(DropdownView.class_map, 'button_style', this.toggle);
+    }
+
+    set_button_style() {
+        this.set_mapped_classes(DropdownView.class_map, 'button_style', this.toggle);
     }
 
     events(): {[e: string]: string} {
@@ -430,6 +427,14 @@ class DropdownView extends LabeledDOMWidgetView {
     selected: HTMLDivElement;
     caret: HTMLSpanElement;
     check: HTMLSpanElement;
+
+    static class_map = {
+        primary: ['mod-primary'],
+        success: ['mod-success'],
+        info: ['mod-info'],
+        warning: ['mod-warning'],
+        danger: ['mod-danger']
+    };
 }
 
 export
@@ -552,6 +557,7 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
     initialize(options) {
         this._css_state = {};
         super.initialize(options);
+        this.listenTo(this.model, 'change:button_style', this.update_button_style);
     }
 
     /**
@@ -567,9 +573,7 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
         this.buttongroup = document.createElement('div');
         this.el.appendChild(this.buttongroup);
 
-        this.listenTo(this.model, 'change:button_style', this.update_button_style);
-        this.update_button_style();
-
+        this.set_button_style();
         this.update();
     }
 
@@ -669,10 +673,16 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
     }
 
     update_button_style() {
-        var view = this;
         var buttons = this.buttongroup.querySelectorAll('button');
-        _.each(buttons, function(button) {
-            view.update_mapped_classes(ToggleButtonsView.classMap, 'button_style', button);
+        _.each(buttons, (button) => {
+            this.update_mapped_classes(ToggleButtonsView.classMap, 'button_style', button);
+        });
+    }
+
+    set_button_style() {
+        var buttons = this.buttongroup.querySelectorAll('button');
+        _.each(buttons, (button) => {
+            this.set_mapped_classes(ToggleButtonsView.classMap, 'button_style', button);
         });
     }
 


### PR DESCRIPTION
This is a proposal for a fix to #946 .

1. The reason for that bug is when `ProgressView.render` is run, `model.previous('bar_style')` and `model.get('bar_style')` are both equal to `info`, so that the difference performed by `update_classes` is nil, and nothing gets applied.

   So what I did is create an extra `set_bar_style` which will make the difference with an empty list instead.

   For the non-mapped classes that can be applied, this is what the base `DOMWidgetView` was doing.

2. I made `class_map` a static variable in all the widget views that use one.

3. In the case of `ButtonView`, mapped classes and top-level element classes properties both edit the same class list, which causes conflicts. One way to solve this would be to move the button element down in the DOM. @jasongrout what do you think of this?



