### PR TITLE
Range readout using dash

### DIFF
--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -236,7 +236,7 @@ class IntSliderView extends LabeledDOMWidgetView {
         if (this.model.get('_range')) {
             return value.map(function (v) {
                 return format(v);
-            }).join('-');
+            }).join(' – ');
         } else {
             return format(value);
         }


### PR DESCRIPTION
For the readout format of a range slider, use "A – B" instead of "A-B" for a range `(A, B)`. This looks much better. The old format looked especially bad with negative numbers: compare "-5 – 5" to "-5-5".