### PR TITLE
Add core widget base class providing module semver ranges

### DIFF
--- a/ipywidgets/_version.py
+++ b/ipywidgets/_version.py
@@ -1,3 +1,3 @@
 version_info = (6, 0, 0, 'beta7')
 __version__ = '.'.join(map(str, version_info))
-__frontend_version__ = '^2.0.19'
+__frontend_version__ = '^2.0.20'

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -4,6 +4,7 @@ from .valuewidget import ValueWidget
 
 from .trait_types import Color, Datetime
 
+from .widget_core import CoreWidget
 from .widget_bool import Checkbox, ToggleButton, Valid
 from .widget_button import Button
 from .widget_box import Box, Proxy, PlaceProxy, HBox, VBox

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -40,6 +40,7 @@ class DOMWidget(Widget):
             self._dom_classes = [c for c in self._dom_classes if c != className]
         return self
 
+
 class LabeledWidget(DOMWidget):
     """Widget that has a description label to the side."""
 

--- a/ipywidgets/widgets/widget_bool.py
+++ b/ipywidgets/widgets/widget_bool.py
@@ -7,12 +7,13 @@ Represents a boolean using a widget.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import LabeledWidget
+from .widget_core import CoreWidget
 from .valuewidget import ValueWidget
 from .widget import register
 from traitlets import Unicode, Bool, CaselessStrEnum
 
 
-class _Bool(LabeledWidget, ValueWidget):
+class _Bool(LabeledWidget, ValueWidget, CoreWidget):
     """A base class for creating widgets that represent booleans."""
     value = Bool(False, help="Bool value").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes.").tag(sync=True)

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -8,13 +8,14 @@ Represents a container that can be used to group other widgets.
 
 from .widget import register, widget_serialization
 from .domwidget import DOMWidget
+from .widget_core import CoreWidget
 from .widget_layout import Layout
 from traitlets import Unicode, Tuple, Int, CaselessStrEnum, Instance, default
 from warnings import warn
 
 
 @register('Jupyter.Box')
-class Box(DOMWidget):
+class Box(DOMWidget, CoreWidget):
     """Displays multiple widgets in a group."""
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _view_module = Unicode('jupyter-js-widgets').tag(sync=True)
@@ -55,7 +56,7 @@ class HBox(Box):
 
 
 @register('Jupyter.Proxy')
-class Proxy(DOMWidget):
+class Proxy(DOMWidget, CoreWidget):
     """A DOMWidget that holds another DOMWidget or nothing."""
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _view_module = Unicode('jupyter-js-widgets').tag(sync=True)

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -9,11 +9,13 @@ click events on the button and trigger backend code when the clicks are fired.
 
 from .domwidget import DOMWidget
 from .widget import CallbackDispatcher, register
+from .widget_core import CoreWidget
+
 from traitlets import Unicode, Bool, CaselessStrEnum, validate
 import warnings
 
 @register('Jupyter.Button')
