### PR TITLE
Make sure that the checkbox reserves enough room for the actual check control

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -324,6 +324,7 @@
     line-height: var(--jp-widgets-inline-height);
     font-size: large;
     flex-grow: 1;
+    flex-shrink: 0;
     align-self: center;
 }
 


### PR DESCRIPTION
Before, the actual checkbox may shrink down to 0px wide if the label was big enough.