### PR TITLE
Use built css instead of original css3 for embedder

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -71,6 +71,7 @@
     "postcss-cli": "^2.6.0",
     "postcss-cssnext": "^2.8.0",
     "postcss-import": "^8.1.2",
+    "postcss-loader": "^1.3.2",
     "rimraf": "^2.4.1",
     "sinon": "^1.17.2",
     "spawn-sync": "^1.0.14",

--- a/jupyter-js-widgets/webpack.config.js
+++ b/jupyter-js-widgets/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     devtool: 'source-map',
     module: {
         loaders: [
-            { test: /\.css$/, loader: "style-loader!css-loader" },
+            { test: /\.css$/, loader: "style-loader!css-loader!postcss-loader" },
             { test: /\.json$/, loader: "json-loader" },
             // jquery-ui loads some images
             { test: /\.(jpg|png|gif)$/, loader: "file" },
@@ -23,6 +23,12 @@ module.exports = {
             { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
             { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
             { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
+        ]
+    },
+    postcss: function () {
+        return [
+            require('postcss-import'),
+            require('postcss-cssnext')
         ]
     }
 };


### PR DESCRIPTION
Fixes #1152 .

Waiting on @jasongrout to comment:  we could also use the post-css loader in the embedder webpack.

