### PR TITLE
Delete margin for HBox and VBox

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -69,17 +69,14 @@
 .widget-box {
     box-sizing: border-box;
     display: flex;
+    margin: 0;
 }
 
 .widget-hbox {
-    box-sizing: border-box;
-    display: flex;
     flex-direction: row;
 }
 
 .widget-vbox {
-    box-sizing: border-box;
-    display: flex;
     flex-direction: column;
 }
 


### PR DESCRIPTION
The margin causes a lot of extra padding as these boxes are nested deeply.