### PR TITLE
Widget styling

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -6,7 +6,7 @@ from .trait_types import Color, Datetime
 
 from .widget_core import CoreWidget
 from .widget_bool import Checkbox, ToggleButton, Valid
-from .widget_button import Button
+from .widget_button import Button, ButtonStyle
 from .widget_box import Box, Proxy, PlaceProxy, HBox, VBox
 from .widget_float import FloatText, BoundedFloatText, FloatSlider, FloatProgress, FloatRangeSlider
 from .widget_image import Image
@@ -21,3 +21,4 @@ from .widget_controller import Controller
 from .interaction import interact, interactive, fixed, interact_manual, interactive_output
 from .widget_link import jslink, jsdlink
 from .widget_layout import Layout
+from .widget_style import Style

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -14,7 +14,7 @@ from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
 from traitlets.config import LoggingConfigurable
 from traitlets.utils.importstring import import_item
-from traitlets import Unicode, Dict, Instance, List, Int, Set, Bytes, observe
+from traitlets import Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default
 from ipython_genutils.py3compat import string_types, PY3
 from IPython.display import display
 
@@ -181,7 +181,9 @@ class Widget(LoggingConfigurable):
     msg_throttle = Int(1, help="""Maximum number of msgs the front-end can send before receiving an idle msg from the back-end.""").tag(sync=True)
 
     keys = List()
-    def _keys_default(self):
+
+    @default('keys')
+    def _default_keys(self):
         return [name for name in self.traits(sync=True)]
 
     _property_lock = Dict()

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -8,11 +8,21 @@ click events on the button and trigger backend code when the clicks are fired.
 # Distributed under the terms of the Modified BSD License.
 
 from .domwidget import DOMWidget
-from .widget import CallbackDispatcher, register
+from .widget import CallbackDispatcher, register, widget_serialization
 from .widget_core import CoreWidget
+from .widget_style import Style
+from .trait_types import Color
 
-from traitlets import Unicode, Bool, CaselessStrEnum, validate
+from traitlets import Unicode, Bool, CaselessStrEnum, Instance, validate, default
 import warnings
+
+
+@register('Jupyter.ButtonStyle')
+class ButtonStyle(Style):
+    """Button style widget."""
+    _model_name = Unicode('ButtonStyleModel').tag(sync=True)
+    button_color = Color(None, allow_none=True).tag(sync=True)
+
 
 @register('Jupyter.Button')
 class Button(DOMWidget, CoreWidget):
@@ -43,6 +53,12 @@ class Button(DOMWidget, CoreWidget):
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], default_value='',
         help="""Use a predefined styling for the button.""").tag(sync=True)
+
+    style = Instance(ButtonStyle).tag(sync=True, **widget_serialization)
+
+    @default('style')
+    def _default_style(self):
+        return ButtonStyle()
 
     def __init__(self, **kwargs):
         super(Button, self).__init__(**kwargs)

--- a/ipywidgets/widgets/widget_style.py
+++ b/ipywidgets/widgets/widget_style.py
@@ -1,0 +1,16 @@
+"""Contains the Style class"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from traitlets import Unicode
+from .widget import Widget
+
+
+class Style(Widget):
+    """Style specification"""
+
+    _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
+    _view_module = Unicode('jupyter-js-widgets').tag(sync=True)
+    _view_name = Unicode('StyleView').tag(sync=True)
+    _model_name = Unicode('StyleModel').tag(sync=True)

--- a/jupyter-js-widgets/src/index.ts
+++ b/jupyter-js-widgets/src/index.ts
@@ -5,6 +5,7 @@ export * from "./manager-base";
 export * from "./utils";
 export * from "./widget";
 export * from "./widget_layout";
+export * from "./widget_style";
 export * from "./widget_link";
 export * from "./widget_bool";
 export * from "./widget_button";

--- a/jupyter-js-widgets/src/widget_button.ts
+++ b/jupyter-js-widgets/src/widget_button.ts
@@ -10,10 +10,31 @@ import {
 } from './widget_core';
 
 import {
+    StyleModel
+} from './widget_style';
+
+import {
     Widget
 } from 'phosphor/lib/ui/widget';
 
 import * as _ from 'underscore';
+
+export
+class ButtonStyleModel extends StyleModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _model_name: 'ButtonStyleModel',
+        });
+    }
+
+    public static style_properties = {
+        button_color: {
+            default_value: '',
+            selector: '',
+            attribute: 'background-color'
+        }
+    };
+}
 
 export
 class ButtonModel extends CoreDOMWidgetModel {
@@ -25,7 +46,8 @@ class ButtonModel extends CoreDOMWidgetModel {
             icon: '',
             button_style: '',
             _view_name: 'ButtonView',
-            _model_name: 'ButtonModel'
+            _model_name: 'ButtonModel',
+            style: void 0
         });
     }
 }


### PR DESCRIPTION
Fixes #992.

I have not yet exposed many properties but the main logic is already there.

Widgets now have a style attribute behaving in a similar way to `layout`. However, these are not directly mapped to css properties of the main `el` element of the view. Instead, in the front-end logic, we specify the css selector for the DOM subtree, css property name, and default value for the attribute.

This allows to define things like  `Slider.style.handle_color` controlling the color of the slider handle without exposing the DOM structure of the widget.

<img width="610" alt="screen shot 2017-02-02 at 4 04 44 pm" src="https://cloud.githubusercontent.com/assets/2397974/22554769/a1d67926-e961-11e6-85f8-a340e864c5ce.png">
