### PR TITLE
Document the message spec

### DIFF
--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -18,7 +18,7 @@ In this section, we concentrate on implementing the Jupyter widget messaging pro
 
 ### The `jupyter.widget.version` comm target
 
-Jupyter widgets define a `jupyter.widget.version` comm target, which is for communicating version information between the frontend and the kernel. When a frontend initializes a Jupyter widget extension (for example, when a notebook is opened), the frontend sends the kernel a `comm_open` message to the `jupyter.widget.version` comm target:
+A kernel-side Jupyter widgets library defines a `jupyter.widget.version` comm target, which is for communicating version information between the frontend and the kernel. When a frontend initializes a Jupyter widget extension (for example, when a notebook is opened), the frontend sends the kernel a `comm_open` message to the `jupyter.widget.version` comm target:
 
 ```
 {
@@ -52,7 +52,7 @@ The frontend then replies with a message on the comm channel giving the validati
 
 ### The `jupyter.widget` comm target
 
-Jupyter interactive widgets create a widget comm channel by sending messages to the `jupyter.widget` comm target. State synchronization and custom messages for a particular widget instance are then sent over the created comm channel.
+A kernel-side Jupyter widgets library also defines a `jupyter.widget` comm target, by which widget comm channels are created (one per widget instance). State synchronization and custom messages for a particular widget instance are then sent over the created comm channel.
 
 ### Instatiating a widget object
 
@@ -74,15 +74,11 @@ When a frontend creates a Jupyter widget, it sends a `comm_open` message to the 
 
 The type of widget to be instantiated is given in the `widget_class` string.
 
-In the python implementation, this string is actually the key in a registry of widget types. In the case where the key is not found, it is parsed as a `module` `+` `class` string.
-
-In the Python implementation of the kernel, widget types are registered in the dictionary with the `register` decorator. For example the integral progress bar is registered with `register('Jupyter.IntProgress')`.
-
-TODO: give a list in another document of the core widgets and each widget_class string.
+In the ipywidgets implementation, this string is actually the key in a registry of widget types. In the ipywidgets implementation, widget types are registered in the dictionary with the `register` decorator. For example the integral progress bar class is registered with `@register('Jupyter.IntProgress')`. When the `widget_class` is not in the registry, it is parsed as a `module` `+` `class` string.
 
 #### Sending a `comm_open` message upon instantiation of a widget
 
-Symmetrically, when instantiating a widget in the kernel, a `comm_open` message is sent to the frontend.
+Symmetrically, when instantiating a widget in the kernel, a `comm_open` message is sent to the frontend:
 
 ```
 {
@@ -98,9 +94,9 @@ The type of widget to be instantiated in the frontend is determined by the `_mod
 
 ### State synchronization
 
-#### Synchronizing from kernel to frontend
+#### Synchronizing from kernel to frontend: `update`
 
-When a widget's state changes in the kernel, the new state (either the entire state or just the changed keys) is sent to the frontend over the widget's comm channel using an `update` message:
+When a widget's state changes in the kernel, the changed state keys and values are sent to the frontend over the widget's comm channel using an `update` message:
 
 ```
 {
@@ -121,7 +117,7 @@ Comm messages for state synchronization may contain binary buffers. The `data.bu
 
 See the [Model state](modelstate.md) documentation for the attributes of core Jupyter widgets.
 
-#### Syncrhonizing from frontend to kernel
+#### Synchronizing from frontend to kernel: `backbone`
 
 When a widget's state changes in the frontend, the changed keys are sent to the frontend over the widget's comm channel using a `backbone` message:
 
@@ -142,7 +138,7 @@ The `data.sync_data` value is a dictionary of widget state keys and values that 
 
 Comm messages for state synchronization may contain binary buffers. The `data.buffer_keys` optional value contains a list of keys corresponding to the binary buffers. For example, if `data.buffer_keys` is `['x', 'y']`, then the first binary buffer is the value of the `'x'` state attribute and the second binary buffer is the value of the `'y'` state attribute.
 
-#### State requests
+#### State requests: `request_state`
 
 When a frontend wants to request the full state of a widget, the frontend sends a `request_state` message:
 
@@ -155,9 +151,9 @@ When a frontend wants to request the full state of a widget, the frontend sends 
 }
 ```
 
-The kernel should immediately send an `update` message (as specified above) with the entire widget state.
+The kernel side of the widget should immediately send an `update` message with the entire widget state.
 
-### Custom messages
+### Custom messages: `custom`
 
 Widgets may also send custom comm messages to their counterpart.
 

--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -16,11 +16,43 @@ Jupyter widget libraries built upon ipywidgets tend to have a large part their c
 
 In this section, we concentrate on implementing the Jupyter widget messaging protocol in the kernel.
 
+### The `jupyter.widget.version` comm target
+
+Jupyter widgets define a `jupyter.widget.version` comm target, which is for communicating version information between the frontend and the kernel. When a frontend initializes a Jupyter widget extension (for example, when a notebook is opened), the frontend sends the kernel a `comm_open` message to the `jupyter.widget.version` comm target:
+
+```
+{
+  'comm_id': 'u-u-i-d',
+  'target_name': 'jupyter.widget.version'
+}
+```
+
+The kernel should immediately send a message on the opened comm channel containing the semver range for the frontend version of jupyter-js-widgets that it expects:
+
+```
+{
+  'comm_id': 'u-u-i-d',
+  'data': {
+    'version': '~2.1.0'
+  }
+}
+```
+
+The frontend then replies with a message on the comm channel giving the validation status and the frontend version:
+
+```
+{
+  'comm_id': 'u-u-i-d',
+  'data': {
+    'frontend_version: '2.1.4',
+    'validated': true
+  }
+}
+```
+
 ### The `jupyter.widget` comm target
 
 Jupyter interactive widgets create a widget comm channel by sending messages to the `jupyter.widget` comm target. State synchronization and custom messages for a particular widget instance are then sent over the created comm channel.
-
-Jupyter widgets also define a `jupyter.widget.version` comm target, which is for communicating version information between the frontend and the kernel, and can be ignored in an initial implementation. We will not address messages to this target here.
 
 ### Instatiating a widget object
 

--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -1,4 +1,4 @@
-# Widget messaging protocol
+# Widget messaging protocol, version 1
 
 A Jupyter widget has both a frontend and kernel object communicating with each other using the `comm` messages provided by the Jupyter kernel messaging protocol. The primary communication that happens is synchronizing widget state, represented in the messages by a dictionary of key-value pairs. The Jupyter widget messaging protocol covers `comm` messages for the following actions:
 

--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -171,6 +171,27 @@ In the ipywidgets implementation, the `Widget.send(content, buffers=None)` metho
 
 ### Displaying widgets
 
-TODO: document the display_data message to send to display widgets
+To display a widget in the classic Jupyter notebook, the kernel sends a `display` comm message to the frontend on the widget's comm channel:
 
-(Note also the comm message to display messages in the old notebook)
+```
+{
+  'comm_id': 'u-u-i-d',
+  'data': {
+    'method': 'display'
+  }
+}
+```
+
+To display a widget in JupyterLab, the kernel sends a Jupyter [iopub `display_data` message](http://jupyter-client.readthedocs.io/en/latest/messaging.html#display-data) with a special mimetype (where the `model_id` is the comm channel id):
+
+```
+{
+  'data': {
+    'application/vnd.jupyter.widget-view+json': {
+      'model_id': 'u-u-i-d'
+    }
+  }
+}
+```
+
+In order to display widgets in both the classic notebook and JupyterLab, ipywidgets sends both the `display` comm message and the iopub `display_data` message, and omits the `text/plain` mimetype from the `display_data` message (so the classic notebook will not show any output from the iopub message).

--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -1,0 +1,132 @@
+# Widget messaging protocol
+
+The protocol for
+
+- instantiating jupyter widgets
+- synchronizing widget state between the front-end and the back-end companion objects
+- sending custom messages between these objects
+
+Is entirely based upon the `Comm` section of the Jupyter kernel protocol.
+
+For more details on comms *per se*, we refer to the [relevant section of the specification for the Jupyter kernel protocol](http://jupyter-client.readthedocs.io/en/latest/messaging.html).
+
+## Implementation of a backend for the Jupyter widgets protocol.
+
+Jupyter widget libraries built upon ipywidgets tend to have a large part their code-base in JavaScript, since this is where the logic for drawing and rendering widgets resides. The Python side mostly consists in a declaration of the widget model attributes.
+
+A byproduct of the *thin backend* of widget libraries is that once the widget protocol is implemented for another kernel, all the widgets and custom widget libraries can be reused in that language.
+
+Therefore, in this documentation, we concentrate on the viewpoint of a kernel author implementing a jupyter widget backend.
+
+### The `jupyter.widget` comm target
+
+Jupyter interactive widgets define two `comm` targets
+
+ - `jupyter.widget`
+ - `jupyter.widget.version`
+ 
+The first one is the target handling all the widget state synchronization as well as the custom messages. The other target is meant for a version check between the front-end and the backend, and can be ignored from now.
+
+### Instantiating widgets from the front-end and the backend
+
+#### Reception of a `comm_open` message
+
+Upon reception of the `comm_open` message for target `jupyter.widget`
+
+```python
+{
+  'comm_id' : 'u-u-i-d',
+  'target_name' : 'jupyter.widget',
+  'data' : {
+      'widget_class': 'some.string'
+  }
+}
+```
+
+The type of widget to be instantiated is determined with the `widget_class` string.
+
+In the python implementation, this string is actually the key in a registry of widget types. In the case where the key is not found, it is parsed as a `module` `+` `class` string.
+
+In the Python implementation of the backend, widget types are registered in the dictionary with the `register` decorator. For example the integral progress bar is registered with `register('Jupyter.IntProgress')`.
+
+#### Emmission of the `comm_open` message upon instantiation of a widget
+
+Symmetrically, when instantiating a widget in the backend, a `comm_open` message is sent to the front-end.
+
+```python
+{
+  'comm_id' : 'u-u-i-d',
+  'target_name' : 'jupyter.widget',
+  'data' : {
+      '[serialized widget state]'
+  }
+}
+```
+
+The type of widget to be instantiated in the front-end is determined by the `_model_name`, `_model_module` and `_model_module_version` keys in the state, which respectively stand for the name of the class that must be instantiated in the frontend, the javascript module where this class is defined, and a semver range for that module.
+
+#### Sending updates of the state for a widget model
+
+```python
+{
+  'comm_id' : 'u-u-i-d',
+  'data' : {
+      'method': 'state',
+      'state': '[serialized widget state or portion of the serialized widget sate]',
+      'buffers': '[optional list of keys for attributes sent in the form of binary buffers]'
+  }
+}
+```
+
+Comm messages for state synchonization optionally contain a list binary buffers. If this list is not empty, a corresponding list of strings must be provided in the `data` message providing the names for these buffers.
+
+The front-end will unpack these buffer and insert them in the state for the specified keys.
+
+#### Sending custom messages
+
+In the Python implementation, the base widget class provides a means to send raw comm messages directly. `Widget.send(content, buffers=None)` will produce a message of the form
+
+```python
+{
+  'comm_id' : 'u-u-i-d',
+  'data' : {
+      'method': 'custom',
+      'content': 'the specified content',
+      'buffers': 'the provided buffers'
+  }
+}
+```
+
+#### Receiving data synchronization messages
+
+Upon updates of the JavaScript model state, the front-end emits widget state patches messages
+
+```python
+{
+  'comm_id' : 'u-u-i-d',
+  'data' : {
+      'method': 'backbone',
+      'sync_data': 'the patch to the data',
+      'buffers': 'optional buffer names list'
+  }
+}
+```
+
+The `sync_data` contains the serialized state of the changed model attributes in the form of a dictionnary.
+
+Optionally, the message may specify a list of buffer names. When provided, the corresponding binary buffers in the zmq message should be appended in the `sync_data` dictionary with the keys specified in the `buffers` list.
+
+#### State requests
+
+In the case of a front-end connecting to a running kernel where widgets have already been instantiated, it may send a request state message, of the form
+
+```python
+{
+  'comm_id' : 'u-u-i-d',
+  'data' : {
+      'method': 'request_state'
+  }
+}
+```
+
+The expected response to that message is a regular `update` message as specified above containining the entirety of the widget model state.

--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -167,7 +167,7 @@ Widgets may also send custom comm messages to their counterpart.
 }
 ```
 
-In the Python Jupyter widgets implementation, the `Widget.send(content, buffers=None)` method will produce a message of this form.
+In the ipywidgets implementation, the `Widget.send(content, buffers=None)` method will produce these messages.
 
 ### Displaying widgets
 

--- a/jupyter-widgets-schema/messages.md
+++ b/jupyter-widgets-schema/messages.md
@@ -72,16 +72,16 @@ Once a widget comm channel is created for a widget instance, state synchronizati
 {
   'comm_id' : 'u-u-i-d',
   'data' : {
-      'method': 'state',
+      'method': 'update',
       'state': { <dictionary of widget state> },
-      'buffers': [ <list of state keys (strings) corresponding to binary buffers in the message> ]
+      'buffers': [ <optional list of state keys (strings) corresponding to binary buffers in the message> ]
   }
 }
 ```
 
 The `data.state` value is a dictionary of widget attributes and values. See the [Model state](modelstate.md) documentation for the attributes of core Jupyter widgets.
 
-Comm messages for state synchronization may contain binary buffers. The `data.buffers` attribute contains a list of keys corresponding to the binary buffers. For example, if `data.buffers` is `['x', 'y']`, then the first binary buffer is the value of the `'x'` state attribute and the second binary buffer is the value of the `'y'` state attribute.
+Comm messages for state synchronization may contain binary buffers. The `data.buffers` optional attribute contains a list of keys corresponding to the binary buffers. For example, if `data.buffers` is `['x', 'y']`, then the first binary buffer is the value of the `'x'` state attribute and the second binary buffer is the value of the `'y'` state attribute.
 
 ### Sending custom messages
 
@@ -98,7 +98,7 @@ In the Python implementation, the base widget class provides a means to send raw
 }
 ```
 
-#### Receiving data synchronization messages
+### Receiving data synchronization messages
 
 Upon updates of the JavaScript model state, the frontend emits widget state patches messages
 
@@ -108,16 +108,16 @@ Upon updates of the JavaScript model state, the frontend emits widget state patc
   'data' : {
       'method': 'backbone',
       'sync_data': 'the patch to the data',
-      'buffers': 'optional buffer names list'
+      'buffer_keys': 'optional buffer names list'
   }
 }
 ```
 
-The `sync_data` contains the serialized state of the changed model attributes in the form of a dictionnary.
+The `sync_data` contains the serialized state of the changed model attributes in the form of a dictionary.
 
-Optionally, the message may specify a list of buffer names. When provided, the corresponding binary buffers in the zmq message should be appended in the `sync_data` dictionary with the keys specified in the `buffers` list.
+Optionally, the message may specify a list of buffer names. When provided, the corresponding binary buffers in the zmq message should be appended in the `sync_data` dictionary with the keys specified in the `buffer_keys` list.
 
-#### State requests
+### State requests
 
 In the case of a frontend connecting to a running kernel where widgets have already been instantiated, it may send a request state message, of the form
 
@@ -130,4 +130,10 @@ In the case of a frontend connecting to a running kernel where widgets have alre
 }
 ```
 
-The expected response to that message is a regular `state` (TODO: check-is it an `update` message?) message as specified above containining the entirety of the widget model state.
+The expected response to that message is a regular `'update'` message as specified above containining the entirety of the widget model state.
+
+## Displaying widgets
+
+TODO: document the display_data message to send to display widgets
+
+(Note also the comm message to display messages in the old notebook)


### PR DESCRIPTION
Documents the comm message spec as of ipywidgets 6.0.

Goes a long way towards fixing https://github.com/ipython/ipywidgets/issues/790 (but this concentrates on the backend), and fixes https://github.com/ipython/ipywidgets/issues/1033 more completely.