### PR TITLE
Move LabeledDOMWidgetModel and LabeledDOMWidgetView to exports so others can subclass

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -932,3 +932,39 @@ class DOMWidgetView extends WidgetView {
     stylePromise: Promise<any>;
 }
 
+
+export
+class LabeledDOMWidgetModel extends DOMWidgetModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            description: '',
+        });
+    }
+}
+
+export
+class LabeledDOMWidgetView extends DOMWidgetView {
+
+    render() {
+        this.label = document.createElement('div');
+        this.el.appendChild(this.label);
+        this.label.className = 'widget-label';
+        this.label.style.display = 'none';
+
+        this.listenTo(this.model, 'change:description', this.updateDescription);
+        this.updateDescription();
+    }
+
+    updateDescription() {
+        let description = this.model.get('description');
+        if (description.length === 0) {
+            this.label.style.display = 'none';
+        } else {
+            this.typeset(this.label, description);
+            this.label.style.display = '';
+        }
+        this.label.title = description;
+    }
+
+    label: HTMLDivElement;
+}

--- a/jupyter-js-widgets/src/widget_bool.ts
+++ b/jupyter-js-widgets/src/widget_bool.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    CoreLabeledDOMWidgetModel
 } from './widget_core';
 
 import {
-    DOMWidgetView
+    DOMWidgetView, LabeledDOMWidgetView
 } from './widget';
 
 import {
@@ -17,7 +17,7 @@ import * as _ from 'underscore';
 
 
 export
-class BoolModel extends LabeledDOMWidgetModel {
+class BoolModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             value: false,
@@ -28,7 +28,7 @@ class BoolModel extends LabeledDOMWidgetModel {
 }
 
 export
-class CheckboxModel extends LabeledDOMWidgetModel {
+class CheckboxModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _view_name: 'CheckboxView',

--- a/jupyter-js-widgets/src/widget_color.ts
+++ b/jupyter-js-widgets/src/widget_color.ts
@@ -2,14 +2,18 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    LabeledDOMWidgetView
+} from './widget';
+
+import {
+    CoreLabeledDOMWidgetModel
 } from './widget_core';
 
 import * as _ from 'underscore';
 
 
 export
-class ColorPickerModel extends LabeledDOMWidgetModel {
+class ColorPickerModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             value: 'black',

--- a/jupyter-js-widgets/src/widget_core.ts
+++ b/jupyter-js-widgets/src/widget_core.ts
@@ -5,7 +5,7 @@
 // that are not to be used directly by third-party widget authors.
 
 import {
-    DOMWidgetModel, WidgetModel, DOMWidgetView
+    DOMWidgetModel, WidgetModel, LabeledDOMWidgetModel
 } from './widget';
 
 import * as _ from 'underscore';
@@ -35,37 +35,12 @@ class CoreDOMWidgetModel extends DOMWidgetModel {
 }
 
 export
-class LabeledDOMWidgetModel extends CoreDOMWidgetModel {
+class CoreLabeledDOMWidgetModel extends LabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
-            description: '',
+            _model_name: 'CoreLabeledDOMWidgetModel',
+            _model_module_version: semver_range,
+            _view_module_version: semver_range
         });
     }
-}
-
-export
-class LabeledDOMWidgetView extends DOMWidgetView {
-
-    render() {
-        this.label = document.createElement('div');
-        this.el.appendChild(this.label);
-        this.label.className = 'widget-label';
-        this.label.style.display = 'none';
-
-        this.listenTo(this.model, 'change:description', this.updateDescription);
-        this.updateDescription();
-    }
-
-    updateDescription() {
-        let description = this.model.get('description');
-        if (description.length === 0) {
-            this.label.style.display = 'none';
-        } else {
-            this.typeset(this.label, description);
-            this.label.style.display = '';
-        }
-        this.label.title = description;
-    }
-
-    label: HTMLDivElement;
 }

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    LabeledDOMWidgetView
+} from './widget';
+
+import {
+    CoreLabeledDOMWidgetModel
 } from './widget_core';
 
 import * as _ from 'underscore';
@@ -75,13 +79,13 @@ function convertDateToUTC(date) {
 }
 
 export
-class DatePickerModel extends LabeledDOMWidgetModel {
+class DatePickerModel extends CoreLabeledDOMWidgetModel {
     static serializers = _.extend({
         value: {
             serialize: serialize_datetime,
             deserialize: deserialize_datetime
         }
-    }, LabeledDOMWidgetModel.serializers)
+    }, CoreLabeledDOMWidgetModel.serializers)
 
     defaults() {
         return _.extend(super.defaults(), {

--- a/jupyter-js-widgets/src/widget_float.ts
+++ b/jupyter-js-widgets/src/widget_float.ts
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    LabeledDOMWidgetView
+} from './widget';
+
+import {
+    CoreLabeledDOMWidgetModel
 } from './widget_core';
 
 import * as _ from 'underscore';
@@ -15,7 +19,7 @@ import {
 var d3format: any = (require('d3-format') as any).format;
 
 export
-class FloatModel extends LabeledDOMWidgetModel {
+class FloatModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: "FloatModel",

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    CoreLabeledDOMWidgetModel
 } from './widget_core';
 
 import {
-    DOMWidgetView
+    DOMWidgetView, LabeledDOMWidgetView
 } from './widget';
 
 import {
@@ -20,7 +20,7 @@ import 'jquery-ui/ui/widgets/slider';
 var d3format: any = (require('d3-format') as any).format;
 
 export
-class IntModel extends LabeledDOMWidgetModel {
+class IntModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'IntModel',

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    CoreLabeledDOMWidgetModel,
 } from './widget_core';
 
 import {
-    unpack_models, ViewList
+    LabeledDOMWidgetView, unpack_models, ViewList
 } from './widget';
 
 import * as _ from 'underscore';
@@ -24,7 +24,7 @@ function scrollIfNeeded(area, elem) {
 }
 
 export
-class SelectionModel extends LabeledDOMWidgetModel {
+class SelectionModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'SelectionModel',

--- a/jupyter-js-widgets/src/widget_string.ts
+++ b/jupyter-js-widgets/src/widget_string.ts
@@ -2,13 +2,18 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    LabeledDOMWidgetModel, LabeledDOMWidgetView
+    LabeledDOMWidgetView
+} from './widget';
+
+import {
+    CoreLabeledDOMWidgetModel
 } from './widget_core';
+
 
 import * as _ from 'underscore';
 
 export
-class StringModel extends LabeledDOMWidgetModel {
+class StringModel extends CoreLabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             value: '',


### PR DESCRIPTION
This provides a standardized way for 3rd party widgets to handle the description labels.