-class Button(DOMWidget):
+class Button(DOMWidget, CoreWidget):
     """Button widget.
 
     This widget has an `on_click` method that allows you to listen for the

--- a/ipywidgets/widgets/widget_color.py
+++ b/ipywidgets/widgets/widget_color.py
@@ -9,12 +9,13 @@ Represents an HTML Color .
 from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import register
+from .widget_core import CoreWidget
 from .trait_types import Color
 from traitlets import Unicode, Bool
 
 
 @register('Jupyter.ColorPicker')
-class ColorPicker(LabeledWidget, ValueWidget):
+class ColorPicker(LabeledWidget, ValueWidget, CoreWidget):
     value = Color('black').tag(sync=True)
     concise = Bool().tag(sync=True)
 

--- a/ipywidgets/widgets/widget_controller.py
+++ b/ipywidgets/widgets/widget_controller.py
@@ -9,11 +9,12 @@ Represents a Gamepad or Joystick controller.
 from .valuewidget import ValueWidget
 from .widget import register, widget_serialization
 from .domwidget import DOMWidget
+from .widget_core import CoreWidget
 from traitlets import Bool, Int, Float, Unicode, List, Instance
 
 
 @register('Jupyter.ControllerButton')
-class Button(ValueWidget):
+class Button(ValueWidget, CoreWidget):
     """Represents a gamepad or joystick button."""
     value = Float(min=0.0, max=1.0, read_only=True).tag(sync=True)
     pressed = Bool(read_only=True).tag(sync=True)
@@ -25,7 +26,7 @@ class Button(ValueWidget):
 
 
 @register('Jupyter.ControllerAxis')
-class Axis(ValueWidget):
+class Axis(ValueWidget, CoreWidget):
     """Represents a gamepad or joystick axis."""
     value = Float(min=-1.0, max=1.0, read_only=True).tag(sync=True)
 
@@ -36,7 +37,7 @@ class Axis(ValueWidget):
 
 
 @register('Jupyter.Controller')
-class Controller(DOMWidget):
+class Controller(DOMWidget, CoreWidget):
     """Represents a game controller."""
     index = Int().tag(sync=True)
 

--- a/ipywidgets/widgets/widget_core.py
+++ b/ipywidgets/widgets/widget_core.py
@@ -1,0 +1,15 @@
+"""Base widget class for widgets provided in Core"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from .widget import Widget
+from .._version import __frontend_version__
+
+from traitlets import Unicode
+
+class CoreWidget(Widget):
+
+    _model_module_version = Unicode(__frontend_version__).tag(sync=True)
+    _view_module_version = Unicode(__frontend_version__).tag(sync=True)
+

--- a/ipywidgets/widgets/widget_date.py
+++ b/ipywidgets/widgets/widget_date.py
@@ -9,12 +9,13 @@ Represents an HTML Color .
 from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import register
+from .widget_core import CoreWidget
 from .trait_types import Datetime, datetime_serialization
 from traitlets import Unicode
 
 
 @register('Jupyter.DatePicker')
-class DatePicker(LabeledWidget, ValueWidget):
+class DatePicker(LabeledWidget, ValueWidget, CoreWidget):
     value = Datetime(None, allow_none=True).tag(sync=True, **datetime_serialization)
 
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -9,12 +9,14 @@ Represents an unbounded float using a widget.
 from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import register
+from .widget_core import CoreWidget
 from .trait_types import Color
-from traitlets import (Unicode, CFloat, Bool, Int, CaselessStrEnum,
-                       Tuple, TraitError, validate)
+from traitlets import (
+    Unicode, CFloat, Bool, Int, CaselessStrEnum, Tuple, TraitError, validate
+)
 
 
-class _Float(LabeledWidget, ValueWidget):
+class _Float(LabeledWidget, ValueWidget, CoreWidget):
     value = CFloat(0.0, help="Float value").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
 

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -8,6 +8,7 @@ Represents an image in the frontend using a widget.
 
 import base64
 
+from .widget_core import CoreWidget
 from .domwidget import DOMWidget
 from .valuewidget import ValueWidget
 from .widget import register
@@ -15,7 +16,7 @@ from traitlets import Unicode, CUnicode, Bytes, observe
 
 
 @register('Jupyter.Image')
-class Image(DOMWidget, ValueWidget):
+class Image(DOMWidget, ValueWidget, CoreWidget):
     """Displays an image as a widget.
 
     The `value` of this widget accepts a byte string.  The byte string is the

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -9,6 +9,7 @@ Represents an unbounded int using a widget.
 from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import register
+from .widget_core import CoreWidget
 from .trait_types import Color
 from traitlets import (Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError,
                        validate)
@@ -62,7 +63,7 @@ def _bounded_int_doc(cls):
     return cls
 
 
-class _Int(LabeledWidget, ValueWidget):
+class _Int(LabeledWidget, ValueWidget, CoreWidget):
     """Base class for widgets that represent an integer."""
     value = CInt(0, help="Int value").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)

--- a/ipywidgets/widgets/widget_layout.py
+++ b/ipywidgets/widgets/widget_layout.py
@@ -3,11 +3,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import Widget, register
 from traitlets import Unicode, Instance
+from .widget_core import CoreWidget
 
 
-class Layout(Widget):
+class Layout(CoreWidget):
     """Layout specification
 
     Defines a layout that can be expressed using CSS.  Supports a subset of
