### PR TITLE
[Alignment] Width of Label widgets (not description)

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -246,6 +246,10 @@
     max-width: var(--jp-widgets-inline-width);
 }
 
+.jupyter-widgets.widget-label {
+    width: var(--jp-widgets-inline-width-tiny);
+}
+
 .widget-inline-hbox .widget-label {
     /* Horizontal Widget Label */
     color: var(--jp-widgets-label-color);


### PR DESCRIPTION
The Label widget does not have a min width, making it shrink proportionally to the width of its content.

Instead of adding a `min-width`, I set `width` so that it can be more easily overridden with `layout`. Its makes `Label` be more similar to other widgets in that it has a natural width.

Before:

<img width="821" alt="screen shot 2017-02-21 at 2 21 34 pm" src="https://cloud.githubusercontent.com/assets/2397974/23166547/53af23f8-f841-11e6-82df-268ab3ca06f9.png">

After:


<img width="818" alt="screen shot 2017-02-21 at 2 19 03 pm" src="https://cloud.githubusercontent.com/assets/2397974/23166540/4b523dc6-f841-11e6-9e88-9fc507daef67.png">