### PR TITLE
interactive.widget_from_abbrev should be a classmethod

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -265,13 +265,14 @@ class interactive(VBox):
             result.append(widget)
         return result
 
-    def widget_from_abbrev(self, abbrev, default=empty):
+    @classmethod
+    def widget_from_abbrev(cls, abbrev, default=empty):
         """Build a ValueWidget instance given an abbreviation or Widget."""
         if isinstance(abbrev, ValueWidget) or isinstance(abbrev, fixed):
             return abbrev
 
         if isinstance(abbrev, tuple):
-            widget = self.widget_from_tuple(abbrev)
+            widget = cls.widget_from_tuple(abbrev)
             if default is not empty:
                 try:
                     widget.value = default
@@ -281,14 +282,14 @@ class interactive(VBox):
             return widget
 
         # Try single value
-        widget = self.widget_from_single_value(abbrev)
+        widget = cls.widget_from_single_value(abbrev)
         if widget is not None:
             return widget
 
         # Something iterable (list, dict, generator, ...). Note that str and
         # tuple should be handled before, that is why we check this case last.
         if isinstance(abbrev, Iterable):
-            widget = self.widget_from_iterable(abbrev)
+            widget = cls.widget_from_iterable(abbrev)
             if default is not empty:
                 try:
                     widget.value = default


### PR DESCRIPTION
All the `widget_from_...` methods can be called from the `interactive` class (without an instance) because they are static methods. The only exception is `widget_from_abbrev` (which calls the other methods). Fix this by making `widget_from_abbrev` a class method. Note that it cannot be a static method, since we need to call other methods.