### PR TITLE
Remove a widget from an accordion by setting parent to null.

### DIFF
--- a/jupyter-js-widgets/src/phosphor/accordion.ts
+++ b/jupyter-js-widgets/src/phosphor/accordion.ts
@@ -99,7 +99,7 @@ class Collapse extends Widget {
     if (oldWidget) {
       oldWidget.disposed.disconnect(this._onChildDisposed, this);
       oldWidget.title.changed.disconnect(this._onTitleChanged, this);
-      this._content.layout.removeWidget(oldWidget);
+      oldWidget.parent = null;
     }
     this._widget = widget;
     widget.disposed.connect(this._onChildDisposed, this);
@@ -284,11 +284,12 @@ class Accordion extends Panel {
 
   removeWidget(widget: Widget): void {
     let index = this.indexOf(widget);
-    let collapse = this.collapseWidgets.at(index) as Collapse;
-    collapse.removeClass(ACCORDION_CHILD_CLASS);
-    let layout = this.layout as PanelLayout;
-    layout.removeWidgetAt(index);
-    this._selection.adjustSelectionForRemove(index, collapse);
+    if (index >= 0) {
+      let collapse = this.collapseWidgets.at(index) as Collapse;
+      widget.parent = null;
+      collapse.dispose();
+      this._selection.adjustSelectionForRemove(index, null);
+    }
   }
 
   private _wrapWidget(widget: Widget) {


### PR DESCRIPTION
The layout removeWidget methods shouldn’t be called directly, according to their docs. This cleans up that code.