### PR TITLE
Remove workaround code for notebook before 4.2.

### DIFF
--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -47,22 +47,3 @@ def _handle_ipython():
     load_ipython_extension(ip)
 
 _handle_ipython()
-
-
-def find_static_assets():
-    import warnings
-    try:
-        import widgetsnbextension
-        if hasattr(widgetsnbextension, 'find_static_assets'):
-            return widgetsnbextension.find_static_assets()
-        else:
-            warnings.warn("""The version of ipywidgets that you have installed
-            only works with Jupyter Notebook 4.2 or later.  Your version of the
-            Jupyter Notebook is too old. If you'd like to use ipywidgets with an
-            older version of the notebook, use ipywidgets 4.x or earlier.
-            """, RuntimeWarning)
-            return []
-    except ImportError:
-        warnings.warn("""To use the widgets with your installed Jupyter Notebook
-        version, please install ipywidgets 4.x or earlier.""", RuntimeWarning)
-        return []

--- a/widgetsnbextension/widgetsnbextension/__init__.py
+++ b/widgetsnbextension/widgetsnbextension/__init__.py
@@ -24,8 +24,3 @@ def _jupyter_nbextension_paths():
         'dest': 'jupyter-js-widgets',
         'require': 'jupyter-js-widgets/extension'
     }]
-
-def find_static_assets():
-    warn("""To use the jupyter-js-widgets nbextension, you'll need to update
-    the Jupyter notebook to version 4.2 or later.""")
-    return []


### PR DESCRIPTION
Since widgets 6.x will require notebook 4.4 or later, we can remove the workaround for older notebook versions.

Fixes #569.