### PR TITLE
fix ES2015 feature of getter

### DIFF
--- a/widgetsnbextension/src/widget_output.js
+++ b/widgetsnbextension/src/widget_output.js
@@ -41,7 +41,7 @@ var OutputModel = widgets.DOMWidgetModel.extend({
         }
     },
 
-    reset_msg_id() {
+    reset_msg_id: function() {
         var kernel = this.kernel;
         // Pop previous message id
         var prev_msg_id = this.previous('msg_id');


### PR DESCRIPTION
We get a javascript error with this syntax on older browsers.

cc @jasongrout 