### PR TITLE
Simplify box disposal

### DIFF
--- a/jupyter-js-widgets/src/widget_box.ts
+++ b/jupyter-js-widgets/src/widget_box.ts
@@ -140,9 +140,6 @@ class ProxyView extends DOMWidgetView {
     }
 
     remove() {
-        if (this.pWidget.isAttached) {
-            Widget.detach(this.pWidget);
-        }
         this.child_promise.then(() => {
             if (this.child) {
                 this.child.remove();
@@ -280,11 +277,8 @@ class BoxView extends DOMWidgetView {
     }
 
     remove() {
-        if (this.pWidget.isAttached) {
-            Widget.detach(this.pWidget);
-        }
-        this.children_views.dispose();
-        super.remove()
+        this.children_views = null;
+        super.remove();
     }
 
     children_views: any;

--- a/jupyter-js-widgets/src/widget_selectioncontainer.ts
+++ b/jupyter-js-widgets/src/widget_selectioncontainer.ts
@@ -226,10 +226,7 @@ class AccordionView extends DOMWidgetView {
     }
 
     remove() {
-        if (this.pWidget.isAttached) {
-            Widget.detach(this.pWidget);
-        }
-        this.children_views.dispose();
+        this.children_views = null;
         super.remove();
     }
 
@@ -420,10 +417,7 @@ class TabView extends DOMWidgetView {
     }
 
     remove() {
-        if (this.pWidget.isAttached) {
-            Widget.detach(this.pWidget);
-        }
-        this.childrenViews.dispose();
+        this.childrenViews = null;
         super.remove();
     }
 


### PR DESCRIPTION
With the current code, removing a box gave the error message “Uncaught (in promise) Error: Cannot detach child widget.” Instead, we simplify the removal code by just directly calling dispose(), which automatically disposes child widgets (and therefore calls child remove methods).