### PR TITLE
Fix textarea layout logic

### DIFF
--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -10,7 +10,7 @@ from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import CallbackDispatcher, register
 from .widget_core import CoreWidget
-from traitlets import Unicode, Bool
+from traitlets import Unicode, Bool, Int
 from warnings import warn
 
 
@@ -66,6 +66,7 @@ class Textarea(_String):
     """Multiline text area widget."""
     _view_name = Unicode('TextareaView').tag(sync=True)
     _model_name = Unicode('TextareaModel').tag(sync=True)
+    rows = Int(None, allow_none=True).tag(sync=True)
 
     def scroll_to_bottom(self):
         self.send({"method": "scroll_to_bottom"})

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -385,6 +385,11 @@
     flex-shrink: 1;
 }
 
+.widget-textarea textarea {
+    height: inherit;
+    width: inherit;
+}
+
 .widget-text input:focus, .widget-textarea textarea:focus {
     -webkit-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2),
                         0 3px 1px -2px rgba(0, 0, 0, 0.14),

--- a/jupyter-js-widgets/src/widget_string.ts
+++ b/jupyter-js-widgets/src/widget_string.ts
@@ -142,7 +142,8 @@ class TextareaModel extends StringModel {
     defaults() {
         return _.extend(super.defaults(), {
             _view_name: 'TextareaView',
-            _model_name: 'TextareaModel'
+            _model_name: 'TextareaModel',
+            rows: null
         });
     }
 }
@@ -164,12 +165,13 @@ class TextareaView extends LabeledDOMWidgetView {
 
         this.update(); // Set defaults.
         this.listenTo(this.model, 'msg:custom', (content) => {
-          this._handle_textarea_msg(content)
+            this._handle_textarea_msg(content)
         });
+
         this.listenTo(this.model, 'change:placeholder',
             function(model, value, options) {
                 this.update_placeholder(value);
-            });
+        });
 
         this.update_placeholder();
     }
@@ -204,7 +206,7 @@ class TextareaView extends LabeledDOMWidgetView {
     update(options?) {
         if (options === undefined || options.updated_view != this) {
             this.textbox.value = this.model.get('value');
-
+            this.textbox.rows = this.model.get('rows');
             var disabled = this.model.get('disabled');
             this.textbox.disabled = disabled;
         }


### PR DESCRIPTION
Closes #1102 .
Fixes #1077 .

A new `rows` attribute controls the natural height and actually sets the `rows` property of the `textarea` tag. Setting it to the default trait value `None` let the browser use its default value which is typically 2.

Layout properties override this natural height when set.

![textarea](https://cloud.githubusercontent.com/assets/2397974/22975808/3f75a302-f388-11e6-869b-f44de5e11183.gif)