@@ -53,6 +53,7 @@ class Layout(Widget):
     top = Unicode(None, allow_none=True).tag(sync=True)
     visibility = Unicode(None, allow_none=True).tag(sync=True)
     width = Unicode(None, allow_none=True).tag(sync=True)
+
 
 class LayoutTraitType(Instance):
 

--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -7,6 +7,8 @@ Propagate changes between widgets on the javascript side.
 # Distributed under the terms of the Modified BSD License.
 
 from .widget import Widget, register, widget_serialization
+from .widget_core import CoreWidget
+
 from traitlets import Unicode, Tuple, List,Instance, TraitError
 
 
@@ -31,7 +33,7 @@ class WidgetTraitTuple(Tuple):
 
 
 @register('jupyter.Link')
-class Link(Widget):
+class Link(CoreWidget):
     """Link Widget
 
     source: a (Widget, 'trait_name') tuple for the source trait

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -7,13 +7,15 @@ Represents a widget that can be used to display output within the widget area.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
+from .widget_core import CoreWidget
+
 import sys
 from traitlets import Unicode
 from IPython.display import clear_output
 from IPython import get_ipython
 
 
-class Output(DOMWidget):
+class Output(DOMWidget, CoreWidget):
     """Widget used as a context manager to display output.
 
     This widget can capture and display stdout, stderr, and rich output.  To use

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -13,6 +13,7 @@ except ImportError:  #python3.x
 
 from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
+from .widget_core import CoreWidget
 from .widget import register
 from traitlets import (Unicode, Bool, Any, Dict, TraitError, CaselessStrEnum,
                        Tuple, List, Union, observe, validate)
@@ -40,7 +41,7 @@ def _label_to_value(k, obj):
     return obj._options_dict[k]
 
 
