### PR TITLE
Suppress exceptions during output widget redirection.

### DIFF
--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -58,6 +58,8 @@ class Output(DOMWidget, CoreWidget):
             ip.showtraceback((etype, evalue, tb), tb_offset=0)
         self._flush()
         self.msg_id = ''
+        # suppress exceptions, since they are shown above
+        return True
 
     def _flush(self):
         """Flush stdout and stderr buffers."""


### PR DESCRIPTION
Exceptions are already captured and shown, so there’s no need to keep raising them.

Fixes #1155.