### PR TITLE
Style select element directly

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -713,23 +713,17 @@ ul.widget-dropdown-droplist.mod-active {
     line-height: var(--jp-widgets-inline-height);
 }
 
-.widget-select .jp-Dialog-selectWrapper {
+.widget-select select {
     border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);
     border-radius: 0;
     height: var(--jp-widgets-inline-height);
     flex: 1 1 var(--jp-widgets-inline-width-short);
-    background-color: var(--jp-widgets-input-background-color);
-}
-
-.widget-select select {
+    box-sizing: border-box;
     outline: none !important;
     box-shadow: none;
-    border: none;
     background-color: var(--jp-widgets-input-background-color);
     color: var(--jp-widgets-input-color);
     font-size: var(--jp-widgets-font-size);
-    width: 100%;
-    height: calc(var(--jp-widgets-inline-height) - 2 * var(--jp-widgets-input-border-width));
     vertical-align: top;
     padding-left: calc( var(--jp-widgets-input-padding) * 2);
 	appearance: none;
@@ -743,6 +737,13 @@ ul.widget-dropdown-droplist.mod-active {
 
 .widget-select select:focus {
     border-color: var(--jp-widgets-input-focus-border-color);
+}
+
+/* To disable the dotted border in Firefox around select controls.
+   See http://stackoverflow.com/a/18853002 */
+.widget-select select:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 #000;
 }
 
 .widget-select select option:checked {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -764,6 +764,11 @@ ul.widget-dropdown-droplist.mod-active {
     color: var(--jp-widgets-input-color);
     font-size: var(--jp-widgets-font-size);
     flex: 1 1 var(--jp-widgets-inline-width-short);
+    outline: none !important;
+}
+
+.widget-select-multiple select:focus {
+    border-color: var(--jp-widgets-input-focus-border-color);
 }
 
 .widget-select-multiple select option:checked {

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -765,6 +765,7 @@ ul.widget-dropdown-droplist.mod-active {
     font-size: var(--jp-widgets-font-size);
     flex: 1 1 var(--jp-widgets-inline-width-short);
     outline: none !important;
+    overflow: auto;
 }
 
 .widget-select-multiple select:focus {

--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -65,11 +65,8 @@ class SelectView extends LabeledDOMWidgetView {
         this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-select');
 
-        let selectWrapper = document.createElement('div');
-        selectWrapper.className = 'jp-Dialog-selectWrapper';
         this.listbox = document.createElement('select');
-        selectWrapper.appendChild(this.listbox)
-        this.el.appendChild(selectWrapper);
+        this.el.appendChild(this.listbox);
         this._updateOptions();
         this.update();
     }


### PR DESCRIPTION
This makes it easy to have the focus styling on the select element and makes the structure cleaner. It also adds focus styling on the multiple select box.

Screenshots:
<img width="394" alt="screen shot 2017-02-20 at 2 44 29 pm" src="https://cloud.githubusercontent.com/assets/192614/23139632/6b50b6e6-f77b-11e6-9892-f3040f1eee3c.png">
<img width="382" alt="screen shot 2017-02-20 at 2 39 18 pm" src="https://cloud.githubusercontent.com/assets/192614/23139633/6b52ca76-f77b-11e6-8e53-ba41e4b46533.png">
