### PR TITLE
The button text should default to empty.

### DIFF
--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -46,7 +46,7 @@ class Button(DOMWidget, CoreWidget):
     _view_name = Unicode('ButtonView').tag(sync=True)
     _model_name = Unicode('ButtonModel').tag(sync=True)
 
-    description = Unicode('Button', help="Button label.").tag(sync=True)
+    description = Unicode(help="Button label.").tag(sync=True)
     tooltip = Unicode(help="Tooltip caption of the button.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes.").tag(sync=True)
     icon = Unicode('', help="Font-awesome icon name, without the 'fa-' prefix.").tag(sync=True)

--- a/jupyter-js-widgets/src/widget_button.ts
+++ b/jupyter-js-widgets/src/widget_button.ts
@@ -45,7 +45,7 @@ export
 class ButtonModel extends CoreDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
-            description: 'Button',
+            description: '',
             tooltip: '',
             disabled: false,
             icon: '',


### PR DESCRIPTION
This follows the convention we have for tab titles, normal descriptions, etc.