### PR TITLE
Provide a way for cells in the classic notebook to notify widgets of resizes

### DIFF
--- a/widgetsnbextension/src/widgetarea.js
+++ b/widgetsnbextension/src/widgetarea.js
@@ -29,6 +29,15 @@ var WidgetArea = function(cell) {
     cell.notebook.events.on('kernel_killed.Kernel', died);
     cell.notebook.events.on('kernel_restarting.Kernel', died);
     cell.notebook.events.on('kernel_dead.Kernel', died);
+
+    cell.events.on('resize.Cell', function(event, options) {
+        if (options.cell !== that._cell) {
+            return;
+        }
+        that.widget_views.forEach(function(view) {
+            messaging.sendMessage(view.pWidget, widgets.ResizeMessage.UnknownSize);
+        });
+    });
 };
 
 /**


### PR DESCRIPTION
JLab automatically handles this, but we still need a way for the classic notebook to notify the top-level widgets of resize events.