### PR TITLE
Selection container title dict should have string keys to be consistent with JSON

### DIFF
--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -9,6 +9,7 @@ pages.
 
 from .widget_box import Box, register
 from traitlets import Unicode, Dict, CInt
+from ipython_genutils.py3compat import unicode_type
 
 
 class _SelectionContainer(Box):
@@ -30,6 +31,8 @@ class _SelectionContainer(Box):
         title : unicode
             New title
         """
+        # JSON dictionaries have string keys, so we convert index to a string
+        index = unicode_type(int(index))
         self._titles[index] = title
         self.send_state('_titles')
 
@@ -41,6 +44,8 @@ class _SelectionContainer(Box):
         index : int
             Index of the container page
         """
+        # JSON dictionaries have string keys, so we convert index to a string
+        index = unicode_type(int(index))
         if index in self._titles:
             return self._titles[index]
         else:


### PR DESCRIPTION
Thanks to @mgeplf for suggesting the fix.

Fixes #1065