### PR TITLE
Make selected range thicker

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -462,13 +462,13 @@
 }
 
 .widget-hslider .ui-slider-range {
-    height: calc( var(--jp-widgets-slider-track-thickness) );
-    margin-top: calc((var(--jp-widgets-slider-track-thickness) - var(--jp-widgets-slider-track-thickness) ) / 2 - var(--jp-widgets-slider-border-width));
+    height: calc( var(--jp-widgets-slider-track-thickness) * 2 );
+    margin-top: calc((var(--jp-widgets-slider-track-thickness) - var(--jp-widgets-slider-track-thickness) * 2 ) / 2 - var(--jp-widgets-slider-border-width));
 }
 
 .widget-vslider .ui-slider-range {
-    width: calc( var(--jp-widgets-slider-track-thickness) );
-    margin-left: calc((var(--jp-widgets-slider-track-thickness) - var(--jp-widgets-slider-track-thickness) ) / 2 - var(--jp-widgets-slider-border-width));
+    width: calc( var(--jp-widgets-slider-track-thickness) * 2 );
+    margin-left: calc((var(--jp-widgets-slider-track-thickness) - var(--jp-widgets-slider-track-thickness) * 2 ) / 2 - var(--jp-widgets-slider-border-width));
 }
 
 /* Horizontal Slider */


### PR DESCRIPTION
This reverts a change that was done in #1130 . 

It makes the selected interval thicker (again) in the range slider:

Thin (before this PR):

![thin](https://cloud.githubusercontent.com/assets/2397974/23168564/eb35c7f2-f848-11e6-9fdd-5d0582cdfd03.gif)

Thick (after this PR):

![thick](https://cloud.githubusercontent.com/assets/2397974/23168574/f2c7ce3e-f848-11e6-9e61-f9664eb9dd99.gif)