-class _Selection(LabeledWidget, ValueWidget):
+class _Selection(LabeledWidget, ValueWidget, CoreWidget):
     """Base class for Selection widgets
 
     ``options`` can be specified as a list of values, list of (label, value)

--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -8,11 +8,12 @@ pages.
 # Distributed under the terms of the Modified BSD License.
 
 from .widget_box import Box, register
+from .widget_core import CoreWidget
 from traitlets import Unicode, Dict, CInt
 from ipython_genutils.py3compat import unicode_type
 
 
-class _SelectionContainer(Box):
+class _SelectionContainer(Box, CoreWidget):
     """Base class used to display multiple child widgets."""
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _view_module = Unicode('jupyter-js-widgets').tag(sync=True)

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -9,11 +9,12 @@ Represents a unicode string using a widget.
 from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import CallbackDispatcher, register
+from .widget_core import CoreWidget
 from traitlets import Unicode, Bool
 from warnings import warn
 
 
-class _String(LabeledWidget, ValueWidget):
+class _String(LabeledWidget, ValueWidget, CoreWidget):
     """Base class used to create widgets that represent a string."""
 
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)

--- a/jupyter-js-widgets/src/index.ts
+++ b/jupyter-js-widgets/src/index.ts
@@ -11,6 +11,7 @@ export * from "./widget_button";
 export * from "./widget_box";
 export * from "./widget_image";
 export * from "./widget_color";
+export * from "./widget_core";
 export * from "./widget_date";
 export * from "./services-shim";
 export * from "./widget_int";

--- a/jupyter-js-widgets/src/index.ts
+++ b/jupyter-js-widgets/src/index.ts
@@ -11,7 +11,6 @@ export * from "./widget_button";
 export * from "./widget_box";
 export * from "./widget_image";
 export * from "./widget_color";
-export * from "./widget_core";
 export * from "./widget_date";
 export * from "./services-shim";
 export * from "./widget_int";

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -535,15 +535,6 @@ class DOMWidgetModel extends WidgetModel {
     }
 }
 
-export
-class LabeledDOMWidgetModel extends DOMWidgetModel {
-    defaults() {
-        return _.extend(super.defaults(), {
-            description: '',
-        });
-    }
-}
-
 /**
  * - create_view and remove_view are default functions called when adding or removing views
  * - create_view takes a model and an index and returns a view or a promise for a view for that model
@@ -911,29 +902,3 @@ class DOMWidgetView extends WidgetView {
     layoutPromise: Promise<any>;
 }
 
-export
-class LabeledDOMWidgetView extends DOMWidgetView {
-
-    render() {
-        this.label = document.createElement('div');
-        this.el.appendChild(this.label);
-        this.label.className = 'widget-label';
-        this.label.style.display = 'none';
-
-        this.listenTo(this.model, 'change:description', this.updateDescription);
-        this.updateDescription();
-    }
-
-    updateDescription() {
-        let description = this.model.get('description');
-        if (description.length === 0) {
-            this.label.style.display = 'none';
-        } else {
-            this.typeset(this.label, description);
-            this.label.style.display = '';
-        }
-        this.label.title = description;
-    }
-
-    label: HTMLDivElement;
-}

--- a/jupyter-js-widgets/src/widget_bool.ts
+++ b/jupyter-js-widgets/src/widget_bool.ts
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView, DOMWidgetView
+    LabeledDOMWidgetModel, LabeledDOMWidgetView
+} from './widget_core';
+
+import {
+    DOMWidgetView
 } from './widget';
 
 import {

--- a/jupyter-js-widgets/src/widget_box.ts
+++ b/jupyter-js-widgets/src/widget_box.ts
@@ -2,8 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView, unpack_models, ViewList, JupyterPhosphorWidget
+    DOMWidgetView, unpack_models, ViewList, JupyterPhosphorWidget
 } from './widget';
+
+import {
+    CoreDOMWidgetModel
+} from './widget_core';
 
 import {
     reject
@@ -70,7 +74,7 @@ class JupyterPhosphorPanelWidget extends Panel {
 
 
 export
-class BoxModel extends DOMWidgetModel {
+class BoxModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _view_name: 'BoxView',
@@ -82,7 +86,7 @@ class BoxModel extends DOMWidgetModel {
 
     static serializers = _.extend({
         children: {deserialize: unpack_models}
-    }, DOMWidgetModel.serializers)
+    }, CoreDOMWidgetModel.serializers)
 }
 
 export
@@ -106,7 +110,7 @@ class VBoxModel extends BoxModel {
 }
 
 export
-class ProxyModel extends DOMWidgetModel {
+class ProxyModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _view_name: 'ProxyView',
@@ -117,7 +121,7 @@ class ProxyModel extends DOMWidgetModel {
 
     static serializers = _.extend({
         child: {deserialize: unpack_models}
-    }, DOMWidgetModel.serializers);
+    }, CoreDOMWidgetModel.serializers);
 }
 
 export

--- a/jupyter-js-widgets/src/widget_button.ts
+++ b/jupyter-js-widgets/src/widget_button.ts
@@ -2,8 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView, JupyterPhosphorWidget
+    DOMWidgetView
 } from './widget';
+
+import {
+    CoreDOMWidgetModel
+} from './widget_core';
 
 import {
     Widget
@@ -12,7 +16,7 @@ import {
 import * as _ from 'underscore';
 
 export
-class ButtonModel extends DOMWidgetModel {
+class ButtonModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             description: '',

--- a/jupyter-js-widgets/src/widget_color.ts
+++ b/jupyter-js-widgets/src/widget_color.ts
@@ -3,7 +3,7 @@
 
 import {
     LabeledDOMWidgetModel, LabeledDOMWidgetView
-} from './widget';
+} from './widget_core';
 
 import * as _ from 'underscore';
 

--- a/jupyter-js-widgets/src/widget_controller.ts
+++ b/jupyter-js-widgets/src/widget_controller.ts
@@ -2,13 +2,19 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView, unpack_models, ViewList
+    CoreDOMWidgetModel
+} from './widget_core';
+
+import {
+    DOMWidgetView, unpack_models, ViewList
 } from './widget';
+
 import * as _ from 'underscore';
+
 import * as utils from './utils';
 
 export
-class ControllerButtonModel extends DOMWidgetModel {
+class ControllerButtonModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'ControllerButtonModel',
@@ -62,7 +68,7 @@ class ControllerButtonView extends DOMWidgetView {
 
 
 export
-class ControllerAxisModel extends DOMWidgetModel {
+class ControllerAxisModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'ControllerAxisModel',
@@ -119,11 +125,11 @@ class ControllerAxisView extends DOMWidgetView {
 }
 
 export
-class ControllerModel extends DOMWidgetModel {
+class ControllerModel extends CoreDOMWidgetModel {
     static serializers = _.extend({
         buttons: {deserialize: unpack_models},
         axes: {deserialize: unpack_models}
-    }, DOMWidgetModel.serializers)
+    }, CoreDOMWidgetModel.serializers)
 
     defaults() {
         return _.extend(super.defaults(), {

--- a/jupyter-js-widgets/src/widget_core.ts
+++ b/jupyter-js-widgets/src/widget_core.ts
@@ -1,8 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+// widget_core implements some common patterns for the core widget collection
+// that are not to be used directly by third-party widget authors.
+
 import {
-    DOMWidgetModel, WidgetModel
+    DOMWidgetModel, WidgetModel, DOMWidgetView
 } from './widget';
 
 import * as _ from 'underscore';
@@ -29,4 +32,40 @@ class CoreDOMWidgetModel extends DOMWidgetModel {
             _view_module_version: semver_range
         });
     }
+}
+
+export
+class LabeledDOMWidgetModel extends CoreDOMWidgetModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            description: '',
+        });
+    }
+}
+
+export
+class LabeledDOMWidgetView extends DOMWidgetView {
+
+    render() {
+        this.label = document.createElement('div');
+        this.el.appendChild(this.label);
+        this.label.className = 'widget-label';
+        this.label.style.display = 'none';
+
+        this.listenTo(this.model, 'change:description', this.updateDescription);
+        this.updateDescription();
+    }
+
+    updateDescription() {
+        let description = this.model.get('description');
+        if (description.length === 0) {
+            this.label.style.display = 'none';
+        } else {
+            this.typeset(this.label, description);
+            this.label.style.display = '';
+        }
+        this.label.title = description;
+    }
+
+    label: HTMLDivElement;
 }

--- a/jupyter-js-widgets/src/widget_core.ts
+++ b/jupyter-js-widgets/src/widget_core.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+    DOMWidgetModel, WidgetModel
+} from './widget';
+
+import * as _ from 'underscore';
+
+var semver_range = `^${require('../package.json').version}`
+
+export
+class CoreWidgetModel extends WidgetModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _model_name: 'CoreWidgetModel',
+            _model_module_version: semver_range,
+            _view_module_version: semver_range
+        });
+    }
+}
+
+export
+class CoreDOMWidgetModel extends DOMWidgetModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _model_name: 'CoreDOMWidgetModel',
+            _model_module_version: semver_range,
+            _view_module_version: semver_range
+        });
+    }
+}

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -3,7 +3,7 @@
 
 import {
     LabeledDOMWidgetModel, LabeledDOMWidgetView
-} from './widget';
+} from './widget_core';
 
 import * as _ from 'underscore';
 

--- a/jupyter-js-widgets/src/widget_float.ts
+++ b/jupyter-js-widgets/src/widget_float.ts
@@ -3,7 +3,8 @@
 
 import {
     LabeledDOMWidgetModel, LabeledDOMWidgetView
-} from './widget';
+} from './widget_core';
+
 import * as _ from 'underscore';
 
 import {

--- a/jupyter-js-widgets/src/widget_image.ts
+++ b/jupyter-js-widgets/src/widget_image.ts
@@ -2,8 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView
+    DOMWidgetView
 } from './widget';
+
+import {
+    CoreDOMWidgetModel
+} from './widget_core';
 
 import {
     Widget
@@ -12,7 +16,7 @@ import {
 import * as _ from 'underscore';
 
 export
-class ImageModel extends DOMWidgetModel {
+class ImageModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'ImageModel',

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -2,12 +2,17 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView,
-    DOMWidgetModel, DOMWidgetView
+    LabeledDOMWidgetModel, LabeledDOMWidgetView
+} from './widget_core';
+
+import {
+    DOMWidgetView
 } from './widget';
+
 import * as _ from 'underscore';
 import * as $ from 'jquery';
 import 'jquery-ui/ui/widgets/slider';
+
 var d3format: any = (require('d3-format') as any).format;
 
 export

--- a/jupyter-js-widgets/src/widget_layout.ts
+++ b/jupyter-js-widgets/src/widget_layout.ts
@@ -2,8 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView
+    WidgetView, DOMWidgetView
 } from './widget';
+
+import {
+    CoreWidgetModel
+} from './widget_core';
 
 import * as _ from 'underscore';
 
@@ -42,7 +46,7 @@ let css_properties = {
  * Represents a group of CSS style attributes
  */
 export
-class LayoutModel extends DOMWidgetModel {
+class LayoutModel extends CoreWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
         _model_name: 'LayoutModel',
@@ -52,7 +56,7 @@ class LayoutModel extends DOMWidgetModel {
 }
 
 export
-class LayoutView extends DOMWidgetView {
+class LayoutView extends WidgetView {
     /**
      * Public constructor
      */

--- a/jupyter-js-widgets/src/widget_link.ts
+++ b/jupyter-js-widgets/src/widget_link.ts
@@ -2,18 +2,22 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView, WidgetModel, unpack_models
+    WidgetModel, unpack_models
 } from './widget';
+
+import {
+    CoreWidgetModel
+} from './widget_core';
 
 import * as _ from 'underscore';
 
 
 export
-class DirectionalLinkModel extends WidgetModel {
+class DirectionalLinkModel extends CoreWidgetModel {
     static serializers = _.extend({
         target: {deserialize: unpack_models},
         source: {deserialize: unpack_models}
-    }, WidgetModel.serializers)
+    }, CoreWidgetModel.serializers)
 
     defaults() {
         return _.extend(super.defaults(), {

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView, unpack_models, ViewList
+    LabeledDOMWidgetModel, LabeledDOMWidgetView
+} from './widget_core';
+
+import {
+    unpack_models, ViewList
 } from './widget';
 
 import * as _ from 'underscore';

--- a/jupyter-js-widgets/src/widget_selectioncontainer.ts
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetModel, DOMWidgetView, ViewList, JupyterPhosphorWidget
+    DOMWidgetView, ViewList, JupyterPhosphorWidget
 } from './widget';
 
 import {

--- a/jupyter-js-widgets/src/widget_string.ts
+++ b/jupyter-js-widgets/src/widget_string.ts
@@ -3,7 +3,8 @@
 
 import {
     LabeledDOMWidgetModel, LabeledDOMWidgetView
-} from './widget';
+} from './widget_core';
+
 import * as _ from 'underscore';
 
 export


### PR DESCRIPTION
Closes #1002.

On the Python side, I use multiple inheritance to specify the version range for all core widgets without impacting the base `Widget` and `DOMWidget` classes that are used in third-party libraries.

On the JS side, I still need to make the change.

Proposed solution: use `'^' + require('../package.json').version`

@jasongrout thoughts?