### PR TITLE
Tab Styling Issue Fix

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -880,6 +880,11 @@ ul.widget-dropdown-droplist.mod-active {
     overflow-y: visible;
 }
 
+.jupyter-widgets .p-TabPanel-tabContents {
+    overflow-x: visible;
+    overflow-y: visible;
+}
+
 .jupyter-widgets.widget-tab .p-TabBar.p-mod-horizontal > .p-TabBar-content {
     align-items: flex-end;
     margin-bottom: 0;


### PR DESCRIPTION
Right now, the `TabPanel` has overflow set to `visible` because of being classed as `jupyter-widgets`. The same styling is set explicitly for the `TabBar`. But the `TabPanel` contents has `overflow` set to `hidden`.